### PR TITLE
feat: manifest v2 extensions support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24725,6 +24725,20 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/u3": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/u3/-/u3-0.1.1.tgz",
@@ -45939,6 +45953,13 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true,
+      "peer": true
     },
     "u3": {
       "version": "0.1.1",


### PR DESCRIPTION
Updates the createDcentTab method to not use Chrome API's MV3 promises overloads, as they cannot be called from Manifest V2 extensions such as Talisman.

With this PR those methods will be called using the callback overload, which should work in both Manifest V2 and V3 according to their docs : 
https://developer.chrome.com/docs/extensions/mv3/promises/#when-can-i-use-promises

Note : noticed that package-lock.json has been updated automatically after doing `npm install`. I'm using node.js LTS (v18.17.0). Please tell me if you prefer that i remove that change.