### PR TITLE
fix: polkadot decimals

### DIFF
--- a/src/type/dcent-web-type.js
+++ b/src/type/dcent-web-type.js
@@ -214,7 +214,7 @@ const coinDecimals = {
   VECHAIN: 18,
   NEAR: 24,
   HAVAH: 18,
-  POLKADOT: 12,
+  POLKADOT: 10,
   COSMOS: 6,
   COREUM: 6,
 }


### PR DESCRIPTION
Polkadot token has been changed from 12 to 10 decimals

Please see : https://wiki.polkadot.network/docs/learn-DOT