### PR TITLE
[Bug] #119: chrome.runtime.getManifest()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,9 +34,10 @@ dcent.popupWindow = undefined
 dcent.popupTab = undefined
 dcent.iframe = undefined
 
-// eslint-disable-next-line no-undef
 let isManifestV3 = false
+// eslint-disable-next-line no-undef
 if (typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.getManifest) {
+  // eslint-disable-next-line no-undef
   isManifestV3 = chrome.runtime.getManifest().manifest_version === 3
 }
 dcent.dcentWebDeferred = function () {

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,10 @@ dcent.popupTab = undefined
 dcent.iframe = undefined
 
 // eslint-disable-next-line no-undef
-const isManifestV3 = typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.getManifest().manifest_version === 3
+let isManifestV3 = false
+if (typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.getManifest) {
+  isManifestV3 = chrome.runtime.getManifest().manifest_version === 3
+}
 dcent.dcentWebDeferred = function () {
   let localResolve
   let localReject


### PR DESCRIPTION
chrome.runtime.getManifest() 가 존재하는지 확인 후 호출하도록 수정