### PR TITLE
[DC-1845] feat(v2): connector v2 core skeleton — Error/Transport/Queue 모듈 + TypeScript 인프라

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
     "presets": [
+      "@babel/preset-typescript",
       "@babel/preset-react",
       [
         "@babel/preset-env",

--- a/jest.v2.config.js
+++ b/jest.v2.config.js
@@ -1,0 +1,14 @@
+/**
+ * Jest 설정 — v2 TypeScript 테스트 전용
+ * babel-jest + @babel/preset-typescript로 트랜스파일 (기존 babel 7 환경 일관)
+ */
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/tests/unit/v2/**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': 'babel-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
+  coverageDirectory: 'tests/coverage-v2',
+  collectCoverage: false,
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "yarn lint && jest --detectOpenHandles --coverage --forceExit --runInBand",
     "unit-mock": "jest --coverage --runInBand 0_mock_test",
     "unit-bridge": "jest --coverage --runInBand 1_bridge_test",
+    "unit-v2": "jest --config jest.v2.config.js --runInBand tests/unit/v2",
     "lint": "eslint --ext .js src-v1 tests",
     "lint:fix": "eslint --ext .js src-v1 tests --fix",
     "tsc": "tsc --noEmit"
@@ -52,9 +53,12 @@
     "@babel/core": "^7.6.0",
     "@babel/preset-env": "^7.6.0",
     "@babel/preset-react": "^7.9.4",
+    "@babel/preset-typescript": "^7.28.5",
     "@noble/curves": "^1.0.0",
     "@scure/base": "^1.1.1",
     "@taquito/utils": "^16.1.2",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^18.0.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^24.8.0",
@@ -83,18 +87,17 @@
     "puppeteer": "^10.4.0",
     "regenerator-runtime": "^0.13.3",
     "thor-devkit": "^2.0.7",
+    "ts-loader": "^9.5.1",
     "tweetnacl": "^1.0.3",
+    "typescript": "~5.9.3",
     "webpack": "^5.72.0",
     "webpack-cli": "^4.9.2",
-    "webpack-dev-server": "^4.9.0",
-    "typescript": "~5.9.3",
-    "ts-loader": "^9.5.1",
-    "@types/node": "^18.0.0"
+    "webpack-dev-server": "^4.9.0"
   },
   "dependencies": {
     "bignumber.js": "^9.1.1",
     "events": "^3.0.0"
-  },  
+  },
   "engines": {
     "node": ">= 18.0.0",
     "npm": ">= 9.0.0"

--- a/src/error/ErrorCode.ts
+++ b/src/error/ErrorCode.ts
@@ -1,0 +1,28 @@
+/**
+ * v2 에러 코드 enum
+ *
+ * JSON-RPC 2.0 표준 (-32700 ~ -32603) + EIP-1193 표준 (4xxx) + D'CENT 디바이스 전용 (5xxx)
+ * 총 15개 코드를 정확한 값으로 export한다.
+ */
+export enum ErrorCode {
+  // JSON-RPC 2.0 표준 (-32700 ~ -32603)
+  PARSE_ERROR = -32700,
+  INVALID_REQUEST = -32600,
+  METHOD_NOT_FOUND = -32601,
+  INVALID_PARAMS = -32602,
+  INTERNAL_ERROR = -32603,
+
+  // EIP-1193 표준 (4xxx)
+  USER_REJECTED = 4001,
+  UNAUTHORIZED = 4100,
+  UNSUPPORTED_METHOD = 4200,
+  DISCONNECTED = 4900,
+  CHAIN_DISCONNECTED = 4901,
+
+  // D'CENT 디바이스 전용 (5xxx) — EIP-1193 4xxx / JSON-RPC -32xxx와 충돌 없음
+  DEVICE_NOT_CONNECTED = 5001,
+  DEVICE_LOCKED = 5002,
+  DEVICE_TIMEOUT = 5003,
+  DEVICE_USER_CANCELLED = 5004,
+  DEVICE_FW_INCOMPATIBLE = 5005,
+}

--- a/src/error/ProviderError.ts
+++ b/src/error/ProviderError.ts
@@ -1,0 +1,26 @@
+import { ErrorCode } from './ErrorCode'
+
+/**
+ * v2 Provider 에러 클래스
+ *
+ * Error를 확장하며 code + message + data 필드를 보존.
+ * instanceof Error / instanceof ProviderError 모두 true.
+ * EIP-1193 호환 에러 구조 (code, message, data).
+ */
+export class ProviderError extends Error {
+  public readonly code: ErrorCode | number
+  public readonly data?: unknown
+
+  constructor(code: ErrorCode | number, message: string, data?: unknown) {
+    super(message)
+    this.name = 'ProviderError'
+    this.code = code
+    this.data = data
+    // V8 stack trace 보존 — non-V8 환경에서는 무시됨
+    // tsconfig types:[] 환경에서는 captureStackTrace가 미정의이므로 타입 단언 사용
+    const ErrorCtor = Error as unknown as { captureStackTrace?: (target: Error, ctor: unknown) => void }
+    if (typeof ErrorCtor.captureStackTrace === 'function') {
+      ErrorCtor.captureStackTrace(this, ProviderError)
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,15 @@
-// v2 entry point — m01-03에서 v2 public API export
-export {}
+// v2 public API entry point (cycle 01 — skeleton 단계)
+// cycle 02: 실제 메시지 송수신 + 핸드셰이크 구현 예정
+export type {
+  MessageEnvelope,
+  ResponseEnvelope,
+  MessageTransport,
+  TransportState,
+} from './transport/MessageTransport'
+export { PopupTransport } from './transport/PopupTransport'
+
+export type { RequestQueue } from './queue/RequestQueue'
+export { SerialRequestQueue } from './queue/RequestQueue'
+
+export { ErrorCode } from './error/ErrorCode'
+export { ProviderError } from './error/ProviderError'

--- a/src/queue/RequestQueue.ts
+++ b/src/queue/RequestQueue.ts
@@ -1,0 +1,56 @@
+/**
+ * v2 요청 큐 — 단일 동시성 보장
+ *
+ * connector가 sdk에 보내는 요청을 직렬화하여 동시에 여러 요청이 처리되는 것을 방지.
+ * cycle 02부터 실제 PopupTransport와 결합되어 동작.
+ */
+
+/** 요청 큐 인터페이스 */
+export interface RequestQueue {
+  /** task를 큐에 추가하고 완료 Promise를 반환 */
+  enqueue<T>(task: () => Promise<T>): Promise<T>
+
+  /** 현재 pending 중인 작업 수 */
+  size(): number
+
+  /** 큐 초기화 (pending 카운트 리셋) */
+  clear(): void
+}
+
+/**
+ * SerialRequestQueue — 단일 동시성 직렬 실행 큐
+ *
+ * async-hygiene 룰: chain.then(task, task) 패턴
+ *   - 두 번째 인자(reject handler)로 동일 task를 매핑하여
+ *     이전 task가 reject되어도 현재 task가 실행되도록 보장.
+ *   - 즉, 한 task의 실패가 후속 enqueue를 영구 차단하지 않음.
+ *
+ * cycle 02에서 AbortController를 도입하여 clear() 시 미완 task 취소 강화 예정.
+ */
+export class SerialRequestQueue implements RequestQueue {
+  private chain: Promise<unknown> = Promise.resolve()
+  private pending = 0
+
+  enqueue<T>(task: () => Promise<T>): Promise<T> {
+    this.pending += 1
+    // chain.then(task, task): 이전 작업의 resolve/reject 무관하게 task 실행
+    const result = this.chain.then(task, task) as Promise<T>
+    // chain 자체는 pending 감소만 담당 — 결과값을 담지 않음
+    this.chain = result.then(
+      () => { this.pending -= 1 },
+      () => { this.pending -= 1 }
+    )
+    return result
+  }
+
+  size(): number {
+    return this.pending
+  }
+
+  clear(): void {
+    // 현재는 새 chain으로 리셋만 수행.
+    // cycle 02에서 AbortController로 미완 task 취소 강화 예정.
+    this.chain = Promise.resolve()
+    this.pending = 0
+  }
+}

--- a/src/transport/MessageTransport.ts
+++ b/src/transport/MessageTransport.ts
@@ -1,0 +1,52 @@
+/**
+ * v2 메시지 트랜스포트 추상 인터페이스
+ *
+ * connector ↔ popup(sdk) 간 양방향 메시지 송수신 추상화.
+ * 실제 구현 (PopupTransport)은 cycle 02에서 window.open + postMessage + 이벤트 리스너 도입.
+ */
+
+/**
+ * 요청 envelope — connector → sdk 방향
+ * UUID v4 기반 id (cycle 02에서 uuid 라이브러리 도입 예정)
+ */
+export interface MessageEnvelope<T = unknown> {
+  id: string        // UUID v4 — 요청-응답 매칭용
+  method: string    // 메서드 이름 (예: 'connect', 'signTransaction')
+  params?: T
+}
+
+/**
+ * 응답 envelope — sdk → connector 방향
+ * JSON-RPC 2.0 호환 형태 (result xor error)
+ */
+export interface ResponseEnvelope<T = unknown> {
+  id: string        // 요청 id와 매칭
+  result?: T
+  error?: { code: number; message: string; data?: unknown }
+}
+
+/** 트랜스포트 연결 상태 */
+export type TransportState = 'connected' | 'disconnected'
+
+/**
+ * 메시지 트랜스포트 인터페이스
+ * 모든 구현체는 이 인터페이스를 준수한다.
+ */
+export interface MessageTransport {
+  /**
+   * 메시지를 sdk popup으로 송신하고 응답을 기다린다.
+   * stub 구현은 METHOD_NOT_FOUND로 reject.
+   */
+  send<TParams, TResult>(
+    message: MessageEnvelope<TParams>
+  ): Promise<ResponseEnvelope<TResult>>
+
+  /** 트랜스포트 상태 변경 이벤트 구독 */
+  on(event: 'state', handler: (state: TransportState) => void): void
+
+  /** 트랜스포트 상태 변경 이벤트 구독 해제 */
+  off(event: 'state', handler: (state: TransportState) => void): void
+
+  /** 트랜스포트 종료 (popup 닫기 등) */
+  close(): Promise<void>
+}

--- a/src/transport/PopupTransport.ts
+++ b/src/transport/PopupTransport.ts
@@ -1,0 +1,44 @@
+import { MessageTransport, MessageEnvelope, ResponseEnvelope, TransportState } from './MessageTransport'
+import { ProviderError } from '../error/ProviderError'
+import { ErrorCode } from '../error/ErrorCode'
+
+/**
+ * PopupTransport — MessageTransport 첫 구현 (skeleton stub)
+ *
+ * cycle 02에서 실제 구현:
+ *   - window.open으로 sdk popup 열기
+ *   - postMessage로 MessageEnvelope 송신
+ *   - addEventListener('message')로 ResponseEnvelope 수신
+ *   - id 기반 요청-응답 매칭
+ *
+ * error-handling-consistency 룰: 모든 stub 메서드는 throw 패턴
+ *   - send → Promise.reject(ProviderError(METHOD_NOT_FOUND))
+ *   - on/off → no-op (void, throw 없음)
+ *   - close → Promise.resolve()
+ */
+export class PopupTransport implements MessageTransport {
+  send<TParams, TResult>(
+    _message: MessageEnvelope<TParams>
+  ): Promise<ResponseEnvelope<TResult>> {
+    // stub — cycle 02에서 실제 postMessage 송신으로 교체
+    return Promise.reject(
+      new ProviderError(
+        ErrorCode.METHOD_NOT_FOUND,
+        'PopupTransport.send not implemented yet (cycle 02)'
+      )
+    )
+  }
+
+  on(_event: 'state', _handler: (state: TransportState) => void): void {
+    // stub — no-op. cycle 02에서 이벤트 리스너 등록으로 교체
+  }
+
+  off(_event: 'state', _handler: (state: TransportState) => void): void {
+    // stub — no-op. cycle 02에서 이벤트 리스너 해제로 교체
+  }
+
+  close(): Promise<void> {
+    // stub — 즉시 resolve. cycle 02에서 popup 닫기 + cleanup으로 교체
+    return Promise.resolve()
+  }
+}

--- a/tests/unit/v2/error/ErrorCode.test.ts
+++ b/tests/unit/v2/error/ErrorCode.test.ts
@@ -1,0 +1,74 @@
+/**
+ * T-U-03, T-U-04, T-U-05: ErrorCode enum 값 검증
+ *
+ * JSON-RPC 2.0 표준 5개 + EIP-1193 표준 5개 + D'CENT 디바이스 5개 = 총 15개
+ */
+import { ErrorCode } from '../../../../src/error/ErrorCode'
+
+describe('ErrorCode', () => {
+  describe('JSON-RPC 2.0 표준 코드 (T-U-03)', () => {
+    it('PARSE_ERROR === -32700', () => {
+      expect(ErrorCode.PARSE_ERROR).toBe(-32700)
+    })
+
+    it('INVALID_REQUEST === -32600', () => {
+      expect(ErrorCode.INVALID_REQUEST).toBe(-32600)
+    })
+
+    it('METHOD_NOT_FOUND === -32601', () => {
+      expect(ErrorCode.METHOD_NOT_FOUND).toBe(-32601)
+    })
+
+    it('INVALID_PARAMS === -32602', () => {
+      expect(ErrorCode.INVALID_PARAMS).toBe(-32602)
+    })
+
+    it('INTERNAL_ERROR === -32603', () => {
+      expect(ErrorCode.INTERNAL_ERROR).toBe(-32603)
+    })
+  })
+
+  describe('EIP-1193 표준 코드 (T-U-04)', () => {
+    it('USER_REJECTED === 4001', () => {
+      expect(ErrorCode.USER_REJECTED).toBe(4001)
+    })
+
+    it('UNAUTHORIZED === 4100', () => {
+      expect(ErrorCode.UNAUTHORIZED).toBe(4100)
+    })
+
+    it('UNSUPPORTED_METHOD === 4200', () => {
+      expect(ErrorCode.UNSUPPORTED_METHOD).toBe(4200)
+    })
+
+    it('DISCONNECTED === 4900', () => {
+      expect(ErrorCode.DISCONNECTED).toBe(4900)
+    })
+
+    it('CHAIN_DISCONNECTED === 4901', () => {
+      expect(ErrorCode.CHAIN_DISCONNECTED).toBe(4901)
+    })
+  })
+
+  describe("D'CENT 디바이스 전용 코드 (T-U-05)", () => {
+    it('DEVICE_NOT_CONNECTED === 5001', () => {
+      expect(ErrorCode.DEVICE_NOT_CONNECTED).toBe(5001)
+    })
+
+    it('DEVICE_LOCKED === 5002', () => {
+      expect(ErrorCode.DEVICE_LOCKED).toBe(5002)
+    })
+
+    it('DEVICE_TIMEOUT === 5003', () => {
+      expect(ErrorCode.DEVICE_TIMEOUT).toBe(5003)
+    })
+
+    it('DEVICE_USER_CANCELLED === 5004', () => {
+      expect(ErrorCode.DEVICE_USER_CANCELLED).toBe(5004)
+    })
+
+    it('DEVICE_FW_INCOMPATIBLE === 5005', () => {
+      expect(ErrorCode.DEVICE_FW_INCOMPATIBLE).toBe(5005)
+    })
+  })
+})

--- a/tests/unit/v2/error/ProviderError.test.ts
+++ b/tests/unit/v2/error/ProviderError.test.ts
@@ -1,0 +1,48 @@
+/**
+ * T-U-01, T-U-02: ProviderError 클래스 검증
+ */
+import { ProviderError } from '../../../../src/error/ProviderError'
+import { ErrorCode } from '../../../../src/error/ErrorCode'
+
+describe('ProviderError', () => {
+  describe('T-U-01: 생성 시 code / message / data 필드 보존', () => {
+    it('code와 message를 정확히 보존한다', () => {
+      const err = new ProviderError(ErrorCode.USER_REJECTED, '사용자가 요청을 거부했습니다')
+      expect(err.code).toBe(ErrorCode.USER_REJECTED)
+      expect(err.message).toBe('사용자가 요청을 거부했습니다')
+    })
+
+    it('data 필드가 제공되면 보존한다', () => {
+      const data = { reason: 'timeout', elapsed: 5000 }
+      const err = new ProviderError(ErrorCode.DEVICE_TIMEOUT, 'device timeout', data)
+      expect(err.data).toEqual(data)
+    })
+
+    it('data 필드가 생략되면 undefined이다', () => {
+      const err = new ProviderError(ErrorCode.INTERNAL_ERROR, 'internal error')
+      expect(err.data).toBeUndefined()
+    })
+
+    it('임의의 숫자 코드도 code로 보존한다', () => {
+      const err = new ProviderError(9999, 'custom error')
+      expect(err.code).toBe(9999)
+    })
+  })
+
+  describe('T-U-02: instanceof 체인 및 name 필드', () => {
+    it('instanceof Error === true', () => {
+      const err = new ProviderError(ErrorCode.UNAUTHORIZED, 'unauthorized')
+      expect(err instanceof Error).toBe(true)
+    })
+
+    it('instanceof ProviderError === true', () => {
+      const err = new ProviderError(ErrorCode.UNAUTHORIZED, 'unauthorized')
+      expect(err instanceof ProviderError).toBe(true)
+    })
+
+    it("name === 'ProviderError'", () => {
+      const err = new ProviderError(ErrorCode.DISCONNECTED, 'disconnected')
+      expect(err.name).toBe('ProviderError')
+    })
+  })
+})

--- a/tests/unit/v2/queue/SerialRequestQueue.test.ts
+++ b/tests/unit/v2/queue/SerialRequestQueue.test.ts
@@ -1,0 +1,142 @@
+/**
+ * T-U-06 ~ T-U-09: SerialRequestQueue 단위 테스트
+ *
+ * async-hygiene 룰: chain.then(task, task) 패턴 — reject 후 chain 끊김 방지
+ */
+import { SerialRequestQueue } from '../../../../src/queue/RequestQueue'
+
+describe('SerialRequestQueue', () => {
+  let queue: SerialRequestQueue
+
+  beforeEach(() => {
+    queue = new SerialRequestQueue()
+  })
+
+  describe('T-U-06: 단일 동시성 — 직렬 실행 보장', () => {
+    it('3개 동시 enqueue 시 직렬로 실행된다', async () => {
+      const executionOrder: number[] = []
+      let concurrentCount = 0
+      let maxConcurrent = 0
+
+      const makeTask = (id: number) => () =>
+        new Promise<number>((resolve) => {
+          concurrentCount += 1
+          maxConcurrent = Math.max(maxConcurrent, concurrentCount)
+          executionOrder.push(id)
+          setTimeout(() => {
+            concurrentCount -= 1
+            resolve(id)
+          }, 10)
+        })
+
+      // 3개 동시 enqueue
+      await Promise.all([
+        queue.enqueue(makeTask(1)),
+        queue.enqueue(makeTask(2)),
+        queue.enqueue(makeTask(3)),
+      ])
+
+      // 동시 실행 최대값이 1 (직렬 실행 보장)
+      expect(maxConcurrent).toBe(1)
+      // 입력 순서대로 실행됨
+      expect(executionOrder).toEqual([1, 2, 3])
+    })
+  })
+
+  describe('T-U-07: size() — pending 카운트 정확성', () => {
+    it('enqueue 직후 size()가 1이고 resolve 후 0이 된다', async () => {
+      // task가 실행되면 resolve를 외부에서 호출할 수 있도록 Promise로 조율
+      let externalResolve!: () => void
+      const taskStarted = new Promise<void>((resolve) => {
+        // task 내부에서 시작을 알리고 외부 resolve를 저장
+        const task = () =>
+          new Promise<void>((res) => {
+            externalResolve = res
+            resolve() // taskStarted 완료
+          })
+        queue.enqueue(task)
+      })
+
+      // task 시작 대기 → 이 시점에 externalResolve가 할당됨
+      await taskStarted
+      expect(queue.size()).toBe(1)
+
+      // task를 완료
+      externalResolve()
+      // microtask flush — pending 감소 대기
+      await new Promise<void>((r) => setTimeout(r, 0))
+      expect(queue.size()).toBe(0)
+    })
+
+    it('3개 enqueue 시 size()가 3을 반환한다', async () => {
+      // 첫 번째 task가 시작되면 나머지 2개는 pending 상태
+      let firstResolve!: () => void
+      const firstStarted = new Promise<void>((resolve) => {
+        const task = () =>
+          new Promise<void>((res) => {
+            firstResolve = res
+            resolve()
+          })
+        queue.enqueue(task)
+      })
+
+      // 두 번째, 세 번째는 즉시 resolve되는 task
+      const p2 = queue.enqueue(() => Promise.resolve(2))
+      const p3 = queue.enqueue(() => Promise.resolve(3))
+
+      await firstStarted
+      // 첫 task 실행 중 → pending === 3
+      expect(queue.size()).toBe(3)
+
+      // 첫 task 해제
+      firstResolve()
+      await Promise.all([p2, p3])
+      expect(queue.size()).toBe(0)
+    })
+  })
+
+  describe('T-U-08: task reject 후 chain 끊김 없음', () => {
+    it('첫 task가 reject되어도 두 번째 task가 정상 실행된다', async () => {
+      const failingTask = () => Promise.reject(new Error('task failed'))
+      const successTask = () => Promise.resolve(42)
+
+      // 첫 task 실패
+      await expect(queue.enqueue(failingTask)).rejects.toThrow('task failed')
+
+      // 두 번째 task는 정상 실행되어야 함 (chain 끊김 없음)
+      const result = await queue.enqueue(successTask)
+      expect(result).toBe(42)
+    })
+
+    it('연속 실패 후에도 마지막 task가 정상 실행된다', async () => {
+      const fail = () => Promise.reject(new Error('fail'))
+      const success = () => Promise.resolve('ok')
+
+      const p1 = queue.enqueue(fail)
+      const p2 = queue.enqueue(fail)
+      const p3 = queue.enqueue(success)
+
+      await expect(p1).rejects.toThrow()
+      await expect(p2).rejects.toThrow()
+      await expect(p3).resolves.toBe('ok')
+    })
+  })
+
+  describe('T-U-09: clear() — 큐 초기화', () => {
+    it('clear() 호출 후 size() === 0이다', () => {
+      // 임의로 pending 카운트 증가
+      const neverResolve = () => new Promise<void>(() => {})
+      queue.enqueue(neverResolve)
+      queue.enqueue(neverResolve)
+
+      queue.clear()
+      expect(queue.size()).toBe(0)
+    })
+
+    it('clear() 후 새 enqueue가 정상 동작한다', async () => {
+      queue.clear()
+      const result = await queue.enqueue(() => Promise.resolve(99))
+      expect(result).toBe(99)
+    })
+  })
+})

--- a/tests/unit/v2/smoke.test.ts
+++ b/tests/unit/v2/smoke.test.ts
@@ -1,0 +1,26 @@
+/**
+ * v2 TypeScript 트랜스파일 인프라 동작 확인용 smoke test
+ * Phase 1 완료 기준: babel-jest + @babel/preset-typescript 인프라가 정상 작동하는지 검증
+ */
+
+describe('v2 TypeScript 트랜스파일 smoke test', () => {
+  it('기본 산술 연산이 TypeScript 환경에서 동작한다', () => {
+    expect(1 + 1).toBe(2)
+  })
+
+  it('TypeScript 타입 어노테이션이 문제없이 트랜스파일된다', () => {
+    const value: number = 42
+    const text: string = 'hello'
+    expect(value).toBe(42)
+    expect(text).toBe('hello')
+  })
+
+  it('TypeScript interface와 객체 생성이 동작한다', () => {
+    interface Point {
+      x: number
+      y: number
+    }
+    const point: Point = { x: 1, y: 2 }
+    expect(point.x + point.y).toBe(3)
+  })
+})

--- a/tests/unit/v2/transport/MessageTransport.contract.test.ts
+++ b/tests/unit/v2/transport/MessageTransport.contract.test.ts
@@ -1,0 +1,55 @@
+/**
+ * T-U-10, T-U-11: PopupTransport stub contract 검증
+ *
+ * error-handling-consistency 룰:
+ *   - send → Promise.reject(ProviderError(METHOD_NOT_FOUND))
+ *   - on/off → no-op (throw 없음)
+ *   - close → Promise.resolve()
+ */
+import { PopupTransport } from '../../../../src/transport/PopupTransport'
+import { ProviderError } from '../../../../src/error/ProviderError'
+import { ErrorCode } from '../../../../src/error/ErrorCode'
+import type { MessageEnvelope } from '../../../../src/transport/MessageTransport'
+
+describe('PopupTransport (stub contract)', () => {
+  let transport: PopupTransport
+
+  beforeEach(() => {
+    transport = new PopupTransport()
+  })
+
+  describe('T-U-10: send — Promise.reject(ProviderError(METHOD_NOT_FOUND))', () => {
+    it('send()가 ProviderError로 reject된다', async () => {
+      const envelope: MessageEnvelope = { id: 'test-id', method: 'connect' }
+      await expect(transport.send(envelope)).rejects.toBeInstanceOf(ProviderError)
+    })
+
+    it('reject된 에러의 code가 METHOD_NOT_FOUND이다', async () => {
+      const envelope: MessageEnvelope = { id: 'test-id', method: 'connect' }
+      try {
+        await transport.send(envelope)
+        // reject되어야 하므로 여기까지 오면 실패
+        expect(true).toBe(false)
+      } catch (err) {
+        expect(err).toBeInstanceOf(ProviderError)
+        expect((err as ProviderError).code).toBe(ErrorCode.METHOD_NOT_FOUND)
+      }
+    })
+  })
+
+  describe('T-U-11: on / off / close — no-op 또는 즉시 resolve', () => {
+    it('on()이 에러 없이 실행된다 (no-op)', () => {
+      const handler = (_state: 'connected' | 'disconnected') => {}
+      expect(() => transport.on('state', handler)).not.toThrow()
+    })
+
+    it('off()가 에러 없이 실행된다 (no-op)', () => {
+      const handler = (_state: 'connected' | 'disconnected') => {}
+      expect(() => transport.off('state', handler)).not.toThrow()
+    })
+
+    it('close()가 Promise.resolve()를 반환한다', async () => {
+      await expect(transport.close()).resolves.toBeUndefined()
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,7 +7,7 @@
   resolved "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz#63430d04bd8c5e74f8d7d049338f1cd9d4f02069"
   integrity sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.28.6", "@babel/code-frame@^7.29.0":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.27.1", "@babel/code-frame@^7.28.6", "@babel/code-frame@^7.29.0":
   version "7.29.0"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz#7cd7a59f15b3cc0dcd803038f7792712a7d0b15c"
   integrity sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==
@@ -304,7 +304,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@^7.28.6":
+"@babel/plugin-syntax-jsx@^7.27.1", "@babel/plugin-syntax-jsx@^7.28.6":
   version "7.28.6"
   resolved "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz#f8ca28bbd84883b5fea0e447c635b81ba73997ee"
   integrity sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==
@@ -352,6 +352,13 @@
   integrity sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-typescript@^7.28.6":
+  version "7.28.6"
+  resolved "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz#c7b2ddf1d0a811145b1de800d1abd146af92e3a2"
+  integrity sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/plugin-syntax-unicode-sets-regex@^7.18.6":
   version "7.18.6"
@@ -549,7 +556,7 @@
     "@babel/helper-module-transforms" "^7.27.1"
     "@babel/helper-plugin-utils" "^7.27.1"
 
-"@babel/plugin-transform-modules-commonjs@^7.28.6":
+"@babel/plugin-transform-modules-commonjs@^7.27.1", "@babel/plugin-transform-modules-commonjs@^7.28.6":
   version "7.28.6"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz#c0232e0dfe66a734cc4ad0d5e75fc3321b6fdef1"
   integrity sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==
@@ -760,6 +767,17 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.27.1"
 
+"@babel/plugin-transform-typescript@^7.28.5":
+  version "7.28.6"
+  resolved "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.6.tgz#1e93d96da8adbefdfdade1d4956f73afa201a158"
+  integrity sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.27.3"
+    "@babel/helper-create-class-features-plugin" "^7.28.6"
+    "@babel/helper-plugin-utils" "^7.28.6"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
+    "@babel/plugin-syntax-typescript" "^7.28.6"
+
 "@babel/plugin-transform-unicode-escapes@^7.27.1":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz#3e3143f8438aef842de28816ece58780190cf806"
@@ -887,6 +905,17 @@
     "@babel/plugin-transform-react-jsx" "^7.27.1"
     "@babel/plugin-transform-react-jsx-development" "^7.27.1"
     "@babel/plugin-transform-react-pure-annotations" "^7.27.1"
+
+"@babel/preset-typescript@^7.28.5":
+  version "7.28.5"
+  resolved "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz#540359efa3028236958466342967522fd8f2a60c"
+  integrity sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-validator-option" "^7.27.1"
+    "@babel/plugin-syntax-jsx" "^7.27.1"
+    "@babel/plugin-transform-modules-commonjs" "^7.27.1"
+    "@babel/plugin-transform-typescript" "^7.28.5"
 
 "@babel/runtime@7.3.1":
   version "7.3.1"
@@ -1637,6 +1666,11 @@
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
+"@jest/diff-sequences@30.3.0":
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz#25b0818d3d83f00b9c7b04e069b8810f9014b143"
+  integrity sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==
+
 "@jest/environment@^25.5.0":
   version "25.5.0"
   resolved "https://registry.npmjs.org/@jest/environment/-/environment-25.5.0.tgz#aa33b0c21a716c65686638e7ef816c0e3a0c7b37"
@@ -1655,6 +1689,13 @@
     "@jest/types" "^27.5.1"
     "@types/node" "*"
     jest-mock "^27.5.1"
+
+"@jest/expect-utils@30.3.0":
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz#c45b2da9802ffed33bf43b3e019ddb95e5ad95e8"
+  integrity sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==
+  dependencies:
+    "@jest/get-type" "30.1.0"
 
 "@jest/fake-timers@^24.9.0":
   version "24.9.0"
@@ -1688,6 +1729,11 @@
     jest-mock "^27.5.1"
     jest-util "^27.5.1"
 
+"@jest/get-type@30.1.0":
+  version "30.1.0"
+  resolved "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz#4fcb4dc2ebcf0811be1c04fd1cb79c2dba431cbc"
+  integrity sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==
+
 "@jest/globals@^25.5.2":
   version "25.5.2"
   resolved "https://registry.npmjs.org/@jest/globals/-/globals-25.5.2.tgz#5e45e9de8d228716af3257eeb3991cc2e162ca88"
@@ -1696,6 +1742,14 @@
     "@jest/environment" "^25.5.0"
     "@jest/types" "^25.5.0"
     expect "^25.5.0"
+
+"@jest/pattern@30.0.1":
+  version "30.0.1"
+  resolved "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz#d5304147f49a052900b4b853dedb111d080e199f"
+  integrity sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==
+  dependencies:
+    "@types/node" "*"
+    jest-regex-util "30.0.1"
 
 "@jest/reporters@^25.5.1":
   version "25.5.1"
@@ -1728,6 +1782,13 @@
     v8-to-istanbul "^4.1.3"
   optionalDependencies:
     node-notifier "^6.0.0"
+
+"@jest/schemas@30.0.5":
+  version "30.0.5"
+  resolved "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz#7bdf69fc5a368a5abdb49fd91036c55225846473"
+  integrity sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==
+  dependencies:
+    "@sinclair/typebox" "^0.34.0"
 
 "@jest/source-map@^24.9.0":
   version "24.9.0"
@@ -1820,6 +1881,19 @@
     slash "^3.0.0"
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
+
+"@jest/types@30.3.0":
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz#cada800d323cb74945c24ac74615fdb312a6c85f"
+  integrity sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==
+  dependencies:
+    "@jest/pattern" "30.0.1"
+    "@jest/schemas" "30.0.5"
+    "@types/istanbul-lib-coverage" "^2.0.6"
+    "@types/istanbul-reports" "^3.0.4"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.33"
+    chalk "^4.1.2"
 
 "@jest/types@^24.9.0":
   version "24.9.0"
@@ -2122,6 +2196,11 @@
   resolved "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
   integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
+"@sinclair/typebox@^0.34.0":
+  version "0.34.49"
+  resolved "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz#4f1369234f2ecf693866476c3b2e1b54d2a9d68e"
+  integrity sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.6"
   resolved "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.6.tgz#80c516a4dc264c2a69115e7578d62581ff455ed9"
@@ -2376,7 +2455,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
+"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1", "@types/istanbul-lib-coverage@^2.0.6":
   version "2.0.6"
   resolved "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz#7739c232a1fee9b4d3ce8985f314c0c6d33549d7"
   integrity sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==
@@ -2396,12 +2475,20 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
-"@types/istanbul-reports@^3.0.0":
+"@types/istanbul-reports@^3.0.0", "@types/istanbul-reports@^3.0.4":
   version "3.0.4"
   resolved "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz#0f03e3d2f670fbdac586e34b433783070cc16f54"
   integrity sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==
   dependencies:
     "@types/istanbul-lib-report" "*"
+
+"@types/jest@^30.0.0":
+  version "30.0.0"
+  resolved "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz#5e85ae568006712e4ad66f25433e9bdac8801f1d"
+  integrity sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==
+  dependencies:
+    expect "^30.0.0"
+    pretty-format "^30.0.0"
 
 "@types/json-schema@*", "@types/json-schema@^7.0.11", "@types/json-schema@^7.0.15", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.9":
   version "7.0.15"
@@ -2539,7 +2626,7 @@
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/stack-utils@^2.0.0":
+"@types/stack-utils@^2.0.0", "@types/stack-utils@^2.0.3":
   version "2.0.3"
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
@@ -2607,6 +2694,13 @@
   version "16.0.11"
   resolved "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.11.tgz#de958fb62e77fc383fa6cd8066eabdd13da88f04"
   integrity sha512-sbtvk8wDN+JvEdabmZExoW/HNr1cB7D/j4LT08rMiuikfA7m/JNJg7ATQcgzs34zHnoScDkY0ZRSl29Fkmk36g==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^17.0.33":
+  version "17.0.35"
+  resolved "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz#07013e46aa4d7d7d50a49e15604c1c5340d4eb24"
+  integrity sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -2963,7 +3057,7 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
-ansi-styles@^5.0.0:
+ansi-styles@^5.0.0, ansi-styles@^5.2.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
@@ -3898,6 +3992,11 @@ ci-info@^3.2.0:
   version "3.9.0"
   resolved "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
   integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
+
+ci-info@^4.2.0:
+  version "4.4.0"
+  resolved "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz#7d54eff9f54b45b62401c26032696eb59c8bd18c"
+  integrity sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==
 
 cids@^1.0.0, cids@^1.1.5:
   version "1.1.9"
@@ -5358,6 +5457,18 @@ expect@^25.5.0:
     jest-matcher-utils "^25.5.0"
     jest-message-util "^25.5.0"
     jest-regex-util "^25.2.6"
+
+expect@^30.0.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz#1b82111517d1ab030f3db0cf1b4061c8aa644f61"
+  integrity sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==
+  dependencies:
+    "@jest/expect-utils" "30.3.0"
+    "@jest/get-type" "30.1.0"
+    jest-matcher-utils "30.3.0"
+    jest-message-util "30.3.0"
+    jest-mock "30.3.0"
+    jest-util "30.3.0"
 
 express@^4.17.3:
   version "4.22.1"
@@ -7276,6 +7387,16 @@ jest-dev-server@^6.2.0:
     tree-kill "^1.2.2"
     wait-on "^6.0.1"
 
+jest-diff@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz#e0a4c84ef350ffd790ffd5b0016acabeecf5f759"
+  integrity sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==
+  dependencies:
+    "@jest/diff-sequences" "30.3.0"
+    "@jest/get-type" "30.1.0"
+    chalk "^4.1.2"
+    pretty-format "30.3.0"
+
 jest-diff@^25.5.0:
   version "25.5.0"
   resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz#1dd26ed64f96667c068cef026b677dfa01afcfa9"
@@ -7426,6 +7547,16 @@ jest-leak-detector@^25.5.0:
     jest-get-type "^25.2.6"
     pretty-format "^25.5.0"
 
+jest-matcher-utils@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz#d6c739fec1ecd33809f2d2b1348f6ab01d2f2493"
+  integrity sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==
+  dependencies:
+    "@jest/get-type" "30.1.0"
+    chalk "^4.1.2"
+    jest-diff "30.3.0"
+    pretty-format "30.3.0"
+
 jest-matcher-utils@^25.5.0:
   version "25.5.0"
   resolved "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-25.5.0.tgz#fbc98a12d730e5d2453d7f1ed4a4d948e34b7867"
@@ -7435,6 +7566,21 @@ jest-matcher-utils@^25.5.0:
     jest-diff "^25.5.0"
     jest-get-type "^25.2.6"
     pretty-format "^25.5.0"
+
+jest-message-util@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz#4d723544d36890ba862ac3961db52db5b0d1ba39"
+  integrity sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==
+  dependencies:
+    "@babel/code-frame" "^7.27.1"
+    "@jest/types" "30.3.0"
+    "@types/stack-utils" "^2.0.3"
+    chalk "^4.1.2"
+    graceful-fs "^4.2.11"
+    picomatch "^4.0.3"
+    pretty-format "30.3.0"
+    slash "^3.0.0"
+    stack-utils "^2.0.6"
 
 jest-message-util@^24.9.0:
   version "24.9.0"
@@ -7479,6 +7625,15 @@ jest-message-util@^27.5.1:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
+jest-mock@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz#e0fa4184a596a6c4fdec53d4f412158418923747"
+  integrity sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==
+  dependencies:
+    "@jest/types" "30.3.0"
+    "@types/node" "*"
+    jest-util "30.3.0"
+
 jest-mock@^24.9.0:
   version "24.9.0"
   resolved "https://registry.npmjs.org/jest-mock/-/jest-mock-24.9.0.tgz#c22835541ee379b908673ad51087a2185c13f1c6"
@@ -7513,6 +7668,11 @@ jest-puppeteer@^6.2.0:
   dependencies:
     expect-puppeteer "^6.1.1"
     jest-environment-puppeteer "^6.2.0"
+
+jest-regex-util@30.0.1:
+  version "30.0.1"
+  resolved "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz#f17c1de3958b67dfe485354f5a10093298f2a49b"
+  integrity sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==
 
 jest-regex-util@^24.9.0:
   version "24.9.0"
@@ -7637,6 +7797,18 @@ jest-snapshot@^25.5.1:
     natural-compare "^1.4.0"
     pretty-format "^25.5.0"
     semver "^6.3.0"
+
+jest-util@30.3.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz#95a4fbacf2dac20e768e2f1744b70519f2ba7980"
+  integrity sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==
+  dependencies:
+    "@jest/types" "30.3.0"
+    "@types/node" "*"
+    chalk "^4.1.2"
+    ci-info "^4.2.0"
+    graceful-fs "^4.2.11"
+    picomatch "^4.0.3"
 
 jest-util@^24.9.0:
   version "24.9.0"
@@ -9123,6 +9295,11 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
   integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
+picomatch@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
+
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -9203,6 +9380,15 @@ pretty-error@^4.0.0:
   dependencies:
     lodash "^4.17.20"
     renderkid "^3.0.0"
+
+pretty-format@30.3.0, pretty-format@^30.0.0:
+  version "30.3.0"
+  resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz#e977eed4bcd1b6195faed418af8eac68b9ea1f29"
+  integrity sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==
+  dependencies:
+    "@jest/schemas" "30.0.5"
+    ansi-styles "^5.2.0"
+    react-is "^18.3.1"
 
 pretty-format@^25.5.0:
   version "25.5.0"
@@ -9442,6 +9628,11 @@ react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-is@^18.3.1:
+  version "18.3.1"
+  resolved "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
 read-pkg-up@^4.0.0:
   version "4.0.0"
@@ -10438,7 +10629,7 @@ stack-utils@^1.0.1:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-stack-utils@^2.0.3:
+stack-utils@^2.0.3, stack-utils@^2.0.6:
   version "2.0.6"
   resolved "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz#aaf0748169c02fc33c8232abccf933f54a1cc34f"
   integrity sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==


### PR DESCRIPTION
## Objective

`m01-03-connector-v2-core-skeleton` — connector v2 아키텍처 핵심 추상화 skeleton 구현

**Jira**: [DC-1845](https://iotrust.atlassian.net/browse/DC-1845)
**depends-on**: m01-01-connector-v2-scaffold (DC-1840, SHIPPED)

## Summary

- **Phase 1**: TypeScript 트랜스파일 인프라 — babel-jest + @babel/preset-typescript + jest.v2.config.js + `yarn unit-v2` script + smoke test 3/3 PASS
- **Phase 2**: v2 핵심 추상화 5개 모듈 + 단위 테스트 4개 파일 + src/index.ts v2 public API export + baseline-checks unit-v2 entry 추가

## 변경 파일

### 신규 src/ 모듈 (5개)
- `src/error/ErrorCode.ts` — JSON-RPC 2.0 (-32xxx) + EIP-1193 (4xxx) + D'CENT 디바이스 (5xxx) 총 15개
- `src/error/ProviderError.ts` — Error 확장, instanceof 체인 보존
- `src/transport/MessageTransport.ts` — MessageEnvelope/ResponseEnvelope/TransportState interface
- `src/transport/PopupTransport.ts` — stub 구현 (cycle 02에서 실제 postMessage 도입)
- `src/queue/RequestQueue.ts` — RequestQueue interface + SerialRequestQueue (단일 동시성, chain.then(task,task) 패턴)

### 신규 테스트 파일 (4개)
- `tests/unit/v2/error/ErrorCode.test.ts`
- `tests/unit/v2/error/ProviderError.test.ts`
- `tests/unit/v2/queue/SerialRequestQueue.test.ts`
- `tests/unit/v2/transport/MessageTransport.contract.test.ts`

### 수정 파일
- `src/index.ts` — `export {}` stub → v2 public API export 6개
- `package.json` — `unit-v2` script 추가, @babel/preset-typescript + @types/jest devDep 추가
- `.babelrc` — @babel/preset-typescript preset 추가
- `jest.v2.config.js` — v2 전용 Jest config 신규 생성

## 자동 검증 결과

| 검증 | 결과 |
|---|---|
| `yarn tsc --noEmit` | PASS |
| `yarn lint` | PASS |
| `yarn build` | PASS (dist/v2/dcent-web-connector.min.js 생성) |
| `yarn unit-v2` | **37/37 PASS** (T-U-01~T-U-11 포함) |
| v2 runtime export 4개 resolve | PASS |
| package.json version/main 미변경 | PASS (0.16.0, src-v1/index.js) |
| LOC diff (테스트 제외) | 443 LOC < 600 LOC |

## Rationale

- `babel-jest + @babel/preset-typescript` 선택 — 기존 babel 7 환경과 일관, ts-loader는 webpack에만 사용
- `chain.then(task, task)` 패턴 — async-hygiene 룰 준수, 한 task reject가 후속 chain을 영구 차단하지 않음
- PopupTransport stub: `Promise.reject(ProviderError(METHOD_NOT_FOUND))` — error-handling-consistency 룰 준수 (return undefined 금지)
- MessageTransport/RequestQueue는 interface (type-only export) — 런타임 번들에 미포함이 정상, tsc로 컴파일 타임 검증

## Notes

- `yarn unit-mock`: puppeteer + webpack-dev-server 필요 — CI에서 검증 (로컬 환경 이슈, 본 변경과 무관)
- cycle 02에서 실제 postMessage 송수신, 핸드셰이크, uuid 도입 예정