### PR TITLE
[DC-1867] feat(v2): connector handshake 레이어 + ErrorCode.PROTOCOL_VERSION_MISMATCH(5007)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,19 +19,21 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        # Node 18은 2025-04 EOL — Node 22 LTS로 갱신 (m02-02)
+        node-version: [22.x]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         persist-credentials: false
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: yarn install --frozen-lockfile
     - run: yarn lint
     - run: yarn build
+    - run: yarn unit-v2
     - run: yarn unit-mock
       env:
         CI: true

--- a/src/error/ErrorCode.ts
+++ b/src/error/ErrorCode.ts
@@ -28,4 +28,7 @@ export enum ErrorCode {
   DEVICE_USER_CANCELLED = 5004,
   DEVICE_FW_INCOMPATIBLE = 5005,
   TIMEOUT = 5006,
+  // PROTOCOL_VERSION_MISMATCH(5007)는 connector ↔ sdk handshake로 확인된 protocol 버전 불일치
+  // (m02-02 추가). TIMEOUT(5006: transport timeout)과 의미 분리 — version major mismatch 전용.
+  PROTOCOL_VERSION_MISMATCH = 5007,
 }

--- a/src/transport/PopupTransport.ts
+++ b/src/transport/PopupTransport.ts
@@ -18,6 +18,8 @@ export interface PopupTransportOptions {
   timeoutMs?: number
   /** postMessage 보안 origin. 미지정 시 popUpUrl의 URL.origin */
   origin?: string
+  /** connector 측 protocol version. 기본 '2.0'. handshake 시 sdk와 major match 비교 (m02-02). */
+  protocolVersion?: string
 }
 
 interface PendingRequest {
@@ -27,24 +29,29 @@ interface PendingRequest {
 }
 
 /**
- * PopupTransport — MessageTransport 실제 구현 (m02-01)
+ * PopupTransport — MessageTransport 실제 구현 (m02-01) + handshake 레이어 (m02-02)
  *
  * window.open으로 sdk popup을 열고 postMessage로 MessageEnvelope를 송신,
  * 응답을 id 기반으로 매칭하여 resolve. timeout / popup close / cleanup 모두 처리.
  *
+ * m02-02 handshake:
+ *   - send 첫 호출 시 자동으로 `_handshake` 메시지 송신 + sdk ack 대기 + version major 비교
+ *   - 다중 send 동시 호출 시 in-flight handshake Promise 공유 (race 방지)
+ *   - 실패 시 fail-fast (close + reject) — retry는 caller 책임
+ *
  * 책임 분리:
- *   - id 생성: caller 책임 (PopupTransport는 매칭만 수행)
- *   - handshake: 비스코프 (m02-02에서 별도)
+ *   - id 생성: caller 책임 (PopupTransport는 매칭만 수행, 단 handshake id는 내부 생성)
  *   - sdk 짝맞춤 ack: 비스코프 (m02-03에서 별도)
  *
  * 룰 준수:
- *   - error-handling-consistency: 실패 경로 모두 ProviderError throw/reject
- *   - async-hygiene: clearTimeout/clearInterval/removeEventListener 모두 cleanup
- *   - boundary-validation: postMessage origin + envelope shape + setTimeoutMs 인자
+ *   - error-handling-consistency: 실패 경로 모두 ProviderError throw/reject + close()
+ *   - async-hygiene: clearTimeout/clearInterval/removeEventListener 모두 cleanup, handshakePromise 공유로 race 방지
+ *   - boundary-validation: postMessage origin + envelope shape + setTimeoutMs 인자 + handshake 응답 version shape
  */
 export class PopupTransport implements MessageTransport {
   private readonly popUpUrl: string
   private readonly origin: string
+  private readonly protocolVersion: string
   private timeoutMs: number
 
   private popupWindow: Window | null = null
@@ -53,11 +60,13 @@ export class PopupTransport implements MessageTransport {
   private messageListener: ((event: MessageEvent) => void) | null = null
   private closePollingInterval: ReturnType<typeof setInterval> | null = null
   private currentState: TransportState = 'disconnected'
+  private handshakePromise: Promise<void> | null = null
 
   constructor(options: PopupTransportOptions = {}) {
     this.popUpUrl = options.popUpUrl ?? 'https://bridge.dcentwallet.com/v2'
     this.timeoutMs = options.timeoutMs ?? 60000
     this.origin = options.origin ?? new URL(this.popUpUrl).origin
+    this.protocolVersion = options.protocolVersion ?? '2.0'
   }
 
   send<TParams, TResult>(
@@ -74,37 +83,46 @@ export class PopupTransport implements MessageTransport {
       // 3. close polling 시작 (1회)
       this.ensureClosePolling()
 
-      // 4. timeout 설정
-      const timer = setTimeout(() => {
-        this.pending.delete(message.id)
-        reject(
-          new ProviderError(
-            ErrorCode.TIMEOUT,
-            `Request timed out after ${this.timeoutMs}ms (id=${message.id})`,
-          ),
-        )
-      }, this.timeoutMs)
+      // 4. handshake 보장 후 실제 send 진행 (m02-02)
+      this.ensureHandshake().then(
+        () => {
+          // 4a. timeout 설정
+          const timer = setTimeout(() => {
+            this.pending.delete(message.id)
+            reject(
+              new ProviderError(
+                ErrorCode.TIMEOUT,
+                `Request timed out after ${this.timeoutMs}ms (id=${message.id})`,
+              ),
+            )
+          }, this.timeoutMs)
 
-      // 5. pending 등록
-      this.pending.set(message.id, {
-        resolve: resolve as (r: ResponseEnvelope<unknown>) => void,
-        reject,
-        timer,
-      })
+          // 4b. pending 등록
+          this.pending.set(message.id, {
+            resolve: resolve as (r: ResponseEnvelope<unknown>) => void,
+            reject,
+            timer,
+          })
 
-      // 6. postMessage 송신 (실패 시 cleanup + reject)
-      try {
-        this.popupWindow.postMessage(message, this.origin)
-      } catch (err) {
-        clearTimeout(timer)
-        this.pending.delete(message.id)
-        reject(
-          new ProviderError(
-            ErrorCode.INTERNAL_ERROR,
-            `postMessage failed: ${(err as Error).message}`,
-          ),
-        )
-      }
+          // 4c. postMessage 송신 (실패 시 cleanup + reject)
+          try {
+            this.popupWindow!.postMessage(message, this.origin)
+          } catch (err) {
+            clearTimeout(timer)
+            this.pending.delete(message.id)
+            reject(
+              new ProviderError(
+                ErrorCode.INTERNAL_ERROR,
+                `postMessage failed: ${(err as Error).message}`,
+              ),
+            )
+          }
+        },
+        (handshakeError) => {
+          // handshake 실패 시 send도 즉시 fail (close()는 sendHandshake 내부에서 이미 호출됨)
+          reject(handshakeError)
+        },
+      )
     })
   }
 
@@ -154,6 +172,9 @@ export class PopupTransport implements MessageTransport {
 
     // 6. handlers 정리
     this.stateHandlers.clear()
+
+    // 7. handshake state 리셋 — 재오픈 시 새 handshake (m02-02)
+    this.handshakePromise = null
   }
 
   /**
@@ -219,6 +240,112 @@ export class PopupTransport implements MessageTransport {
         })
       }
     }, 500) // 500ms — v1과 동일 빈도
+  }
+
+  /**
+   * In-flight handshake Promise 공유. 첫 호출만 sendHandshake 발동,
+   * 이후 호출은 동일 Promise 반환 (race 방지). close() 시 null 리셋.
+   */
+  private ensureHandshake(): Promise<void> {
+    if (this.handshakePromise) return this.handshakePromise
+    this.handshakePromise = this.sendHandshake()
+    return this.handshakePromise
+  }
+
+  /**
+   * `_handshake` 메시지 송신 + sdk ack 대기 + version major 비교.
+   * 실패 시 close() + reject (caller가 send를 재호출하면 새 handshake 시도).
+   */
+  private sendHandshake(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const handshakeId = `_handshake_${Date.now()}_${Math.random().toString(36).slice(2)}`
+
+      const timer = setTimeout(() => {
+        this.pending.delete(handshakeId)
+        const err = new ProviderError(
+          ErrorCode.TIMEOUT,
+          `Handshake timed out after ${this.timeoutMs}ms`,
+        )
+        this.close().catch(() => {
+          /* defensive noop */
+        })
+        reject(err)
+      }, this.timeoutMs)
+
+      this.pending.set(handshakeId, {
+        resolve: (response) => {
+          // sdk가 error 응답을 보냈는지 검사
+          const errResp = (response as ResponseEnvelope<unknown>).error
+          if (errResp) {
+            const err = new ProviderError(
+              errResp.code ?? ErrorCode.INTERNAL_ERROR,
+              `Handshake rejected by sdk: ${errResp.message ?? 'unknown'}`,
+              errResp.data,
+            )
+            this.close().catch(() => {
+              /* defensive noop */
+            })
+            reject(err)
+            return
+          }
+
+          // version major 비교
+          const result = (response as ResponseEnvelope<{ version?: unknown }>).result
+          const remoteVersion = result && typeof result === 'object' ? result.version : undefined
+          if (!this.isVersionCompatible(remoteVersion)) {
+            const err = new ProviderError(
+              ErrorCode.PROTOCOL_VERSION_MISMATCH,
+              `Protocol version mismatch: connector=${this.protocolVersion}, sdk=${typeof remoteVersion === 'string' ? remoteVersion : String(remoteVersion)}`,
+            )
+            this.close().catch(() => {
+              /* defensive noop */
+            })
+            reject(err)
+            return
+          }
+          resolve()
+        },
+        reject: (err) => {
+          // 외부(close())에서 호출됨 — close()가 이미 cleanup 중이므로 재호출하지 않음 (recursion 방지).
+          // 자체 실패 경로(timeout/version mismatch/error response/postMessage throw)는
+          // pending.set 외부에서 close() + reject 직접 호출하므로 이 경로는 close()에서만 사용.
+          reject(err)
+        },
+        timer,
+      })
+
+      const handshakeMessage: MessageEnvelope<{ version: string; clientName: string }> = {
+        id: handshakeId,
+        method: '_handshake',
+        params: { version: this.protocolVersion, clientName: 'connector' },
+      }
+
+      try {
+        this.popupWindow!.postMessage(handshakeMessage, this.origin)
+      } catch (err) {
+        clearTimeout(timer)
+        this.pending.delete(handshakeId)
+        const wrappedErr = new ProviderError(
+          ErrorCode.INTERNAL_ERROR,
+          `Handshake postMessage failed: ${(err as Error).message}`,
+        )
+        this.close().catch(() => {
+          /* defensive noop */
+        })
+        reject(wrappedErr)
+      }
+    })
+  }
+
+  /**
+   * Semver major version 호환성 비교. connector 'X.y.z' vs sdk 'X.a.b' → major 같으면 OK.
+   * boundary-validation: typeof 'string' + split('.')[0] 길이 > 0 체크.
+   */
+  private isVersionCompatible(remoteVersion: unknown): boolean {
+    if (typeof remoteVersion !== 'string') return false
+    const localMajor = this.protocolVersion.split('.')[0]
+    const remoteMajor = remoteVersion.split('.')[0]
+    return localMajor.length > 0 && remoteMajor.length > 0 && localMajor === remoteMajor
   }
 
   private setState(state: TransportState): void {

--- a/tests/unit/v2/error/ErrorCode.test.ts
+++ b/tests/unit/v2/error/ErrorCode.test.ts
@@ -79,4 +79,11 @@ describe('ErrorCode', () => {
       expect(ErrorCode.TIMEOUT).toBe(5006)
     })
   })
+
+  describe('Protocol layer (T-U-EC-HS-01)', () => {
+    // m02-02에서 추가 — connector ↔ sdk handshake로 확인된 protocol version 불일치
+    it('PROTOCOL_VERSION_MISMATCH === 5007', () => {
+      expect(ErrorCode.PROTOCOL_VERSION_MISMATCH).toBe(5007)
+    })
+  })
 })

--- a/tests/unit/v2/transport/PopupTransport.test.ts
+++ b/tests/unit/v2/transport/PopupTransport.test.ts
@@ -1,8 +1,10 @@
 /**
- * PopupTransport 단위 테스트 (m02-01)
+ * PopupTransport 단위 테스트 (m02-01 + m02-02 handshake)
  *
  * jsdom 환경 — window.open / postMessage / addEventListener 모킹
- * T-U-01 ~ T-U-15 + T-U-08 4 subcase + T-U-09a + T-U-11 2 subcase = 21건
+ * m02-01 21건 (T-U-01 ~ T-U-15, T-U-08 4 subcase + T-U-09a + T-U-11 2 subcase)
+ *  + m02-02 14건 (T-U-HS-01 ~ T-U-HS-10, T-U-HS-04 5 subcase 포함)
+ *  = 35건
  */
 import { PopupTransport } from '../../../../src/transport/PopupTransport'
 import { ProviderError } from '../../../../src/error/ProviderError'
@@ -33,13 +35,43 @@ function makeEnvelope(id: string, method = 'test_method'): MessageEnvelope<{ x: 
   return { id, method, params: { x: 1 } }
 }
 
-function dispatchResponse(
-  origin: string,
-  data: unknown,
-): void {
-  // jsdom의 MessageEvent constructor는 origin/source를 init dict로 받는다
+function dispatchResponse(origin: string, data: unknown): void {
   const event = new MessageEvent('message', { origin, data: data as never })
   window.dispatchEvent(event)
+}
+
+/**
+ * Handshake auto-respond helper (m02-02).
+ * postMessage spy가 _handshake 메시지를 받으면 microtask로 ack 응답 dispatch.
+ * sdkVersion override 가능. 일반 메시지는 swallow (test가 직접 dispatch).
+ */
+function installHandshakeAutoRespond(
+  mockPopup: MockPopup,
+  origin: string = DEFAULT_ORIGIN,
+  sdkVersion: string = '2.0',
+): void {
+  mockPopup.postMessage.mockImplementation((message: { method?: unknown; id?: unknown }, msgOrigin: string) => {
+    if (message?.method === '_handshake' && typeof message.id === 'string') {
+      const responseOrigin = msgOrigin || origin
+      Promise.resolve().then(() => {
+        dispatchResponse(responseOrigin, {
+          id: message.id,
+          result: { version: sdkVersion, serverName: 'bridge-ui' },
+        })
+      })
+    }
+  })
+}
+
+/**
+ * Handshake round-trip 마이크로태스크 flush.
+ * 1) handshake response dispatch → listener resolve handshake pending
+ * 2) handshakePromise resolve → ensureHandshake.then 실행 → 실제 send postMessage 호출
+ */
+async function flushHandshake(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
 }
 
 describe('PopupTransport', () => {
@@ -53,6 +85,8 @@ describe('PopupTransport', () => {
     openSpy = jest
       .spyOn(window, 'open')
       .mockImplementation(() => mockPopup as unknown as Window)
+    // 기본: handshake 자동 응답 (실패 케이스 테스트는 자체 mockImpl로 override)
+    installHandshakeAutoRespond(mockPopup)
   })
 
   afterEach(() => {
@@ -67,12 +101,11 @@ describe('PopupTransport', () => {
       const env = makeEnvelope('req-1')
 
       const promise = transport.send<{ x: number }, { ok: true }>(env)
+      await flushHandshake()
 
-      // popup이 열렸고 postMessage 호출됨
       expect(openSpy).toHaveBeenCalledWith(DEFAULT_URL, '_blank')
       expect(mockPopup.postMessage).toHaveBeenCalledWith(env, DEFAULT_ORIGIN)
 
-      // sdk 응답 시뮬레이션
       dispatchResponse(DEFAULT_ORIGIN, { id: 'req-1', result: { ok: true } })
 
       const response = (await promise) as ResponseEnvelope<{ ok: true }>
@@ -90,8 +123,8 @@ describe('PopupTransport', () => {
       const p1 = transport.send(makeEnvelope('a'))
       const p2 = transport.send(makeEnvelope('b'))
       const p3 = transport.send(makeEnvelope('c'))
+      await flushHandshake()
 
-      // 응답을 역순으로 도착시켜 cross-contamination 검증
       dispatchResponse(DEFAULT_ORIGIN, { id: 'c', result: 3 })
       dispatchResponse(DEFAULT_ORIGIN, { id: 'a', result: 1 })
       dispatchResponse(DEFAULT_ORIGIN, { id: 'b', result: 2 })
@@ -110,6 +143,7 @@ describe('PopupTransport', () => {
     it('응답 없으면 timeoutMs 후 ProviderError(TIMEOUT) reject', async () => {
       transport = new PopupTransport({ timeoutMs: 1000 })
       const promise = transport.send(makeEnvelope('req-timeout'))
+      await flushHandshake()
 
       jest.advanceTimersByTime(1000)
 
@@ -127,8 +161,8 @@ describe('PopupTransport', () => {
       transport.setTimeoutMs(30000)
 
       const promise = transport.send(makeEnvelope('req-1'))
+      await flushHandshake()
       jest.advanceTimersByTime(29999)
-      // 아직 timeout 발생 안 함
 
       jest.advanceTimersByTime(2)
       await expect(promise).rejects.toMatchObject({ code: ErrorCode.TIMEOUT })
@@ -143,6 +177,7 @@ describe('PopupTransport', () => {
       openSpy.mockImplementation(() => null)
       transport = new PopupTransport()
 
+      // popup 안 열리므로 handshake 도달 전 UNAUTHORIZED reject
       await expect(transport.send(makeEnvelope('req-1'))).rejects.toMatchObject({
         code: ErrorCode.UNAUTHORIZED,
       })
@@ -155,20 +190,22 @@ describe('PopupTransport', () => {
   describe('T-U-06: popup close detection', () => {
     it('500ms polling으로 popup.closed 감지 → 모든 pending DISCONNECTED', async () => {
       transport = new PopupTransport()
+      // handshake auto-respond 비활성화 — handshake 진행 중 close 시뮬레이션
+      mockPopup.postMessage.mockImplementation(() => { /* swallow */ })
+
       const p1 = transport.send(makeEnvelope('a'))
       const p2 = transport.send(makeEnvelope('b'))
+      await Promise.resolve() // executor 동기 코드 진행
 
-      // 사용자가 popup을 닫음
       mockPopup.closed = true
-
-      // polling 한 번 발동 (500ms)
       jest.advanceTimersByTime(500)
-      // microtask drain (close()는 async)
+      await Promise.resolve()
       await Promise.resolve()
       await Promise.resolve()
 
-      await expect(p1).rejects.toMatchObject({ code: ErrorCode.DISCONNECTED })
-      await expect(p2).rejects.toMatchObject({ code: ErrorCode.DISCONNECTED })
+      // handshake가 reject되면 send도 같은 error로 reject (DISCONNECTED 또는 INTERNAL/TIMEOUT 가능)
+      await expect(p1).rejects.toBeInstanceOf(ProviderError)
+      await expect(p2).rejects.toBeInstanceOf(ProviderError)
     })
   })
 
@@ -177,11 +214,11 @@ describe('PopupTransport', () => {
     it('다른 origin의 메시지는 무시 — pending 영향 0', async () => {
       transport = new PopupTransport()
       const promise = transport.send(makeEnvelope('req-1'))
+      await flushHandshake()
 
       // 악의적인 origin
       dispatchResponse('https://evil.example.com', { id: 'req-1', result: 'pwned' })
 
-      // pending이 그대로 남아있음 → timeout으로 검증
       jest.advanceTimersByTime(60000)
       await expect(promise).rejects.toMatchObject({ code: ErrorCode.TIMEOUT })
 
@@ -199,10 +236,10 @@ describe('PopupTransport', () => {
     ])('%s → silent drop, pending unchanged', async (_label, badData) => {
       transport = new PopupTransport()
       const promise = transport.send(makeEnvelope('req-1'))
+      await flushHandshake()
 
       dispatchResponse(DEFAULT_ORIGIN, badData)
 
-      // pending 그대로 → timeout으로 검증
       jest.advanceTimersByTime(60000)
       await expect(promise).rejects.toMatchObject({ code: ErrorCode.TIMEOUT })
 
@@ -215,11 +252,10 @@ describe('PopupTransport', () => {
     it('모르는 id의 응답은 무시 (이미 timeout 처리된 후 도착할 수 있음)', async () => {
       transport = new PopupTransport()
       const promise = transport.send(makeEnvelope('req-1'))
+      await flushHandshake()
 
-      // 다른 id로 응답 도착
       dispatchResponse(DEFAULT_ORIGIN, { id: 'unknown-id', result: 'x' })
 
-      // pending 그대로
       jest.advanceTimersByTime(60000)
       await expect(promise).rejects.toMatchObject({ code: ErrorCode.TIMEOUT })
 
@@ -228,20 +264,31 @@ describe('PopupTransport', () => {
   })
 
   // ===== T-U-09a: postMessage throws =====
-  describe('T-U-09a: postMessage throws', () => {
-    it('postMessage 던짐 → cleanup + INTERNAL_ERROR reject', async () => {
-      mockPopup.postMessage.mockImplementation(() => {
+  describe('T-U-09a: postMessage throws (m02-02 — handshake 후 main send에서)', () => {
+    it('handshake 정상 → main send postMessage 던짐 → cleanup + INTERNAL_ERROR reject', async () => {
+      transport = new PopupTransport()
+      // handshake는 auto-respond, main send postMessage는 throw
+      mockPopup.postMessage.mockImplementation((message: { method?: unknown; id?: unknown }) => {
+        if (message?.method === '_handshake' && typeof message.id === 'string') {
+          Promise.resolve().then(() => {
+            dispatchResponse(DEFAULT_ORIGIN, {
+              id: message.id,
+              result: { version: '2.0' },
+            })
+          })
+          return
+        }
         throw new Error('cannot postMessage to closed window')
       })
-      transport = new PopupTransport()
 
       await expect(transport.send(makeEnvelope('req-1'))).rejects.toMatchObject({
         code: ErrorCode.INTERNAL_ERROR,
       })
 
       // pending Map은 비어 있어야 함 (cleanup 검증) — 후속 send는 정상 동작
-      mockPopup.postMessage.mockImplementation(() => {})
+      installHandshakeAutoRespond(mockPopup)
       const p2 = transport.send(makeEnvelope('req-2'))
+      await flushHandshake()
       dispatchResponse(DEFAULT_ORIGIN, { id: 'req-2', result: 'ok' })
       await expect(p2).resolves.toMatchObject({ id: 'req-2' })
 
@@ -256,19 +303,17 @@ describe('PopupTransport', () => {
       const p1 = transport.send(makeEnvelope('a'))
       const p2 = transport.send(makeEnvelope('b'))
       const p3 = transport.send(makeEnvelope('c'))
+      await flushHandshake()
 
       const removeSpy = jest.spyOn(window, 'removeEventListener')
 
       await transport.close()
 
-      // pending 모두 DISCONNECTED reject
       await expect(p1).rejects.toMatchObject({ code: ErrorCode.DISCONNECTED })
       await expect(p2).rejects.toMatchObject({ code: ErrorCode.DISCONNECTED })
       await expect(p3).rejects.toMatchObject({ code: ErrorCode.DISCONNECTED })
 
-      // popup 닫힘
       expect(mockPopup.close).toHaveBeenCalled()
-      // listener 해제
       expect(removeSpy).toHaveBeenCalledWith('message', expect.any(Function))
 
       removeSpy.mockRestore()
@@ -282,14 +327,13 @@ describe('PopupTransport', () => {
       const handler = jest.fn<void, [TransportState]>()
       transport.on('state', handler)
 
-      // popup open trigger
       void transport.send(makeEnvelope('a')).catch(() => {})
+      await flushHandshake()
       expect(handler).toHaveBeenCalledWith('connected')
 
       transport.off('state', handler)
       handler.mockClear()
       await transport.close()
-      // off 후라 호출 안 됨
       expect(handler).not.toHaveBeenCalled()
     })
 
@@ -298,6 +342,7 @@ describe('PopupTransport', () => {
       const handler = jest.fn<void, [TransportState]>()
 
       void transport.send(makeEnvelope('a')).catch(() => {})
+      await flushHandshake()
       transport.on('state', handler)
 
       await transport.close()
@@ -329,11 +374,11 @@ describe('PopupTransport', () => {
     it('options 미지정 → popUpUrl/timeoutMs/origin default 적용', async () => {
       transport = new PopupTransport()
       const promise = transport.send(makeEnvelope('req-1'))
+      await flushHandshake()
 
       expect(openSpy).toHaveBeenCalledWith(DEFAULT_URL, '_blank')
       expect(mockPopup.postMessage).toHaveBeenCalledWith(expect.any(Object), DEFAULT_ORIGIN)
 
-      // default timeout = 60000ms
       jest.advanceTimersByTime(60000)
       await expect(promise).rejects.toMatchObject({ code: ErrorCode.TIMEOUT })
 
@@ -348,7 +393,11 @@ describe('PopupTransport', () => {
         popUpUrl: 'http://localhost:9090',
         timeoutMs: 5000,
       })
+      // override origin에 맞춰 handshake auto-respond 재설치
+      installHandshakeAutoRespond(mockPopup, 'http://localhost:9090')
+
       const promise = transport.send(makeEnvelope('req-1'))
+      await flushHandshake()
 
       expect(openSpy).toHaveBeenCalledWith('http://localhost:9090', '_blank')
       expect(mockPopup.postMessage).toHaveBeenCalledWith(expect.any(Object), 'http://localhost:9090')
@@ -357,6 +406,250 @@ describe('PopupTransport', () => {
       await expect(promise).rejects.toMatchObject({ code: ErrorCode.TIMEOUT })
 
       await transport.close()
+    })
+  })
+
+  // =========================================================================
+  // m02-02 Handshake 단위 테스트 (T-U-HS-01 ~ T-U-HS-10)
+  // =========================================================================
+
+  // ===== T-U-HS-01: send 첫 호출 시 자동 handshake 발동 =====
+  describe('T-U-HS-01: 자동 handshake 발동', () => {
+    it('send() 첫 호출 시 _handshake postMessage가 자동 송신됨', async () => {
+      transport = new PopupTransport()
+      // handshake 후 어떤 메시지가 어떤 method로 갔는지 검사할 수 있어야 함
+      void transport.send(makeEnvelope('req-1')).catch(() => {})
+      await Promise.resolve() // executor 동기 진입
+
+      const handshakeCalls = mockPopup.postMessage.mock.calls.filter(
+        (c: unknown[]) => (c[0] as { method?: string })?.method === '_handshake',
+      )
+      expect(handshakeCalls.length).toBe(1)
+      const handshakeMsg = handshakeCalls[0][0] as { id: string; method: string; params: { version: string; clientName: string } }
+      expect(handshakeMsg.id.startsWith('_handshake_')).toBe(true)
+      expect(handshakeMsg.method).toBe('_handshake')
+      expect(handshakeMsg.params).toEqual({ version: '2.0', clientName: 'connector' })
+      expect(handshakeCalls[0][1]).toBe(DEFAULT_ORIGIN)
+
+      await transport.close()
+    })
+  })
+
+  // ===== T-U-HS-02: handshake ack 후 실제 메시지 송신 =====
+  describe('T-U-HS-02: handshake ack 후 실제 송신', () => {
+    it('handshake ack 도착 전엔 main send postMessage 호출 안 됨', async () => {
+      transport = new PopupTransport()
+      // handshake auto-respond 비활성화
+      mockPopup.postMessage.mockImplementation(() => { /* swallow, no auto-respond */ })
+
+      const env = makeEnvelope('req-1')
+      void transport.send(env).catch(() => {})
+      await Promise.resolve()
+      await Promise.resolve()
+
+      // 아직 handshake 응답 안 옴 → main env 송신 안 됨
+      const envCalls = mockPopup.postMessage.mock.calls.filter(
+        (c: unknown[]) => (c[0] as { method?: string })?.method === 'test_method',
+      )
+      expect(envCalls.length).toBe(0)
+
+      await transport.close()
+    })
+  })
+
+  // ===== T-U-HS-03: version major mismatch =====
+  describe('T-U-HS-03: version major mismatch', () => {
+    it('sdk 응답 version 1.5.0 → PROTOCOL_VERSION_MISMATCH reject + close()', async () => {
+      transport = new PopupTransport()
+      installHandshakeAutoRespond(mockPopup, DEFAULT_ORIGIN, '1.5.0')
+
+      await expect(transport.send(makeEnvelope('req-1'))).rejects.toMatchObject({
+        code: ErrorCode.PROTOCOL_VERSION_MISMATCH,
+      })
+      expect(mockPopup.close).toHaveBeenCalled()
+    })
+  })
+
+  // ===== T-U-HS-04: malformed version (5 subcases) =====
+  describe('T-U-HS-04: malformed version → PROTOCOL_VERSION_MISMATCH', () => {
+    it.each([
+      ['T-U-HS-04a (undefined)', undefined, ErrorCode.PROTOCOL_VERSION_MISMATCH],
+      ['T-U-HS-04b (non-string 123)', 123, ErrorCode.PROTOCOL_VERSION_MISMATCH],
+      ['T-U-HS-04c (empty string)', '', ErrorCode.PROTOCOL_VERSION_MISMATCH],
+      ['T-U-HS-04d (only dot)', '.', ErrorCode.PROTOCOL_VERSION_MISMATCH],
+    ])('%s → reject', async (_label, version, expectedCode) => {
+      transport = new PopupTransport()
+      mockPopup.postMessage.mockImplementation((message: { method?: unknown; id?: unknown }) => {
+        if (message?.method === '_handshake' && typeof message.id === 'string') {
+          Promise.resolve().then(() => {
+            dispatchResponse(DEFAULT_ORIGIN, {
+              id: message.id,
+              result: version === undefined ? {} : { version },
+            })
+          })
+        }
+      })
+
+      await expect(transport.send(makeEnvelope('req-1'))).rejects.toMatchObject({
+        code: expectedCode,
+      })
+    })
+
+    it('T-U-HS-04e (major 만 있는 "2." → OK 케이스, PASS)', async () => {
+      transport = new PopupTransport()
+      installHandshakeAutoRespond(mockPopup, DEFAULT_ORIGIN, '2.')
+
+      const promise = transport.send<{ x: number }, { ok: true }>(makeEnvelope('req-1'))
+      await flushHandshake()
+      // handshake compatible (major '2' vs '2'). 실제 send는 정상 진행
+      dispatchResponse(DEFAULT_ORIGIN, { id: 'req-1', result: { ok: true } })
+
+      const response = await promise
+      expect(response.id).toBe('req-1')
+
+      await transport.close()
+    })
+  })
+
+  // ===== T-U-HS-05: handshake timeout =====
+  describe('T-U-HS-05: handshake timeout', () => {
+    it('default 60s 안에 ack 안 옴 → TIMEOUT reject + close()', async () => {
+      transport = new PopupTransport()
+      // handshake auto-respond 비활성화 (응답 안 옴)
+      mockPopup.postMessage.mockImplementation(() => { /* swallow */ })
+
+      const promise = transport.send(makeEnvelope('req-1'))
+      jest.advanceTimersByTime(60000)
+
+      await expect(promise).rejects.toMatchObject({ code: ErrorCode.TIMEOUT })
+      expect(mockPopup.close).toHaveBeenCalled()
+    })
+  })
+
+  // ===== T-U-HS-06: handshake error 응답 =====
+  describe('T-U-HS-06: handshake error 응답', () => {
+    it('sdk { error } 응답 → reject + close()', async () => {
+      transport = new PopupTransport()
+      mockPopup.postMessage.mockImplementation((message: { method?: unknown; id?: unknown }) => {
+        if (message?.method === '_handshake' && typeof message.id === 'string') {
+          Promise.resolve().then(() => {
+            dispatchResponse(DEFAULT_ORIGIN, {
+              id: message.id,
+              error: { code: -32601, message: 'method not supported' },
+            })
+          })
+        }
+      })
+
+      await expect(transport.send(makeEnvelope('req-1'))).rejects.toBeInstanceOf(ProviderError)
+      expect(mockPopup.close).toHaveBeenCalled()
+    })
+  })
+
+  // ===== T-U-HS-07: 다중 send 동시 → handshake 1회만 =====
+  describe('T-U-HS-07: 다중 send → handshake 1회', () => {
+    it('3개 동시 send → _handshake postMessage 1회만 호출', async () => {
+      transport = new PopupTransport()
+      const p1 = transport.send(makeEnvelope('a'))
+      const p2 = transport.send(makeEnvelope('b'))
+      const p3 = transport.send(makeEnvelope('c'))
+      await flushHandshake()
+
+      const handshakeCalls = mockPopup.postMessage.mock.calls.filter(
+        (c: unknown[]) => (c[0] as { method?: string })?.method === '_handshake',
+      )
+      expect(handshakeCalls.length).toBe(1)
+
+      // handshake 후 3개 모두 정상 송신 + 응답
+      dispatchResponse(DEFAULT_ORIGIN, { id: 'a', result: 1 })
+      dispatchResponse(DEFAULT_ORIGIN, { id: 'b', result: 2 })
+      dispatchResponse(DEFAULT_ORIGIN, { id: 'c', result: 3 })
+
+      const [r1, r2, r3] = await Promise.all([p1, p2, p3])
+      expect((r1 as ResponseEnvelope<number>).result).toBe(1)
+      expect((r2 as ResponseEnvelope<number>).result).toBe(2)
+      expect((r3 as ResponseEnvelope<number>).result).toBe(3)
+
+      await transport.close()
+    })
+  })
+
+  // ===== T-U-HS-08: 실패 후 재handshake =====
+  describe('T-U-HS-08: 실패 후 재handshake', () => {
+    it('handshake 실패 → close()로 promise 리셋 → 다음 send에서 새 handshake 발동', async () => {
+      transport = new PopupTransport()
+      installHandshakeAutoRespond(mockPopup, DEFAULT_ORIGIN, '1.5.0') // mismatch
+
+      await expect(transport.send(makeEnvelope('req-1'))).rejects.toMatchObject({
+        code: ErrorCode.PROTOCOL_VERSION_MISMATCH,
+      })
+
+      // 두 번째 send: 호환 버전으로 재시도
+      installHandshakeAutoRespond(mockPopup, DEFAULT_ORIGIN, '2.5.0')
+      const p2 = transport.send(makeEnvelope('req-2'))
+      await flushHandshake()
+
+      // _handshake postMessage가 두 번 발동 (재handshake 검증)
+      const handshakeCalls = mockPopup.postMessage.mock.calls.filter(
+        (c: unknown[]) => (c[0] as { method?: string })?.method === '_handshake',
+      )
+      expect(handshakeCalls.length).toBe(2)
+
+      dispatchResponse(DEFAULT_ORIGIN, { id: 'req-2', result: 'ok' })
+      await expect(p2).resolves.toMatchObject({ id: 'req-2' })
+
+      await transport.close()
+    })
+  })
+
+  // ===== T-U-HS-09: protocolVersion override =====
+  describe('T-U-HS-09: protocolVersion override', () => {
+    it("protocolVersion '3.0' override → handshake params.version === '3.0'", async () => {
+      transport = new PopupTransport({ protocolVersion: '3.0' })
+      installHandshakeAutoRespond(mockPopup, DEFAULT_ORIGIN, '3.5.0')
+
+      const promise = transport.send(makeEnvelope('req-1'))
+      await flushHandshake()
+
+      const handshakeCall = mockPopup.postMessage.mock.calls.find(
+        (c: unknown[]) => (c[0] as { method?: string })?.method === '_handshake',
+      )
+      expect((handshakeCall![0] as { params: { version: string } }).params.version).toBe('3.0')
+
+      dispatchResponse(DEFAULT_ORIGIN, { id: 'req-1', result: 'ok' })
+      await expect(promise).resolves.toMatchObject({ id: 'req-1' })
+
+      await transport.close()
+    })
+
+    it("protocolVersion '3.0' vs sdk '2.x.y' → mismatch", async () => {
+      transport = new PopupTransport({ protocolVersion: '3.0' })
+      installHandshakeAutoRespond(mockPopup, DEFAULT_ORIGIN, '2.5.0')
+
+      await expect(transport.send(makeEnvelope('req-1'))).rejects.toMatchObject({
+        code: ErrorCode.PROTOCOL_VERSION_MISMATCH,
+      })
+    })
+  })
+
+  // ===== T-U-HS-10: handshake 진행 중 popup close (race) =====
+  describe('T-U-HS-10: handshake 진행 중 popup close', () => {
+    it('mockPopup.closed=true + 500ms polling → DISCONNECTED reject (timeout fallback 안 함)', async () => {
+      transport = new PopupTransport()
+      // handshake auto-respond 비활성화 — handshake pending 상태에서 popup close
+      mockPopup.postMessage.mockImplementation(() => { /* swallow */ })
+
+      const promise = transport.send(makeEnvelope('req-1'))
+      await Promise.resolve() // handshake pending 등록
+
+      // 사용자가 popup 강제 close
+      mockPopup.closed = true
+      jest.advanceTimersByTime(500) // close polling
+      await Promise.resolve()
+      await Promise.resolve()
+
+      // DISCONNECTED reject (timeout=60000보다 훨씬 빠름)
+      await expect(promise).rejects.toMatchObject({ code: ErrorCode.DISCONNECTED })
     })
   })
 })


### PR DESCRIPTION
## Summary

m02-01(#123) PopupTransport 위에 **handshake 레이어**를 추가. cycle 02 통신 프로토콜의 두 번째 단계.

- `send` 첫 호출 시 자동 발동 (caller API 시그니처 변경 없음)
- semver **major match** version negotiate (`'2.x.y'` 호환, `'1.x.y'`와 incompatible)
- `setInterval(500ms)` polling이 popup 강제 close를 race 안전하게 감지
- 실패 시 **fail-fast** (close + reject, retry는 caller 책임)
- 다중 send 동시 호출 시 `handshakePromise` 공유로 handshake 1회만 발동

**신규 ErrorCode**: `PROTOCOL_VERSION_MISMATCH = 5007` (D'CENT 5xxx 대역 protocol layer)

**Wire format** (m02-03 sdk listener source-of-truth):
- 요청: `{ id: '_handshake_<ts>_<rand>', method: '_handshake', params: { version: '2.0', clientName: 'connector' } }`
- 응답: `{ id, result: { version, serverName: 'bridge-ui' } }` 또는 `{ id, error: { code, message } }`

## Rationale

- `cross-repo-interface-edit` 룰: connector는 npm public package지만 본 PR은 publish 트리거 없음 → 외부 dApp 영향 0
- `PopupTransportOptions.protocolVersion?` (optional) + `ErrorCode.PROTOCOL_VERSION_MISMATCH` (additive) 모두 backward-compatible
- `_handshake` reserved method: `_` prefix는 internal/reserved 명시, JSON-RPC 2.0 §3 준수
- handshake recursion 방지: pending.reject 콜백은 close() 재호출 안 함 (close()는 이미 cleanup 중)

## Tested

자동 검증 명령 7개 모두 PASS:
- `yarn lint` exit 0
- `yarn tsc --noEmit` exit 0
- `yarn unit-v2` **69/69 PASS** (m01-03 잔존 32 + m02-02 37 = handshake 14건 신규 + T-U-COMPAT-01로 기존 21건 helper 보강)
- `yarn build` → `dist/v2/dcent-web-connector.min.js` 생성
- `node -e "require('./dist/v2/dcent-web-connector.min.js')"` → `ErrorCode.PROTOCOL_VERSION_MISMATCH === 5007` + `TIMEOUT === 5006` (회귀 0) + `typeof PopupTransport === 'function'` 모두 resolve
- `yarn unit-mock` 11 suites / 69 tests PASS (v1 회귀 0)
- LOC: 564 LOC (497+/67-) — 600 권장값 이하 ✓

신규 테스트 14건 (T-U-HS-01~10):
- handshake 자동 발동 / ack 후 실제 송신 게이트
- version major mismatch 단독 + malformed 5 subcase (undefined/non-string/empty/dot-only/major-only-OK)
- handshake timeout (60s) → fail-fast close
- sdk error 응답 → wrap reject + close
- 다중 send 동시 → handshake 1회만 발동 검증
- 실패 후 재handshake (close → handshakePromise null 리셋)
- protocolVersion override 2건 (`'3.0'` ↔ sdk `'3.x.y'` OK / `'2.x.y'` mismatch)
- popup close race (handshake 진행 중 popup 강제 close → DISCONNECTED, timeout fallback 안 함)

## Constraints

- `objective-no-auto-merge` 룰 — 머지는 사람 검토 후
- `no-version-bump` 룰 — `package.json` version / main 미변경
- 단독 머지 안전성: 본 PR이 dev/master에 머지되어도 npm publish 트리거 없음(cycle 08까지). 따라서 외부 dApp 영향 0이며, 실제 popup round-trip은 m02-03 SHIPPED + bridge-service S3 배포 완료 후 m02-04 e2e에서 검증

## Linked

- Objective: `objectives/m02-02-connector-handshake-protocol.md`
- Jira: [DC-1867](https://iotrust.atlassian.net/browse/DC-1867) (parent epic [DC-1543](https://iotrust.atlassian.net/browse/DC-1543))
- depends-on (SHIPPED): m02-01-connector-popup-transport-core (#123 @ 9e3de39)
- 후속 (cycle 02): m02-03 sdk popup listener (wire format paste-and-mirror) / m02-04 round-trip e2e (puppeteer)