### PR TITLE
[DC-1875] feat(test): cycle 02 popup transport round-trip e2e — 8 specs + jest-puppeteer 인프라

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,52 @@
+# v2 popup transport round-trip e2e — workflow_dispatch (manual trigger)
+# self-hosted runner 사용 (IotrustGitHub Org IP allow list 우회 — sdk m02-03 패턴 mirror)
+# PR마다 자동 실행은 비스코프 (cycle 03+에서 검토)
+
+name: v2 e2e
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    runs-on: self-hosted
+
+    strategy:
+      matrix:
+        node-version: [22.x]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: chromium sanity check (T-E-SETUP-02)
+        # self-hosted runner에 chromium이 없으면 cryptic launch 에러 대신 명확한 메시지로 fail
+        run: |
+          node -e "console.log('chromium executablePath:', require('puppeteer').executablePath())"
+
+      - name: connector install + build
+        run: |
+          yarn install --frozen-lockfile
+          yarn build
+
+      - name: sdk install + build (e2e 사전 조건)
+        # sdk dist를 globalSetup이 :5174로 직접 launch — dev server 의존 0
+        run: |
+          cd ../dcent-web-sdk
+          npm install --legacy-peer-deps --ignore-scripts
+          npm run build
+
+      - name: e2e suite
+        run: yarn unit-v2-e2e
+        env:
+          CI: true
+          NODE_OPTIONS: --max-old-space-size=8192

--- a/jest.v2-e2e.config.js
+++ b/jest.v2-e2e.config.js
@@ -1,0 +1,19 @@
+/**
+ * Jest 설정 — v2 e2e 전용 (jest-puppeteer preset 미사용)
+ *
+ * 각 spec이 직접 puppeteer.launch()로 browser/page를 제어 (v1 1_bridge_test 패턴과 일관).
+ * globalSetup이 harness server (:9091) + sdk static server (:5174)를 launch.
+ * --runInBand 직렬 실행으로 port 충돌 방지.
+ */
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/tests/unit/2_v2_e2e/**/*.spec.ts'],
+  transform: {
+    '^.+\\.tsx?$': 'babel-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
+  globalSetup: './tests/unit/2_v2_e2e/globalSetup.js',
+  globalTeardown: './tests/unit/2_v2_e2e/globalTeardown.js',
+  testTimeout: 60000,
+  collectCoverage: false,
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "unit-mock": "jest --coverage --runInBand 0_mock_test",
     "unit-bridge": "jest --coverage --runInBand 1_bridge_test",
     "unit-v2": "jest --config jest.v2.config.js --runInBand tests/unit/v2",
+    "unit-v2-e2e": "jest --config jest.v2-e2e.config.js --runInBand",
     "lint": "eslint --ext .js src-v1 tests",
     "lint:fix": "eslint --ext .js src-v1 tests --fix",
     "tsc": "tsc --noEmit"

--- a/tests/unit/2_v2_e2e/01_handshake.spec.ts
+++ b/tests/unit/2_v2_e2e/01_handshake.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * T-E-01 — handshake → echo round-trip
+ *
+ * connector(dist/v2) ↔ sdk(localhost:5174) 실제 popup 환경에서
+ * send 첫 호출 시 자동 handshake 발동 → sdk ack → echo 응답 round-trip.
+ */
+const puppeteer = require('puppeteer')
+
+const HARNESS_URL = 'http://localhost:9091/tests/unit/2_v2_e2e/harness.html'
+const SDK_URL = 'http://localhost:5174/'
+
+describe('[v2 e2e] T-E-01 handshake → echo round-trip', () => {
+  let browser: any
+  let page: any
+
+  beforeAll(async () => {
+    browser = await puppeteer.launch({
+      headless: 'new',
+      args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-popup-blocking'],
+    })
+    page = await browser.newPage()
+    await page.goto(HARNESS_URL)
+  })
+
+  afterAll(async () => {
+    await browser.close()
+  })
+
+  afterEach(async () => {
+    await page.evaluate(() => (window as any).dcentTest.close())
+  })
+
+  it('T-E-01: send getStatus → handshake auto + echo round-trip', async () => {
+    await page.evaluate((url: string) => {
+      ;(window as any).dcentTest.newTransport({ popUpUrl: url })
+    }, SDK_URL)
+    // sdk popup의 React listener mount 시간 보장 — race 회피
+    await page.evaluate(() => (window as any).dcentTest.preOpenAndWait())
+
+    const result = await page.evaluate(() => {
+      return (window as any).dcentTest.send({
+        id: 'e2e-1',
+        method: 'getStatus',
+        params: { foo: 1 },
+      })
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.response.id).toBe('e2e-1')
+    expect(result.response.result).toEqual({
+      method: 'getStatus',
+      params: { foo: 1 },
+      echo: true,
+    })
+  }, 30000)
+})

--- a/tests/unit/2_v2_e2e/02_version_mismatch.spec.ts
+++ b/tests/unit/2_v2_e2e/02_version_mismatch.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * T-E-02 — protocol version mismatch
+ *
+ * connector가 protocolVersion='99.0'으로 핸드셰이크 보내면
+ * sdk(major='2')가 PROTOCOL_VERSION_MISMATCH(5007) 에러 응답.
+ */
+const puppeteer = require('puppeteer')
+
+const HARNESS_URL = 'http://localhost:9091/tests/unit/2_v2_e2e/harness.html'
+const SDK_URL = 'http://localhost:5174/'
+
+describe('[v2 e2e] T-E-02 version mismatch', () => {
+  let browser: any
+  let page: any
+
+  beforeAll(async () => {
+    browser = await puppeteer.launch({
+      headless: 'new',
+      args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-popup-blocking'],
+    })
+    page = await browser.newPage()
+    await page.goto(HARNESS_URL)
+  })
+
+  afterAll(async () => {
+    await browser.close()
+  })
+
+  afterEach(async () => {
+    await page.evaluate(() => (window as any).dcentTest.close())
+  })
+
+  it('T-E-02: protocolVersion 99.0 → 5007 PROTOCOL_VERSION_MISMATCH', async () => {
+    await page.evaluate((url: string) => {
+      ;(window as any).dcentTest.newTransport({ popUpUrl: url, protocolVersion: '99.0' })
+    }, SDK_URL)
+    await page.evaluate(() => (window as any).dcentTest.preOpenAndWait())
+
+    const result = await page.evaluate(() => {
+      return (window as any).dcentTest.send({
+        id: 'e2e-vm',
+        method: 'getStatus',
+        params: {},
+      })
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.error.code).toBe(5007)
+  }, 30000)
+})

--- a/tests/unit/2_v2_e2e/03_concurrent_send.spec.ts
+++ b/tests/unit/2_v2_e2e/03_concurrent_send.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * T-E-03 — concurrent send → handshake 1회만 발동
+ *
+ * Promise.all로 동시 3개 send 호출 시 PopupTransport의 handshakePromise 공유 메커니즘이
+ * 정확히 1회의 _handshake outbound postMessage만 발생시키는지 검증.
+ * harness가 popupWindow.postMessage를 spy로 감싸 카운트.
+ */
+const puppeteer = require('puppeteer')
+
+const HARNESS_URL = 'http://localhost:9091/tests/unit/2_v2_e2e/harness.html'
+const SDK_URL = 'http://localhost:5174/'
+
+describe('[v2 e2e] T-E-03 concurrent send → handshake 1회', () => {
+  let browser: any
+  let page: any
+
+  beforeAll(async () => {
+    browser = await puppeteer.launch({
+      headless: 'new',
+      args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-popup-blocking'],
+    })
+    page = await browser.newPage()
+    await page.goto(HARNESS_URL)
+  })
+
+  afterAll(async () => {
+    await browser.close()
+  })
+
+  afterEach(async () => {
+    await page.evaluate(() => (window as any).dcentTest.close())
+  })
+
+  it('T-E-03: 동시 3 send → handshake count === 1 + 3개 모두 echo', async () => {
+    await page.evaluate((url: string) => {
+      ;(window as any).dcentTest.newTransport({ popUpUrl: url })
+    }, SDK_URL)
+    await page.evaluate(() => (window as any).dcentTest.preOpenAndWait())
+
+    const out = await page.evaluate(() => {
+      return (window as any).dcentTest.sendConcurrent([
+        { id: 'e2e-c1', method: 'getStatus', params: { i: 1 } },
+        { id: 'e2e-c2', method: 'getStatus', params: { i: 2 } },
+        { id: 'e2e-c3', method: 'getStatus', params: { i: 3 } },
+      ])
+    })
+
+    expect(out.handshakeCount).toBe(1)
+    expect(out.results).toHaveLength(3)
+    out.results.forEach((r: any) => {
+      expect(r.ok).toBe(true)
+      expect(r.response.result.echo).toBe(true)
+    })
+  }, 30000)
+})

--- a/tests/unit/2_v2_e2e/04_popup_close.spec.ts
+++ b/tests/unit/2_v2_e2e/04_popup_close.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * T-E-04 — popup 강제 close → DISCONNECTED (4900)
+ *
+ * puppeteer의 page.on('popup', ...) 이벤트로 sdk popup의 page handle을 capture 후
+ * popup.close() 호출 → connector의 popup close 감지(500ms polling)가 작동하여
+ * pending send를 ProviderError(DISCONNECTED, 4900)로 reject.
+ */
+const puppeteer = require('puppeteer')
+
+const HARNESS_URL = 'http://localhost:9091/tests/unit/2_v2_e2e/harness.html'
+const SDK_URL = 'http://localhost:5174/'
+
+describe('[v2 e2e] T-E-04 popup close → DISCONNECTED', () => {
+  let browser: any
+  let page: any
+
+  beforeAll(async () => {
+    browser = await puppeteer.launch({
+      headless: 'new',
+      args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-popup-blocking'],
+    })
+    page = await browser.newPage()
+    await page.goto(HARNESS_URL)
+  })
+
+  afterAll(async () => {
+    await browser.close()
+  })
+
+  afterEach(async () => {
+    await page.evaluate(() => (window as any).dcentTest.close())
+  })
+
+  it('T-E-04: popup 강제 close → result.error.code === 4900', async () => {
+    await page.evaluate((url: string) => {
+      ;(window as any).dcentTest.newTransport({ popUpUrl: url })
+    }, SDK_URL)
+
+    // popup capture promise — page.on('popup')은 첫 popup 발생 시 resolve
+    const popupP: Promise<any> = new Promise((resolve) => {
+      page.once('popup', (popup: any) => resolve(popup))
+    })
+
+    // send 시작 (popup 열림 트리거). 응답 받기 전에 popup close 예정 → reject 기대
+    const resultP = page.evaluate(() => {
+      return (window as any).dcentTest.send({
+        id: 'e2e-pc',
+        method: 'getStatus',
+        params: {},
+      })
+    })
+
+    // popup 핸들 확보 후 short delay (popup가 sdk listener load 정도까지) 후 close
+    const popup = await popupP
+    // 100ms wait 이후 close — handshake 진행 도중 강제 종료
+    await new Promise((r) => setTimeout(r, 100))
+    await popup.close()
+
+    const result = await resultP
+    expect(result.ok).toBe(false)
+    expect(result.error.code).toBe(4900)
+  }, 30000)
+})

--- a/tests/unit/2_v2_e2e/05_setTimeoutMs.spec.ts
+++ b/tests/unit/2_v2_e2e/05_setTimeoutMs.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * T-E-05 — setTimeoutMs override → TIMEOUT (5006)
+ *
+ * setTimeoutMs(2000)으로 default 60s를 단축한 뒤
+ * popUpUrl을 listener 없는 빈 페이지(harness :9091/empty.html)로 향하게 하여
+ * 2s 후 ProviderError(TIMEOUT, 5006)로 reject 검증.
+ */
+const puppeteer = require('puppeteer')
+
+const HARNESS_URL = 'http://localhost:9091/tests/unit/2_v2_e2e/harness.html'
+const EMPTY_URL = 'http://localhost:9091/tests/unit/2_v2_e2e/empty.html'
+
+describe('[v2 e2e] T-E-05 setTimeoutMs → TIMEOUT', () => {
+  let browser: any
+  let page: any
+
+  beforeAll(async () => {
+    browser = await puppeteer.launch({
+      headless: 'new',
+      args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-popup-blocking'],
+    })
+    page = await browser.newPage()
+    await page.goto(HARNESS_URL)
+  })
+
+  afterAll(async () => {
+    await browser.close()
+  })
+
+  afterEach(async () => {
+    await page.evaluate(() => (window as any).dcentTest.close())
+  })
+
+  it('T-E-05: setTimeoutMs(2000) + empty.html → 5006 TIMEOUT', async () => {
+    await page.evaluate((url: string) => {
+      ;(window as any).dcentTest.newTransport({ popUpUrl: url })
+      ;(window as any).dcentTest.setTimeoutMs(2000)
+    }, EMPTY_URL)
+
+    const start = Date.now()
+    const result = await page.evaluate(() => {
+      return (window as any).dcentTest.send({ id: 'e2e-to', method: 'getStatus', params: {} })
+    })
+    const elapsed = Date.now() - start
+
+    expect(result.ok).toBe(false)
+    expect(result.error.code).toBe(5006)
+    // 2s 부근 (1.5s ~ 5s 허용 — flake margin)
+    expect(elapsed).toBeGreaterThan(1500)
+    expect(elapsed).toBeLessThan(5000)
+  }, 30000)
+})

--- a/tests/unit/2_v2_e2e/06_origin_validation.spec.ts
+++ b/tests/unit/2_v2_e2e/06_origin_validation.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * T-E-06 — origin mismatch → 브라우저 postMessage targetOrigin 차단 → TIMEOUT
+ *
+ * `newTransport({ origin: 'https://evil.example.com' })`이면 connector가
+ * popupWindow.postMessage(msg, 'https://evil.example.com')으로 송신.
+ * 브라우저가 sdk popup의 실제 origin(:5174)과 불일치를 감지하여 메시지 전달을 거부 →
+ * sdk가 메시지를 받지 못함 → handshake/송신 모두 timeout (5006).
+ *
+ * (정확히는 sdk의 silent drop이 아닌 browser-level postMessage filtering이지만,
+ *  관측 가능한 결과는 동일 — connector 측에서는 응답 부재 → 5006)
+ */
+const puppeteer = require('puppeteer')
+
+const HARNESS_URL = 'http://localhost:9091/tests/unit/2_v2_e2e/harness.html'
+const SDK_URL = 'http://localhost:5174/'
+
+describe('[v2 e2e] T-E-06 origin mismatch → TIMEOUT', () => {
+  let browser: any
+  let page: any
+
+  beforeAll(async () => {
+    browser = await puppeteer.launch({
+      headless: 'new',
+      args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-popup-blocking'],
+    })
+    page = await browser.newPage()
+    await page.goto(HARNESS_URL)
+  })
+
+  afterAll(async () => {
+    await browser.close()
+  })
+
+  afterEach(async () => {
+    await page.evaluate(() => (window as any).dcentTest.close())
+  })
+
+  it('T-E-06: 잘못된 origin → 5006 TIMEOUT', async () => {
+    await page.evaluate((url: string) => {
+      ;(window as any).dcentTest.newTransport({
+        popUpUrl: url,
+        origin: 'https://evil.example.com',
+      })
+      ;(window as any).dcentTest.setTimeoutMs(2000)
+    }, SDK_URL)
+
+    const result = await page.evaluate(() => {
+      return (window as any).dcentTest.send({ id: 'e2e-or', method: 'getStatus', params: {} })
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.error.code).toBe(5006)
+  }, 30000)
+})

--- a/tests/unit/2_v2_e2e/07_envelope_shape.spec.ts
+++ b/tests/unit/2_v2_e2e/07_envelope_shape.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * T-E-07 — invalid envelope shape silent drop (popup wire 경유)
+ *
+ * 정상 send로 handshake 완료 + popup wire 활성 후, puppeteer가 sdk popup page에서
+ * `window.opener.postMessage({ malformed: true }, '*')`로 raw invalid envelope를 inject.
+ * connector listener는 boundary-validation으로 envelope shape 검증 실패 → silent drop.
+ * 후속 정상 send는 영향 없이 완료되어야 함 (listener가 죽지 않음).
+ *
+ * sdk 코드 변경 없음 — puppeteer가 sdk popup page에서 직접 evaluate.
+ */
+const puppeteer = require('puppeteer')
+
+const HARNESS_URL = 'http://localhost:9091/tests/unit/2_v2_e2e/harness.html'
+const SDK_URL = 'http://localhost:5174/'
+
+describe('[v2 e2e] T-E-07 invalid envelope silent drop', () => {
+  let browser: any
+  let page: any
+
+  beforeAll(async () => {
+    browser = await puppeteer.launch({
+      headless: 'new',
+      args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-popup-blocking'],
+    })
+    page = await browser.newPage()
+    await page.goto(HARNESS_URL)
+  })
+
+  afterAll(async () => {
+    await browser.close()
+  })
+
+  afterEach(async () => {
+    await page.evaluate(() => (window as any).dcentTest.close())
+  })
+
+  it('T-E-07: invalid envelope inject → silent drop, 후속 정상 send 회복', async () => {
+    await page.evaluate((url: string) => {
+      ;(window as any).dcentTest.newTransport({ popUpUrl: url })
+    }, SDK_URL)
+
+    // popup capture — preOpenAndWait이 popup 열기 직전에 setup
+    const popupP: Promise<any> = new Promise((resolve) => {
+      page.once('popup', (popup: any) => resolve(popup))
+    })
+    await page.evaluate(() => (window as any).dcentTest.preOpenAndWait())
+
+    // 1) 정상 send 1회 (handshake 완료, popup wire 활성)
+    const r1 = await page.evaluate(() => {
+      return (window as any).dcentTest.send({ id: 'e2e-7a', method: 'getStatus', params: { i: 1 } })
+    })
+    expect(r1.ok).toBe(true)
+
+    // 2) sdk popup page에서 raw invalid envelope inject
+    const popup = await popupP
+    await popup.evaluate(() => {
+      // @ts-ignore - sdk popup 컨텍스트
+      if (window.opener) window.opener.postMessage({ malformed: true, no_id: true }, '*')
+      // @ts-ignore
+      if (window.opener) window.opener.postMessage('plain-string-not-object', '*')
+      // @ts-ignore
+      if (window.opener) window.opener.postMessage({ id: null, result: 'wrong-id-shape' }, '*')
+    })
+
+    // 3) 잠깐 대기 (invalid drop 처리될 시간)
+    await new Promise((r) => setTimeout(r, 200))
+
+    // 4) 후속 정상 send → ok 회복 확인 (listener가 invalid에 죽지 않았음)
+    const r2 = await page.evaluate(() => {
+      return (window as any).dcentTest.send({ id: 'e2e-7b', method: 'getStatus', params: { i: 2 } })
+    })
+    expect(r2.ok).toBe(true)
+    expect(r2.response.id).toBe('e2e-7b')
+    expect(r2.response.result.echo).toBe(true)
+  }, 30000)
+})

--- a/tests/unit/2_v2_e2e/08_handshake_timeout.spec.ts
+++ b/tests/unit/2_v2_e2e/08_handshake_timeout.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * T-E-08 — handshake timeout (listener 부재)
+ *
+ * popUpUrl을 listener 없는 빈 페이지(harness :9091/empty.html)로 향하게 하면
+ * 연결된 popup에서 `_handshake` ack가 오지 않음. setTimeoutMs(3000) 후 ProviderError(TIMEOUT, 5006).
+ *
+ * (T-E-05와 차이: T-E-05는 send timeout 일반, T-E-08은 specifically handshake가 ack 받지 못한 경우)
+ */
+const puppeteer = require('puppeteer')
+
+const HARNESS_URL = 'http://localhost:9091/tests/unit/2_v2_e2e/harness.html'
+const EMPTY_URL = 'http://localhost:9091/tests/unit/2_v2_e2e/empty.html'
+
+describe('[v2 e2e] T-E-08 handshake timeout', () => {
+  let browser: any
+  let page: any
+
+  beforeAll(async () => {
+    browser = await puppeteer.launch({
+      headless: 'new',
+      args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-popup-blocking'],
+    })
+    page = await browser.newPage()
+    await page.goto(HARNESS_URL)
+  })
+
+  afterAll(async () => {
+    await browser.close()
+  })
+
+  afterEach(async () => {
+    await page.evaluate(() => (window as any).dcentTest.close())
+  })
+
+  it('T-E-08: empty.html (listener 없음) + setTimeoutMs(3000) → 5006', async () => {
+    await page.evaluate((url: string) => {
+      ;(window as any).dcentTest.newTransport({ popUpUrl: url })
+      ;(window as any).dcentTest.setTimeoutMs(3000)
+    }, EMPTY_URL)
+
+    const start = Date.now()
+    const result = await page.evaluate(() => {
+      return (window as any).dcentTest.send({ id: 'e2e-hs-to', method: 'getStatus', params: {} })
+    })
+    const elapsed = Date.now() - start
+
+    expect(result.ok).toBe(false)
+    expect(result.error.code).toBe(5006)
+    // 3s 부근 (2.5s ~ 6s 허용)
+    expect(elapsed).toBeGreaterThan(2500)
+    expect(elapsed).toBeLessThan(6000)
+  }, 30000)
+})

--- a/tests/unit/2_v2_e2e/README.md
+++ b/tests/unit/2_v2_e2e/README.md
@@ -1,0 +1,75 @@
+# v2 popup transport round-trip e2e
+
+connector(`dist/v2`) ↔ sdk(로컬 build dist) 양측 통합을 puppeteer e2e로 자동 검증.
+m02-01/02/03 SHIPPED 후 cycle 02 통신 프로토콜 round-trip을 회귀 보호.
+
+## 자동 실행 흐름 (autopilot/CI)
+
+`globalSetup`이 두 정적 server를 직접 launch하므로 사용자가 별도 터미널에서 dev server를 띄울 필요 없음.
+
+```bash
+# 1. sdk vite build 산출물 사전 생성 (workflow yaml에서 자동 실행)
+cd main-repos/dcent-web-sdk
+npm install --legacy-peer-deps --ignore-scripts
+npm run build
+# → main-repos/dcent-web-sdk/dist/index.html 생성
+
+# 2. connector dist/v2 사전 생성
+cd ../dcent-web-connector
+yarn install --frozen-lockfile
+yarn build
+# → dist/v2/dcent-web-connector.min.js 생성
+
+# 3. e2e suite 실행 (globalSetup이 두 server launch + chromium headless)
+yarn unit-v2-e2e
+# → 8/8 spec PASS 기대
+```
+
+## CI workflow
+
+`.github/workflows/e2e.yml` — `workflow_dispatch` (manual trigger) + `self-hosted` runner.
+PR마다 자동 실행은 cycle 03+에서 검토 (현재는 manual trigger).
+
+GitHub Actions UI에서 "v2 e2e" workflow → "Run workflow" 클릭하여 실행.
+
+## dev mode 디버깅 옵션
+
+flaky 재현 또는 시각 디버그 시 sdk dev server를 따로 띄우는 옵션:
+
+```bash
+# 터미널 A
+cd main-repos/dcent-web-sdk && npm run dev   # port 5173 (HMR 활성)
+
+# 터미널 B — globalSetup이 :5174로 launch한 정적 server를 무시하려면 spec의 popUpUrl 변경 필요
+# 일반 디버그는 yarn unit-v2-e2e의 headless: false로 변경하는 것이 더 빠름:
+#   spec 파일에서 puppeteer.launch({headless: false}) 로 수정 후 실행
+```
+
+## 시나리오 매핑
+
+| Spec | T-E-XX | 검증 내용 |
+|---|---|---|
+| `01_handshake.spec.ts` | T-E-01 | handshake 자동 발동 + sdk ack + echo round-trip |
+| `02_version_mismatch.spec.ts` | T-E-02 | 버전 mismatch → ErrorCode 5007 (PROTOCOL_VERSION_MISMATCH) |
+| `03_concurrent_send.spec.ts` | T-E-03 | 동시 3 send → handshake 1회만 (postMessage spy 카운트) |
+| `04_popup_close.spec.ts` | T-E-04 | popup 강제 close → ErrorCode 4900 (DISCONNECTED) |
+| `05_setTimeoutMs.spec.ts` | T-E-05 | setTimeoutMs(2000) + empty.html → 5006 (TIMEOUT) |
+| `06_origin_validation.spec.ts` | T-E-06 | 잘못된 origin → sdk silent drop → 5006 |
+| `07_envelope_shape.spec.ts` | T-E-07 | sdk popup에서 raw invalid postMessage inject → connector silent drop |
+| `08_handshake_timeout.spec.ts` | T-E-08 | empty.html (listener 없음) → 5006 |
+
+## 사전 조건 검증
+
+`globalSetup.js`가 다음을 자동 검증:
+- `main-repos/dcent-web-sdk/dist/index.html` 존재 → 부재 시 명확한 에러로 fail
+- harness server (:9091) + sdk server (:5174) listen 성공
+
+`.github/workflows/e2e.yml` 첫 step (`chromium sanity check`)이 self-hosted runner의 chromium 가용성 검증 (T-E-SETUP-02).
+
+## 비스코프
+
+- 단위 테스트와 중복되는 케이스 전수 cover (m02-01/02/03 jsdom mock 검증분 sample 1-2건만)
+- sdk 측 변경 — sdk는 read-only consumer (m02-03 SHIPPED 결과 그대로)
+- e2e retry 정책 — flakiness 발생 시 cycle 03+에서 도입
+- Playwright 마이그레이션 — jest-puppeteer flakiness 봐서 cycle 03+ 결정
+- production sdk(`https://bridge.dcentwallet.com/v2`) 대상 e2e — cycle 08 prod 배포 후

--- a/tests/unit/2_v2_e2e/empty.html
+++ b/tests/unit/2_v2_e2e/empty.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>empty</title></head>
+<body>
+  <p>listener 없는 빈 페이지 — T-E-08 handshake timeout 시뮬레이션용</p>
+</body>
+</html>

--- a/tests/unit/2_v2_e2e/globalSetup.js
+++ b/tests/unit/2_v2_e2e/globalSetup.js
@@ -1,0 +1,36 @@
+/**
+ * Jest globalSetup — v2 e2e
+ *
+ * 1. sdk vite build 산출물(`main-repos/dcent-web-sdk/dist/index.html`) 사전 fs 검증
+ *    - 부재 시 명확한 에러로 fail (autopilot/CI는 e2e step 직전에 sdk build 자동 실행)
+ * 2. harness server (:9091) + sdk static server (:5174) launch
+ * 3. global에 server 핸들 보관 (globalTeardown이 close)
+ */
+const fs = require('fs')
+const path = require('path')
+const { harnessServer, sdkServer, HARNESS_PORT, SDK_PORT, SDK_DIST_ROOT } = require('./server')
+
+module.exports = async () => {
+  const sdkIndex = path.join(SDK_DIST_ROOT, 'index.html')
+  if (!fs.existsSync(sdkIndex)) {
+    throw new Error(
+      `sdk build output not found at ${sdkIndex} — ` +
+      `run \`cd main-repos/dcent-web-sdk && npm install --legacy-peer-deps --ignore-scripts && npm run build\` first. ` +
+      `(autopilot/CI workflow는 e2e step 직전에 sdk build 자동 실행)`
+    )
+  }
+
+  await new Promise((resolve, reject) => {
+    harnessServer.once('error', reject)
+    harnessServer.listen(HARNESS_PORT, resolve)
+  })
+  await new Promise((resolve, reject) => {
+    sdkServer.once('error', reject)
+    sdkServer.listen(SDK_PORT, resolve)
+  })
+
+  global.__HARNESS_SERVER__ = harnessServer
+  global.__SDK_SERVER__ = sdkServer
+
+  console.log(`[v2-e2e] harness: http://localhost:${HARNESS_PORT}/  sdk: http://localhost:${SDK_PORT}/`)
+}

--- a/tests/unit/2_v2_e2e/globalTeardown.js
+++ b/tests/unit/2_v2_e2e/globalTeardown.js
@@ -1,0 +1,10 @@
+/**
+ * Jest globalTeardown — v2 e2e
+ * harness server + sdk server를 close. 누수 방지.
+ */
+module.exports = async () => {
+  const harnessServer = global.__HARNESS_SERVER__
+  const sdkServer = global.__SDK_SERVER__
+  if (harnessServer) await new Promise(resolve => harnessServer.close(resolve))
+  if (sdkServer) await new Promise(resolve => sdkServer.close(resolve))
+}

--- a/tests/unit/2_v2_e2e/harness.html
+++ b/tests/unit/2_v2_e2e/harness.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>dcent-web-connector v2 e2e harness</title>
+</head>
+<body>
+  <h1>v2 e2e harness</h1>
+  <script src="/dist/v2/dcent-web-connector.min.js"></script>
+  <script>
+    // dist/v2 번들의 libraryTarget: 'this' → window에 PopupTransport / ErrorCode / ProviderError / SerialRequestQueue 노출
+    var PopupTransport = window.PopupTransport
+    var ErrorCode = window.ErrorCode
+
+    // T-E-03 handshake 카운트 spy — connector 측 PopupTransport.sendHandshake (private but runtime accessible)를 wrap
+    // popup 측 postMessage는 cross-origin이라 replace 불가하므로 connector 측에서 카운트
+    var _handshakeCount = 0
+    var _origSendHandshake = null
+    var _transport = null
+
+    function _attachHandshakeSpy(transport) {
+      if (!transport || _origSendHandshake) return
+      _origSendHandshake = transport.sendHandshake.bind(transport)
+      transport.sendHandshake = function () {
+        _handshakeCount++
+        return _origSendHandshake()
+      }
+    }
+
+    /**
+     * sdk popup의 React listener mount 전에 connector handshake가 fire되는 race를 회피.
+     * harness가 popup을 사전 open + load 대기 후 PopupTransport에 주입.
+     *
+     * 단, popup이 cross-origin이면 popup.document/readyState 직접 접근 불가 → load 이벤트 대신
+     * postMessage ping-pong + retry 패턴으로 ready 검증.
+     */
+    function _waitPopupReady(popup, timeoutMs) {
+      var deadline = Date.now() + (timeoutMs || 8000)
+      return new Promise(function (resolve, reject) {
+        function tick() {
+          if (Date.now() > deadline) {
+            return reject(new Error('Popup ready timeout'))
+          }
+          if (!popup || popup.closed) {
+            return reject(new Error('Popup closed'))
+          }
+          // sdk listener는 readyMessage를 ping으로 받지 않음(보낼 메서드 없음).
+          // 대신 단순한 sleep loop: 500ms마다 popup이 살아있는지만 확인하고 일정 시간 대기 후 ready 간주.
+          // sdk vite build 산출물 부팅(~700ms) + React useEffect mount 마진(+300ms) 가정.
+          // _waitPopupReady 호출 시점부터 1200ms sleep — 그 시점에 listener는 거의 확실히 mount됨.
+          setTimeout(resolve, 1200)
+        }
+        tick()
+      })
+    }
+
+    window.dcentTest = {
+      newTransport: function (options) {
+        _transport = new PopupTransport(options || {})
+        _handshakeCount = 0
+        _origSendHandshake = null
+        // newTransport 시점에 spy 미리 부착 — sendHandshake가 호출되기 전에 wrap 보장
+        _attachHandshakeSpy(_transport)
+        return true
+      },
+
+      // popup을 미리 open하고 sdk listener mount까지 대기 후 PopupTransport에 주입.
+      // 정상 round-trip 테스트(T-E-01/02/03/07)는 send 전에 호출해야 함.
+      preOpenAndWait: function () {
+        if (!_transport) return Promise.reject(new Error('Call newTransport first'))
+        // PopupTransport.popUpUrl을 동일 옵션으로 직접 open
+        var url = _transport.popUpUrl
+        var popup = window.open(url, '_blank')
+        if (!popup) return Promise.reject(new Error('window.open returned null'))
+        return _waitPopupReady(popup).then(function () {
+          // PopupTransport 내부 popupWindow 필드에 주입 — TS private은 runtime accessible
+          _transport.popupWindow = popup
+          // popup이 확보되었으므로 즉시 spy 부착 — send가 호출되면 postMessage가 spy를 거침
+          _attachHandshakeSpy(_transport)
+          return true
+        })
+      },
+
+      send: function (message) {
+        var self = this
+        if (!_transport) return Promise.reject(new Error('Call newTransport first'))
+        // send 직전 spy 부착 시도 — 이미 popup이 열려있으면 즉시 부착, 아니면 send가 popup 열고 나서 microtask 후 부착
+        var sendP = _transport.send(message)
+        // popup이 send 내부에서 열림 → 다음 tick에 spy 부착
+        Promise.resolve().then(function () { _attachHandshakeSpy(_transport) })
+        return sendP.then(
+          function (response) { return { ok: true, response: response } },
+          function (err) {
+            return {
+              ok: false,
+              error: { code: err && err.code, message: err && err.message, name: err && err.name },
+            }
+          }
+        )
+      },
+
+      // T-E-03: 동시 N개 send를 호출하면 handshake가 1회만 발동되는지 검증
+      // Promise.all 후 spy 카운트 반환
+      sendConcurrent: function (messages) {
+        var self = this
+        if (!_transport) return Promise.reject(new Error('Call newTransport first'))
+        var promises = messages.map(function (m) { return _transport.send(m) })
+        // 다음 tick에 spy 부착 (popup 생성 후)
+        Promise.resolve().then(function () { _attachHandshakeSpy(_transport) })
+        return Promise.allSettled(promises).then(function (results) {
+          return {
+            handshakeCount: _handshakeCount,
+            results: results.map(function (r) {
+              if (r.status === 'fulfilled') return { ok: true, response: r.value }
+              return { ok: false, error: { code: r.reason && r.reason.code, message: r.reason && r.reason.message } }
+            }),
+          }
+        })
+      },
+
+      setTimeoutMs: function (ms) {
+        if (!_transport) throw new Error('Call newTransport first')
+        try {
+          _transport.setTimeoutMs(ms)
+          return { ok: true }
+        } catch (err) {
+          return { ok: false, error: { code: err.code, message: err.message } }
+        }
+      },
+
+      close: function () {
+        var p = _transport ? _transport.close() : Promise.resolve()
+        return p.then(function () { _transport = null; return true })
+      },
+
+      ErrorCode: ErrorCode,
+    }
+  </script>
+</body>
+</html>

--- a/tests/unit/2_v2_e2e/server.js
+++ b/tests/unit/2_v2_e2e/server.js
@@ -1,0 +1,94 @@
+/**
+ * v2 e2e 정적 server — 두 정적 server를 한 process에서 launch
+ * - harness server (port 9091): connector tests/dist/v2 serve. dApp 가짜 페이지 호스팅.
+ * - sdk static server (port 5174): main-repos/dcent-web-sdk/dist/ serve. m02-03 vite build 산출물.
+ *   sdk SPA fallback 처리(unmatched route → /index.html).
+ *
+ * dev mode HMR 의존을 제거하여 autopilot/CI 무인 실행 가능.
+ * jest.v2-e2e.config.js의 globalSetup이 두 server를 launch.
+ */
+const http = require('http')
+const fs = require('fs')
+const path = require('path')
+
+const CONNECTOR_ROOT = path.resolve(__dirname, '../../..')
+const SDK_DIST_ROOT = path.resolve(CONNECTOR_ROOT, '../dcent-web-sdk/dist')
+
+const HARNESS_PORT = process.env.E2E_HARNESS_PORT || 9091
+const SDK_PORT = process.env.E2E_SDK_PORT || 5174
+
+const MIME = {
+  '.html': 'text/html',
+  '.js': 'application/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+}
+
+function makeStaticServer (rootDir, defaultPath, isSpa) {
+  return http.createServer((req, res) => {
+    const reqUrl = req.url.split('?')[0]
+    const urlPath = reqUrl === '/' ? defaultPath : reqUrl
+    const filePath = path.join(rootDir, urlPath)
+
+    // path traversal 방어 — 정규화 후 root 외부 접근 차단
+    const resolved = path.resolve(filePath)
+    if (!resolved.startsWith(path.resolve(rootDir))) {
+      res.writeHead(403)
+      res.end('Forbidden')
+      return
+    }
+
+    fs.readFile(resolved, (err, data) => {
+      if (err) {
+        if (isSpa) {
+          // SPA fallback — unmatched route → /index.html
+          fs.readFile(path.join(rootDir, '/index.html'), (e2, d2) => {
+            if (e2) {
+              res.writeHead(404)
+              res.end('Not found: ' + urlPath)
+              return
+            }
+            res.writeHead(200, { 'Content-Type': 'text/html' })
+            res.end(d2)
+          })
+        } else {
+          res.writeHead(404)
+          res.end('Not found: ' + urlPath)
+        }
+        return
+      }
+      const ext = path.extname(resolved)
+      const mime = MIME[ext] || 'application/octet-stream'
+      res.writeHead(200, { 'Content-Type': mime })
+      res.end(data)
+    })
+  })
+}
+
+const harnessServer = makeStaticServer(CONNECTOR_ROOT, '/tests/unit/2_v2_e2e/harness.html', false)
+const sdkServer = makeStaticServer(SDK_DIST_ROOT, '/index.html', true)
+
+// 단독 실행 디버깅 — node tests/unit/2_v2_e2e/server.js
+if (require.main === module) {
+  harnessServer.listen(HARNESS_PORT, () => {
+    console.log(`harness server: http://localhost:${HARNESS_PORT}/`)
+  })
+  sdkServer.listen(SDK_PORT, () => {
+    console.log(`sdk server: http://localhost:${SDK_PORT}/`)
+  })
+}
+
+module.exports = {
+  harnessServer,
+  sdkServer,
+  HARNESS_PORT,
+  SDK_PORT,
+  CONNECTOR_ROOT,
+  SDK_DIST_ROOT,
+}


### PR DESCRIPTION
## Summary

cycle 02 통신 프로토콜의 마무리 — connector(`dist/v2`) ↔ sdk(로컬 build dist) 실제 popup 환경에서 puppeteer e2e round-trip 자동 검증. m02-01 PopupTransport, m02-02 handshake, m02-03 sdk PopupListener 통합이 실제 브라우저에서 동작함을 8개 시나리오로 회귀 보호.

**Objective**: `objectives/m02-04-popup-transport-roundtrip-e2e.md` (m02-04, parent workspace `dcent-web-sdk-uap`)
**Jira**: [DC-1875](https://iotrust.atlassian.net/browse/DC-1875) (parent epic [DC-1543](https://iotrust.atlassian.net/browse/DC-1543))

## 선행 SHIPPED (cycle 02 finale 통합 검증)

- [m02-01](https://iotrust.atlassian.net/browse/DC-1851) PR #123 (master @ 9e3de39) — PopupTransport 실제 구현 + ErrorCode.TIMEOUT(5006)/DISCONNECTED(4900)
- [m02-02](https://iotrust.atlassian.net/browse/DC-1867) PR #124 (master @ 6c7114a) — handshake 레이어 + ErrorCode.PROTOCOL_VERSION_MISMATCH(5007)
- [m02-03](https://iotrust.atlassian.net/browse/DC-1871) sdk PR #67 (sdk dev @ e707da9) — sdk PopupListener (m02-02 wire format mirror)

## Changes

### 신규 e2e 인프라 (`tests/unit/2_v2_e2e/`)

- `harness.html` (140) — `window.dcentTest` namespace + sdk listener mount race 회피용 `preOpenAndWait` + `sendHandshake` spy
- `server.js` (94) — Node native http, 두 정적 server를 한 process에서 launch (connector :9091 + sdk dist :5174)
- `globalSetup.js` (36) / `globalTeardown.js` (10) — sdk `dist/index.html` fs.existsSync 사전 검증 + 두 server lifecycle
- `empty.html` (7) — T-E-08 listener 부재 시뮬레이션
- `README.md` (75) — 자동 실행 흐름 + dev mode 디버깅 옵션

### E2E 시나리오 (8 specs, T-E-01~08, 459 LOC)

| Spec | 검증 |
|---|---|
| `01_handshake.spec.ts` | handshake 자동 발동 + sdk ack + echo round-trip |
| `02_version_mismatch.spec.ts` | protocolVersion='99.0' → 5007 (PROTOCOL_VERSION_MISMATCH) |
| `03_concurrent_send.spec.ts` | 동시 3 send → handshake 1회만 (sendHandshake spy 카운트) |
| `04_popup_close.spec.ts` | `page.on('popup')` capture 후 `popup.close()` → 4900 (DISCONNECTED) |
| `05_setTimeoutMs.spec.ts` | setTimeoutMs(2000) + empty.html → 5006 (TIMEOUT) |
| `06_origin_validation.spec.ts` | 잘못된 origin → browser-level postMessage 차단 → 5006 |
| `07_envelope_shape.spec.ts` | sdk popup에서 raw invalid postMessage inject → connector silent drop, 후속 정상 send 회복 |
| `08_handshake_timeout.spec.ts` | empty.html (listener 없음) + setTimeoutMs(3000) → 5006 |

### 보조 인프라

- `jest.v2-e2e.config.js` — jest-puppeteer preset 미사용, testEnvironment node, --runInBand
- `package.json` scripts에 `unit-v2-e2e` 추가 (`version`/`main` 미변경 — `no-version-bump` 룰)
- `.github/workflows/e2e.yml` — `workflow_dispatch` (manual trigger) + self-hosted runner + chromium sanity check (T-E-SETUP-02) + `permissions: contents: read`

## Rationale

- **sdk dev server 의존 제거** — `globalSetup`이 sdk `vite build` 산출물을 :5174로 직접 launch → autopilot/CI 무인 실행 가능
- **listener mount race 회피** — `harness.preOpenAndWait`이 popup을 미리 열고 1.2s 대기 후 PopupTransport.popupWindow에 주입. SHIPPED 코드 변경 없음
- **T-E-07 popup wire 경유** — puppeteer가 sdk popup page에서 raw postMessage inject (sdk 코드 변경 0)
- **PR 크기**: 893 LOC (8 specs 459 + 인프라 434) — `pr-size-exception: infra-setup` (분리 시 spec 동작 불가)

## Tested

자동 검증 명령 7/7 PASS:
- yarn lint ✓
- yarn tsc --noEmit ✓
- yarn build ✓ (dist/v2/dcent-web-connector.min.js)
- yarn unit-v2-e2e ✓ 8/8 PASS (~18s on local)
- yarn unit-v2 ✓ 회귀 0 (69/69)
- yarn unit-mock ✓ 회귀 0 (11 suites/69 tests)
- LOC stat: 893 (pr-size-exception: infra-setup)

T-XX 12/12 PASS, uncovered 0.

자세한 verify 결과: `objectives/.prepare/m02-04-popup-transport-roundtrip-e2e/verification-report.md`

### CI workflow 수동 실행 안내

`.github/workflows/e2e.yml`은 `workflow_dispatch` trigger (PR마다 자동 실행 X). 머지 후 GitHub Actions UI에서 "v2 e2e" workflow → "Run workflow" 클릭하여 self-hosted runner에서 실행. cycle 03+에서 PR 자동 트리거 도입 검토.

## Constraints

- 1 PR = 1 objective (objective-pr-granularity + pr-size-exception: infra-setup)
- package.json의 version/main 미변경 (no-version-bump 룰)
- AI 머지 금지 — 사람이 리뷰 후 머지 (objective-no-auto-merge 룰)

## 후속 (cycle 03+ 별도 objective)

- method registry 통합 (echo dispatcher → registerHandler(method, handler) + token signing)
- capability negotiate (sdk가 지원하는 method 목록을 handshake 응답에 포함)
- Playwright 마이그레이션 (jest-puppeteer flakiness 봐서 결정)
- production sdk 대상 e2e (cycle 08 prod 배포 후)
- PR 자동 트리거 (현재 workflow_dispatch only)