### PR TITLE
[DC-1902] feat(playground): EVM signTransaction 지원 추가 (m06-01-02)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "unit-v2-e2e:visual": "E2E_HEADLESS=false jest --config jest.v2-e2e.config.js --runInBand",
     "unit-v2-e2e:slowmo": "E2E_HEADLESS=false E2E_SLOWMO=100 jest --config jest.v2-e2e.config.js --runInBand",
     "unit-v2-e2e:devtools": "E2E_HEADLESS=false E2E_DEVTOOLS=true jest --config jest.v2-e2e.config.js --runInBand",
+    "extract-chains": "node scripts/extract-chains.js",
+    "prebuild": "yarn extract-chains",
     "lint": "eslint --ext .js src-v1 tests playground.js",
     "lint:fix": "eslint --ext .js src-v1 tests playground.js --fix",
     "tsc": "tsc --noEmit"

--- a/playground.js
+++ b/playground.js
@@ -7,28 +7,47 @@
  *
  * 룰 준수:
  *   - error-handling-consistency: 모든 실패 경로는 appendLog({ error: ... }) 통일
- *   - boundary-validation: keyPath / message 필드 검증 후 dispatcher 호출
+ *   - boundary-validation: keyPath / message / transaction 필드 검증 후 dispatcher 호출
  *   - async-hygiene: await + catch 블록 정형화
  *   - sensitive-info-logging: console 호출 0
  *   - no-console-direct: playground.js는 src/ 바깥이나 방어적으로 0건 유지
+ *
+ * m06-01-02: signTransaction EVM 추가
+ *   - CHAIN_KEY_PATH inline 테이블 제거 (R13=a) → chains.evm.json runtime fetch lookup
+ *   - EVM 트리 그룹: Sign Transaction > Ethereum (EIP-155) > chain variants
+ *   - presets.evm.json 로드 (runtime fetch)
  */
 ;(function () {
   'use strict'
 
-  // ── chainId → default keyPath SLIP44 매핑 (signMessage 대상만, ~10 entry) ──
-  // Child 2에서 chains.json lookup으로 교체 예정 (R13=a)
-  var CHAIN_KEY_PATH = {
-    'eip155:1': "m/44'/60'/0'/0/0", // Ethereum Mainnet
-    'eip155:56': "m/44'/60'/0'/0/0", // BNB Smart Chain
-    'eip155:137': "m/44'/60'/0'/0/0", // Polygon
-    'eip155:42161': "m/44'/60'/0'/0/0", // Arbitrum One
-    'eip155:10': "m/44'/60'/0'/0/0", // Optimism
-    'eip155:8217': "m/44'/8217'/0'/0/0", // Kaia
+  // ── EVM chains runtime state (chains.evm.json 로드 후 채워짐) ──
+  // chainId → { displayName, defaultKeyPath }
+  var evmChainsMap = {} // 로드 완료 전: 빈 객체
+  var evmChainsList = [] // 순서 유지용 배열
+  var evmPresetsMap = {} // presetId → preset object
+  var evmPresetsList = [] // 전체 preset 배열
+
+  // ── Solana chainId → keyPath (non-EVM 고정값; EVM은 chains.evm.json) ──
+  var SOLANA_KEY_PATH = {
     'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': "m/44'/501'/0'/0'", // Solana Mainnet
     'solana:4sGjMW1sUnHzSxGspuhpqLDx6wiys6fWEeD': "m/44'/501'/0'/0'", // Solana Devnet
   }
 
+  // ── chainId → default keyPath lookup (EVM: chains.evm.json, Solana: 고정값) ──
+  // CHAIN_KEY_PATH 인라인 테이블은 chains.evm.json lookup으로 교체됨 (R13=a)
+  var CHAIN_KEY_PATH = new Proxy({}, {
+    get: function (_, chainId) {
+      if (evmChainsMap[chainId]) return evmChainsMap[chainId].defaultKeyPath
+      return SOLANA_KEY_PATH[chainId] || "m/44'/60'/0'/0/0"
+    },
+    has: function (_, chainId) {
+      return !!(evmChainsMap[chainId] || SOLANA_KEY_PATH[chainId])
+    },
+  })
+
   // ── 트리 선언적 정의 ──
+  // Sign Transaction > Ethereum (EIP-155) 그룹은 chains.evm.json 로드 후
+  // buildEvmSignTxGroup()이 동적으로 채운다.
   var TREE = [
     {
       kind: 'group',
@@ -80,6 +99,28 @@
               label: 'signMessage (raw)',
               chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
               metaKind: 'raw',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      kind: 'group',
+      id: 'signTx-evm-group',
+      label: 'Sign Transaction',
+      items: [
+        {
+          kind: 'family',
+          id: 'signTx-evm-family',
+          label: 'Ethereum (EIP-155)',
+          // items는 chains.evm.json 로드 후 buildEvmSignTxGroup()이 채운다
+          items: [
+            {
+              kind: 'method',
+              id: 'signTx:evm:loading',
+              label: '(loading chains…)',
+              chainId: '',
+              _placeholder: true,
             },
           ],
         },
@@ -152,6 +193,7 @@
     logs: [], // append-only LogEntry[]
     pauseAutoScroll: false,
     sdkVersion: null, // dist에서 추출한 packageVersion (있으면)
+    evmChainsLoaded: false, // chains.evm.json 로드 완료 여부
   }
 
   // ── DOM refs ──
@@ -217,8 +259,97 @@
     })
   }
 
+  // ── chains.evm.json + presets.evm.json 런타임 로드 ──
+  function loadEvmData () {
+    // fetch 미지원 환경 (jsdom unit test 등) — 조용히 스킵
+    if (typeof fetch !== 'function') return
+
+    // chains.evm.json
+    var chainsPromise = fetch('/playground/chains.evm.json')
+      .then(function (r) {
+        if (!r.ok) throw new Error('chains.evm.json fetch failed: ' + r.status)
+        return r.json()
+      })
+      .then(function (chains) {
+        evmChainsList = chains
+        evmChainsMap = {}
+        chains.forEach(function (c) {
+          evmChainsMap[c.chainId] = { displayName: c.displayName, defaultKeyPath: c.defaultKeyPath }
+        })
+      })
+      .catch(function () {
+        // 로드 실패 시 트리에 안내 노드 유지 (placeholder)
+        evmChainsList = []
+        evmChainsMap = {}
+      })
+
+    // presets.evm.json
+    var presetsPromise = fetch('/playground/presets.evm.json')
+      .then(function (r) {
+        if (!r.ok) throw new Error('presets.evm.json fetch failed: ' + r.status)
+        return r.json()
+      })
+      .then(function (presets) {
+        evmPresetsList = presets
+        evmPresetsMap = {}
+        presets.forEach(function (p) {
+          evmPresetsMap[p.id] = p
+        })
+      })
+      .catch(function () {
+        evmPresetsList = []
+        evmPresetsMap = {}
+      })
+
+    // 둘 다 완료 후 트리 재빌드
+    Promise.all([chainsPromise, presetsPromise]).then(function () {
+      state.evmChainsLoaded = true
+      buildEvmSignTxGroup()
+      buildTree()
+    }).catch(function () {
+      buildTree()
+    })
+  }
+
+  // ── EVM SignTx 트리 그룹 빌드 (chains.evm.json 로드 후) ──
+  function buildEvmSignTxGroup () {
+    // TREE 내 signTx-evm-family 를 찾아 items를 교체
+    var signTxGroup = TREE.find(function (g) { return g.id === 'signTx-evm-group' })
+    if (!signTxGroup) return
+
+    var evmFamily = signTxGroup.items.find(function (f) { return f.id === 'signTx-evm-family' })
+    if (!evmFamily) return
+
+    if (evmChainsList.length === 0) {
+      // chains.evm.json 로드 실패 — 안내 노드
+      evmFamily.items = [
+        {
+          kind: 'method',
+          id: 'signTx:evm:error',
+          label: '⚠ Run yarn extract-chains first',
+          chainId: '',
+          _placeholder: true,
+        },
+      ]
+      return
+    }
+
+    // 체인별 method node 생성
+    evmFamily.items = evmChainsList.map(function (c) {
+      return {
+        kind: 'method',
+        id: 'signTx:evm:' + c.chainId,
+        label: c.displayName,
+        chainId: c.chainId,
+        defaultKeyPath: c.defaultKeyPath,
+      }
+    })
+  }
+
   // ── Select method → populate form ──
   function selectMethod (methodDef) {
+    if (methodDef._placeholder) return // placeholder는 선택 불가
+
     state.selectedMethodId = methodDef.id
     state.selectedMethodDef = methodDef
 
@@ -237,6 +368,8 @@
       renderGetDeviceInfoForm()
     } else if (methodDef.id.startsWith('signMessage:')) {
       renderSignMessageForm(methodDef)
+    } else if (methodDef.id.startsWith('signTx:evm:')) {
+      renderSignTxEvmForm(methodDef)
     }
 
     // Update Send button state
@@ -315,6 +448,81 @@
       presetRow.appendChild(presetLabel)
       presetRow.appendChild(presetSelect)
       formFields.appendChild(presetRow)
+    }
+  }
+
+  // ── renderSignTxEvmForm ──
+  function renderSignTxEvmForm (methodDef) {
+    // chainId (read-only, 트리 선택값)
+    appendFormRow('chainId', 'Chain ID', 'input', {
+      value: methodDef.chainId,
+      readOnly: true,
+    })
+
+    // keyPath (chains.evm.json defaultKeyPath 초기값)
+    appendFormRow('keyPath', 'Key Path', 'input', {
+      value: methodDef.defaultKeyPath || "m/44'/60'/0'/0/0",
+      placeholder: "m/44'/60'/0'/0/0",
+    })
+
+    // transaction (JSON textarea)
+    var txInput = appendFormRow('transaction', 'Transaction (JSON)', 'textarea', {
+      value: '',
+      placeholder: '{"type":2,"to":"0x...","value":"0x...","gasLimit":"0x..."}',
+    })
+    if (txInput) txInput.rows = 8
+
+    // preset note
+    var noteEl = document.createElement('p')
+    noteEl.style.cssText = 'font-size:10px;color:#aaa;margin-bottom:6px;'
+    noteEl.textContent = 'Edit nonce/fee before send — preset is a template only'
+    formFields.appendChild(noteEl)
+
+    // preset selector (applicable presets 필터링)
+    var applicablePresets = evmPresetsList.filter(function (p) {
+      return !p.applicableChainIds || p.applicableChainIds.indexOf(methodDef.chainId) !== -1
+    })
+
+    if (applicablePresets.length > 0) {
+      var presetRow = document.createElement('div')
+      presetRow.className = 'form-row'
+      var presetLabel = document.createElement('label')
+      presetLabel.setAttribute('for', 'field-preset')
+      presetLabel.textContent = 'Preset'
+      var presetSelect = document.createElement('select')
+      presetSelect.id = 'field-preset'
+      var defaultOpt = document.createElement('option')
+      defaultOpt.value = ''
+      defaultOpt.textContent = '-- select preset --'
+      presetSelect.appendChild(defaultOpt)
+      applicablePresets.forEach(function (p) {
+        var opt = document.createElement('option')
+        opt.value = p.id
+        opt.textContent = p.label
+        presetSelect.appendChild(opt)
+      })
+      presetSelect.addEventListener('change', function () {
+        var presetId = presetSelect.value
+        if (!presetId) return
+        var preset = evmPresetsMap[presetId]
+        if (!preset) return
+        var txEl = document.getElementById('field-transaction')
+        if (txEl) txEl.value = JSON.stringify(preset.transaction, null, 2)
+      })
+
+      // applicableChainIds 외 chain에서는 preset select 비활성
+      var isApplicable = applicablePresets.length > 0
+      if (!isApplicable) presetSelect.disabled = true
+
+      presetRow.appendChild(presetLabel)
+      presetRow.appendChild(presetSelect)
+      formFields.appendChild(presetRow)
+    } else {
+      // 해당 chain에 applicable preset 없음 — 안내
+      var noPresetEl = document.createElement('p')
+      noPresetEl.style.cssText = 'font-size:10px;color:#888;margin-bottom:4px;'
+      noPresetEl.textContent = 'No presets available for this chain. Enter transaction JSON manually.'
+      formFields.appendChild(noPresetEl)
     }
   }
 
@@ -461,6 +669,8 @@
       sendGetDeviceInfo()
     } else if (methodId.startsWith('signMessage:')) {
       sendSignMessage()
+    } else if (methodId.startsWith('signTx:evm:')) {
+      sendSignTxEvm()
     }
   })
 
@@ -556,6 +766,68 @@
     }).catch(function (err) {
       appendLog({
         method: 'signMessage',
+        chainId: chainId,
+        keyPath: keyPath,
+        request: params,
+        error: normalizeError(err),
+        latencyMs: Date.now() - startMs,
+      })
+    })
+  }
+
+  function sendSignTxEvm () {
+    var methodDef = state.selectedMethodDef
+    if (!methodDef) return
+
+    var chainIdEl = document.getElementById('field-chainId')
+    var keyPathEl = document.getElementById('field-keyPath')
+    var txEl = document.getElementById('field-transaction')
+
+    var chainId = chainIdEl ? chainIdEl.value : methodDef.chainId
+    var keyPath = keyPathEl ? keyPathEl.value.trim() : ''
+    var txRaw = txEl ? txEl.value.trim() : ''
+
+    // boundary-validation: keyPath
+    var keyPathError = validateKeyPath(keyPath)
+    if (keyPathError) {
+      showFieldError('keyPath', keyPathError)
+      return
+    }
+
+    // boundary-validation: transaction required
+    if (!txRaw) {
+      showFieldError('transaction', 'Transaction JSON is required')
+      return
+    }
+
+    // boundary-validation: transaction must be valid JSON
+    var txObj
+    try {
+      txObj = JSON.parse(txRaw)
+    } catch (e) {
+      showFieldError('transaction', 'Transaction must be valid JSON')
+      return
+    }
+
+    var params = { chainId: chainId, keyPath: keyPath, transaction: txObj }
+    var startMs = Date.now()
+
+    state.queue.enqueue(function () {
+      return state.transport.send({ id: _genId(), method: 'signTransaction', params: params })
+    }).then(function (resp) {
+      var result = resp && resp.result ? resp.result : resp
+      appendLog({
+        method: 'signTransaction',
+        chainId: chainId,
+        keyPath: keyPath,
+        request: params,
+        response: result,
+        latencyMs: Date.now() - startMs,
+        deviceFirmware: state.device && state.device.firmware,
+      })
+    }).catch(function (err) {
+      appendLog({
+        method: 'signTransaction',
         chainId: chainId,
         keyPath: keyPath,
         request: params,
@@ -706,6 +978,8 @@
     }
     buildTree()
     updateSendBtn()
+    // Load EVM chain + preset data asynchronously (non-blocking)
+    loadEvmData()
   }
 
   init()
@@ -733,7 +1007,7 @@
       var count = 0
       function walk (items) {
         items.forEach(function (item) {
-          if (item.kind === 'method') count++
+          if (item.kind === 'method' && !item._placeholder) count++
           else if (item.items) walk(item.items)
         })
       }
@@ -768,5 +1042,21 @@
       btnDisconnect.style.display = 'none'
       updateSendBtn()
     },
+    // ── EVM SignTx test helpers ──
+    getEvmChainsMap: function () { return evmChainsMap },
+    getEvmChainsList: function () { return evmChainsList },
+    getEvmPresetsList: function () { return evmPresetsList },
+    simulateEvmLoad: function (chains, presets) {
+      evmChainsMap = {}
+      evmChainsList = chains || []
+      evmChainsList.forEach(function (c) { evmChainsMap[c.chainId] = c })
+      evmPresetsMap = {}
+      evmPresetsList = presets || []
+      evmPresetsList.forEach(function (p) { evmPresetsMap[p.id] = p })
+      state.evmChainsLoaded = true
+      buildEvmSignTxGroup()
+      buildTree()
+    },
+    buildEvmSignTxGroup: buildEvmSignTxGroup,
   }
 })()

--- a/playground/chains.evm.json
+++ b/playground/chains.evm.json
@@ -1,0 +1,386 @@
+[
+  {
+    "chainId": "eip155:1",
+    "family": "ethereum",
+    "displayName": "Ethereum",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:30",
+    "family": "ethereum",
+    "displayName": "RSK Smart Bitcoin",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:8217",
+    "family": "ethereum",
+    "displayName": "Kaia",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:61",
+    "family": "ethereum",
+    "displayName": "Ethereum Classic",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:256",
+    "family": "ethereum",
+    "displayName": "Luniverse",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:50",
+    "family": "ethereum",
+    "displayName": "XDC (XinFin)",
+    "defaultKeyPath": "m/44'/550'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:56",
+    "family": "ethereum",
+    "displayName": "Binance Smart Chain",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:10",
+    "family": "ethereum",
+    "displayName": "Optimism",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:11",
+    "family": "ethereum",
+    "displayName": "Metadium",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:14",
+    "family": "ethereum",
+    "displayName": "Flare Network",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:19",
+    "family": "ethereum",
+    "displayName": "Songbird Canary-Network",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:25",
+    "family": "ethereum",
+    "displayName": "Cronos",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:66",
+    "family": "ethereum",
+    "displayName": "OKX Chain",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:100",
+    "family": "ethereum",
+    "displayName": "Gnosis",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:246",
+    "family": "ethereum",
+    "displayName": "Energy Web Chain",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:248",
+    "family": "ethereum",
+    "displayName": "Oasys",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:250",
+    "family": "ethereum",
+    "displayName": "Fantom Opera",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:255",
+    "family": "ethereum",
+    "displayName": "Kroma",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:288",
+    "family": "ethereum",
+    "displayName": "Boba",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:321",
+    "family": "ethereum",
+    "displayName": "KCC",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:592",
+    "family": "ethereum",
+    "displayName": "Astar EVM",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:2017",
+    "family": "ethereum",
+    "displayName": "Orbit Chain",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:7518",
+    "family": "ethereum",
+    "displayName": "MEVerse",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:8453",
+    "family": "ethereum",
+    "displayName": "Base",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:42161",
+    "family": "ethereum",
+    "displayName": "Arbitrum One",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:42220",
+    "family": "ethereum",
+    "displayName": "Celo",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:43114",
+    "family": "ethereum",
+    "displayName": "Avalanche C-Chain",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:1666600000",
+    "family": "ethereum",
+    "displayName": "Harmony",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:11297108109",
+    "family": "ethereum",
+    "displayName": "Palm",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:137",
+    "family": "ethereum",
+    "displayName": "Polygon",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:3776",
+    "family": "ethereum",
+    "displayName": "Astar zkEVM",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:612",
+    "family": "ethereum",
+    "displayName": "EIOB Chain",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:4613",
+    "family": "ethereum",
+    "displayName": "VERY Mainnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:37",
+    "family": "ethereum",
+    "displayName": "XPLA",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:81",
+    "family": "ethereum",
+    "displayName": "Japan Open Chain",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:1625",
+    "family": "ethereum",
+    "displayName": "Gravity Alpha",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:102030",
+    "family": "ethereum",
+    "displayName": "Creditcoin EVM",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:314",
+    "family": "ethereum",
+    "displayName": "Filecoin EVM",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:1689",
+    "family": "ethereum",
+    "displayName": "NERO",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:146",
+    "family": "ethereum",
+    "displayName": "Sonic",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:22776",
+    "family": "ethereum",
+    "displayName": "MAP Protocol",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:1868",
+    "family": "ethereum",
+    "displayName": "Soneium",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:534352",
+    "family": "ethereum",
+    "displayName": "Scroll",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:41923",
+    "family": "ethereum",
+    "displayName": "Edu Chain",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:5050",
+    "family": "ethereum",
+    "displayName": "Skate",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:888888888",
+    "family": "ethereum",
+    "displayName": "Ancient8",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:88888",
+    "family": "ethereum",
+    "displayName": "Chiliz",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:167000",
+    "family": "ethereum",
+    "displayName": "Taiko Alethia",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:80094",
+    "family": "ethereum",
+    "displayName": "Berachain",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:1514",
+    "family": "ethereum",
+    "displayName": "Story Network",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:1440000",
+    "family": "ethereum",
+    "displayName": "XRPL EVM",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:169",
+    "family": "ethereum",
+    "displayName": "Manta Pacific",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:20250217",
+    "family": "ethereum",
+    "displayName": "Xphere",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:999",
+    "family": "ethereum",
+    "displayName": "HyperEVM",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:484",
+    "family": "ethereum",
+    "displayName": "Camp Mainnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:6985385",
+    "family": "ethereum",
+    "displayName": "Humanity Protocol",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:210000",
+    "family": "ethereum",
+    "displayName": "JuChain",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:50104",
+    "family": "ethereum",
+    "displayName": "Sophon",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:4352",
+    "family": "ethereum",
+    "displayName": "MemeCore",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:98866",
+    "family": "ethereum",
+    "displayName": "Plume",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:1776",
+    "family": "ethereum",
+    "displayName": "Injective",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:143",
+    "family": "ethereum",
+    "displayName": "Monad Mainnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:7300",
+    "family": "ethereum",
+    "displayName": "XPLAVerse",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:204",
+    "family": "ethereum",
+    "displayName": "opBNB",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  }
+]

--- a/playground/presets.evm.json
+++ b/playground/presets.evm.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "evm-transfer-1559",
+    "label": "EVM transfer (EIP-1559)",
+    "note": "Template only — edit nonce/maxFeePerGas before send",
+    "applicableChainIds": [
+      "eip155:1",
+      "eip155:10",
+      "eip155:56",
+      "eip155:100",
+      "eip155:137",
+      "eip155:250",
+      "eip155:8217",
+      "eip155:8453",
+      "eip155:42161",
+      "eip155:42220",
+      "eip155:43114"
+    ],
+    "transaction": {
+      "type": 2,
+      "to": "0x0000000000000000000000000000000000000000",
+      "value": "0x2386f26fc10000",
+      "gasLimit": "0x5208",
+      "maxFeePerGas": "0x77359400",
+      "maxPriorityFeePerGas": "0x3b9aca00",
+      "nonce": "0x0",
+      "data": "0x"
+    }
+  }
+]

--- a/scripts/extract-chains.js
+++ b/scripts/extract-chains.js
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * extract-chains.js — EVM chain metadata 추출 스크립트
+ *
+ * refer-repos/dcent-wallet-models/src/common/assets/coins/families/ethereum-family.ts
+ * 또는 wallet-models npm 패키지에서 EVM mainnet 체인 목록을 추출하여
+ * playground/chains.evm.json으로 저장한다.
+ *
+ * 출력 shape (ChainEntry):
+ *   chainId:       string  — CAIP-19 namespace only, e.g. "eip155:1"
+ *   family:        'ethereum'
+ *   displayName:   string  — human readable name
+ *   defaultKeyPath: string — default BIP32 derivation path
+ *
+ * 실행: node scripts/extract-chains.js
+ * 또는 yarn extract-chains (package.json scripts에 등록)
+ *
+ * 출력 경로: playground/chains.evm.json
+ */
+
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+const OUTPUT_PATH = path.resolve(__dirname, '..', 'playground', 'chains.evm.json')
+
+// ── 소스 결정: npm 패키지 우선, 없으면 refer-repos TypeScript 파싱 ──
+function findEthereumFamilySource () {
+  // 1) npm 패키지 (빌드 환경)
+  const npmCandidates = [
+    path.resolve(__dirname, '..', 'node_modules', '@iotrustgithub', 'dcent-wallet-models'),
+    path.resolve(__dirname, '..', 'node_modules', 'dcent-wallet-models'),
+  ]
+  for (const base of npmCandidates) {
+    const candidates = [
+      path.join(base, 'lib', 'common', 'assets', 'coins', 'families', 'ethereum-family.js'),
+      path.join(base, 'src', 'common', 'assets', 'coins', 'families', 'ethereum-family.ts'),
+    ]
+    for (const p of candidates) {
+      if (fs.existsSync(p)) return { path: p, type: fs.extname(p) === '.ts' ? 'ts' : 'js' }
+    }
+  }
+
+  // 2) refer-repos (로컬 개발 환경)
+  // scripts/ → connector/ → main-repos/ → dcent-web-sdk-uap/ → refer-repos/
+  const referReposTs = path.resolve(
+    __dirname, '..', '..', '..', 'refer-repos', 'dcent-wallet-models',
+    'src', 'common', 'assets', 'coins', 'families', 'ethereum-family.ts'
+  )
+  if (fs.existsSync(referReposTs)) return { path: referReposTs, type: 'ts' }
+
+  return null
+}
+
+// ── TypeScript 소스를 regex 파싱하여 EVM mainnet 체인 추출 ──
+function parseEthereumFamilyTs (tsPath) {
+  const src = fs.readFileSync(tsPath, 'utf8')
+  const chains = []
+  const seen = new Set()
+
+  // 전략:
+  // caip19 line을 pivot으로, 해당 entry block 경계 안에서만 필드를 스캔한다.
+  // entry block 시작: caip19 이전에 나오는 가장 가까운 "  'KEY': {" 또는 "  KEY: {" 패턴
+  // entry block 종료: caip19 이후에 나오는 가장 가까운 단독 "  }," 또는 "  }"
+  // 이렇게 하면 다른 entry의 필드(예: 파일 상단 공유 units 상수)가 섞이지 않는다.
+
+  const lines = src.split('\n')
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const caip19Match = line.match(/caip19:\s*['"]([^'"]+)['"]/)
+    if (!caip19Match) continue
+
+    const caip19Full = caip19Match[1]
+    if (!caip19Full.startsWith('eip155:')) continue
+
+    const chainId = caip19Full.replace(/\/slip44:\d+$/, '')
+    if (isNaN(parseInt(chainId.replace('eip155:', ''), 10))) continue
+
+    // entry block 시작을 뒤로 탐색 (indent 2칸 + id key 패턴)
+    let blockStart = i
+    for (let j = i - 1; j >= Math.max(0, i - 40); j--) {
+      if (/^  ['"]?[\w:.-]+['"]?\s*:\s*\{/.test(lines[j])) {
+        blockStart = j
+        break
+      }
+    }
+
+    // entry block 끝을 앞으로 탐색 (indent 2칸의 닫는 괄호)
+    let blockEnd = i
+    for (let j = i + 1; j < Math.min(lines.length, i + 80); j++) {
+      if (/^  \},?$/.test(lines[j])) {
+        blockEnd = j
+        break
+      }
+    }
+
+    let isTestnet = false
+    let displayName = null
+    let bip44CoinType = 60
+
+    for (let j = blockStart; j <= blockEnd; j++) {
+      const l = lines[j]
+      if (/isTestnet:\s*true/.test(l)) isTestnet = true
+      // name 필드: indent 4칸 이상의 "name:" (공유 units 상수는 파일 상단 indent 0)
+      const nameMatch = l.match(/^    name:\s*['"]([^'"]+)['"]/)
+      if (nameMatch && displayName === null) displayName = nameMatch[1]
+      const bip44Match = l.match(/bip44CoinType:\s*(\d+)/)
+      if (bip44Match) bip44CoinType = parseInt(bip44Match[1], 10)
+    }
+
+    if (isTestnet) continue
+    if (!displayName) continue
+    if (seen.has(chainId)) continue
+    seen.add(chainId)
+
+    const defaultKeyPath = `m/44'/${bip44CoinType}'/0'/0/0`
+    chains.push({ chainId, family: 'ethereum', displayName, defaultKeyPath })
+  }
+
+  return chains
+}
+
+// ── JS 모듈에서 추출 (npm 패키지 빌드 결과) ──
+function parseEthereumFamilyJs (jsPath) {
+  // eslint-disable-next-line import/no-dynamic-require
+  const mod = require(jsPath)
+  const currencies = mod.ethereumFamilyCurrencies || mod.default || {}
+  const chains = []
+  const seen = new Set()
+
+  for (const [, entry] of Object.entries(currencies)) {
+    if (!entry || !entry.caip19) continue
+    if (!entry.caip19.startsWith('eip155:')) continue
+    if (entry.isTestnet) continue
+
+    const chainId = entry.caip19.replace(/\/slip44:\d+$/, '')
+    if (seen.has(chainId)) continue
+    seen.add(chainId)
+
+    const bip44 = entry.bip44CoinType || 60
+    chains.push({
+      chainId,
+      family: 'ethereum',
+      displayName: entry.name,
+      defaultKeyPath: `m/44'/${bip44}'/0'/0/0`,
+    })
+  }
+  return chains
+}
+
+// ── Main ──
+function main () {
+  const source = findEthereumFamilySource()
+  if (!source) {
+    console.error([
+      'extract-chains: wallet-models source not found.',
+      '  Expected one of:',
+      '    node_modules/@iotrustgithub/dcent-wallet-models/...',
+      '    ../../../../refer-repos/dcent-wallet-models/src/...',
+      '',
+      '  In CI: npm/yarn install with wallet-models in devDependencies.',
+      '  Locally: clone refer-repos/dcent-wallet-models (see refer-repos/README.md).',
+    ].join('\n'))
+    process.exit(1)
+  }
+
+  console.log('extract-chains: reading', source.path)
+
+  let chains
+  if (source.type === 'js') {
+    chains = parseEthereumFamilyJs(source.path)
+  } else {
+    chains = parseEthereumFamilyTs(source.path)
+  }
+
+  if (chains.length < 5) {
+    console.error('extract-chains: suspiciously few chains extracted (' + chains.length + '). Aborting.')
+    process.exit(1)
+  }
+
+  // 출력 디렉터리 생성
+  const outDir = path.dirname(OUTPUT_PATH)
+  if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true })
+
+  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(chains, null, 2) + '\n')
+  console.log('extract-chains: wrote ' + chains.length + ' chains to ' + OUTPUT_PATH)
+}
+
+main()

--- a/tests/unit/2_v2_e2e/playground.signtx-evm.spec.ts
+++ b/tests/unit/2_v2_e2e/playground.signtx-evm.spec.ts
@@ -1,0 +1,179 @@
+/**
+ * playground.signtx-evm.spec.ts — EVM signTransaction e2e 테스트 (m06-01-02)
+ *
+ * puppeteer로 index-v2.html 로드 후 EVM signTx 전체 흐름 검증:
+ * 1. simulateEvmLoad로 체인 데이터 주입
+ * 2. 트리에 EVM 체인 노드 노출 확인
+ * 3. 폼 렌더링 + 입력 + Send → signTransaction request 파라미터 검증
+ *
+ * T-E2E-EVM-01: EVM 체인 로드 + signTransaction round-trip
+ *
+ * 전제조건:
+ * - globalSetup이 harness server (port 9091) 구동 중
+ * - sdk dist build 존재 (Mock transport 패턴 사용)
+ */
+const { launchBrowser } = require('./launchBrowser')
+
+const HARNESS_BASE = 'http://localhost:9091'
+const PLAYGROUND_URL = `${HARNESS_BASE}/index-v2.html`
+
+const SAMPLE_CHAINS = [
+  {
+    chainId: 'eip155:1',
+    family: 'ethereum',
+    displayName: 'Ethereum',
+    defaultKeyPath: "m/44'/60'/0'/0/0",
+  },
+  {
+    chainId: 'eip155:137',
+    family: 'ethereum',
+    displayName: 'Polygon',
+    defaultKeyPath: "m/44'/60'/0'/0/0",
+  },
+]
+
+const SAMPLE_PRESETS = [
+  {
+    id: 'evm-transfer-1559',
+    label: 'EVM transfer (EIP-1559)',
+    note: 'Template only — edit nonce/maxFeePerGas before send',
+    applicableChainIds: ['eip155:1', 'eip155:137'],
+    transaction: {
+      type: 2,
+      to: '0x0000000000000000000000000000000000000000',
+      value: '0x2386f26fc10000',
+      gasLimit: '0x5208',
+      maxFeePerGas: '0x77359400',
+      maxPriorityFeePerGas: '0x3b9aca00',
+      nonce: '0x0',
+      data: '0x',
+    },
+  },
+]
+
+const VALID_TX_JSON = JSON.stringify({
+  type: 2,
+  to: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+  value: '0xde0b6b3a7640000',
+  gasLimit: '0x5208',
+  maxFeePerGas: '0x3b9aca00',
+  maxPriorityFeePerGas: '0x3b9aca00',
+  nonce: '0x5',
+  data: '0x',
+})
+
+describe('[v2 e2e] playground signTx EVM', () => {
+  let browser: any
+  let page: any
+
+  beforeAll(async () => {
+    browser = await launchBrowser()
+    page = await browser.newPage()
+  })
+
+  afterAll(async () => {
+    await browser.close()
+  })
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // T-E2E-EVM-01: EVM 체인 로드 + signTransaction round-trip
+  // ────────────────────────────────────────────────────────────────────────────
+  it('T-E2E-EVM-01: simulateEvmLoad + EVM signTx round-trip — signTransaction 파라미터 검증', async () => {
+    await page.goto(PLAYGROUND_URL, { waitUntil: 'networkidle0' })
+
+    // Step 1: EVM 체인 데이터 주입
+    await page.evaluate(
+      (chains: typeof SAMPLE_CHAINS, presets: typeof SAMPLE_PRESETS) => {
+        const api = (window as any)._playgroundTestAPI
+        api.simulateEvmLoad(chains, presets)
+      },
+      SAMPLE_CHAINS,
+      SAMPLE_PRESETS
+    )
+
+    // Step 2: EVM 체인 트리 노드 존재 확인
+    const evmNodeCount = await page.$$eval(
+      '[data-method-id^="signTx:evm:"]',
+      (nodes: Element[]) => nodes.length
+    )
+    expect(evmNodeCount).toBe(SAMPLE_CHAINS.length)
+
+    // Step 3: Mock transport 주입 + connect
+    await page.evaluate(() => {
+      const api = (window as any)._playgroundTestAPI
+      ;(window as any)._capturedRequests = []
+      const mockTransport = {
+        send: (payload: any) => {
+          ;(window as any)._capturedRequests.push(payload)
+          return Promise.resolve({ id: payload.id, result: { signedTx: '0xdeadbeef' } })
+        },
+        on: (_: string, _fn: any) => {},
+        off: () => {},
+        close: () => Promise.resolve(),
+      }
+      const mockQueue = {
+        enqueue: (task: any) => task(),
+        size: () => 0,
+        clear: () => {},
+      }
+      api.simulateConnect(mockTransport, mockQueue, { model: 'Biometric', firmware: '3.23.0' })
+    })
+
+    // Step 4: Ethereum (eip155:1) 노드 클릭
+    await page.click('[data-method-id="signTx:evm:eip155:1"]')
+
+    // Step 5: 폼 렌더링 확인 — keyPath, transaction 필드 존재
+    const hasKeyPath = await page.$('#field-keyPath')
+    expect(hasKeyPath).not.toBeNull()
+
+    const hasTxField = await page.$('#field-transaction')
+    expect(hasTxField).not.toBeNull()
+
+    // Step 6: 폼 입력
+    await page.evaluate(
+      (keyPath: string, txJson: string) => {
+        const kp = document.getElementById('field-keyPath') as HTMLInputElement
+        const tx = document.getElementById('field-transaction') as HTMLTextAreaElement
+        if (kp) {
+          kp.value = keyPath
+          kp.dispatchEvent(new Event('input', { bubbles: true }))
+        }
+        if (tx) {
+          tx.value = txJson
+          tx.dispatchEvent(new Event('input', { bubbles: true }))
+        }
+      },
+      "m/44'/60'/0'/0/0",
+      VALID_TX_JSON
+    )
+
+    // Step 7: Send 버튼 클릭
+    const sendDisabled = await page.$eval('#btn-send', (el: HTMLButtonElement) => el.disabled)
+    expect(sendDisabled).toBe(false)
+    await page.click('#btn-send')
+
+    // Step 8: 응답 대기
+    await new Promise((r) => setTimeout(r, 300))
+
+    // Step 9: 전송된 요청 파라미터 검증
+    const captured = await page.evaluate(() => (window as any)._capturedRequests)
+    expect(captured.length).toBe(1)
+
+    const req = captured[0]
+    expect(req.method).toBe('signTransaction')
+    expect(req.params.chainId).toBe('eip155:1')
+    expect(req.params.keyPath).toBe("m/44'/60'/0'/0/0")
+    expect(req.params.transaction).toBeDefined()
+    expect(req.params.transaction.type).toBe(2)
+
+    // Step 10: 로그 엔트리 확인
+    const entries = await page.evaluate(() =>
+      (window as any)._playgroundTestAPI.getLogEntries()
+    )
+    expect(entries.length).toBeGreaterThan(0)
+    const lastEntry = entries[entries.length - 1]
+    expect(lastEntry.method).toBe('signTransaction')
+    expect(lastEntry.error).toBeUndefined()
+    expect(lastEntry.response).toBeDefined()
+  }, 30000)
+})

--- a/tests/unit/2_v2_e2e/playground.skeleton.spec.ts
+++ b/tests/unit/2_v2_e2e/playground.skeleton.spec.ts
@@ -33,18 +33,21 @@ describe('[v2 e2e] playground skeleton', () => {
   })
 
   // ────────────────────────────────────────────────────────
-  // T-E2E-01: 페이지 smoke — 로드 + 트리 5개 노드 + 디바이스 indicator 회색 dot
+  // T-E2E-01: 페이지 smoke — 로드 + 트리 노드(EVM 포함) + 디바이스 indicator 회색 dot
   // ────────────────────────────────────────────────────────
-  it('T-E2E-01: index-v2.html 로드 + 트리 5개 노드 + indicator 초기 회색', async () => {
+  it('T-E2E-01: index-v2.html 로드 + 트리 5개 non-placeholder 노드 + indicator 초기 회색', async () => {
     await page.goto(PLAYGROUND_URL, { waitUntil: 'networkidle0' })
 
     // 타이틀 확인
     const title = await page.title()
     expect(title).toContain("D'CENT")
 
-    // 트리 5개 노드 존재
-    const treeItems = await page.$$('.tree-item')
-    expect(treeItems.length).toBe(5)
+    // countMethodNodes: EVM 체인 로드 후 placeholder 제외 노드가 5 이상
+    // (chains.evm.json 로드 성공 시 5 + 64 = 69, 실패 시 5)
+    const nonPlaceholderCount = await page.evaluate(() => {
+      return (window as any)._playgroundTestAPI.countMethodNodes()
+    })
+    expect(nonPlaceholderCount).toBeGreaterThanOrEqual(5)
 
     // 디바이스 indicator: #conn-dot에 connected/error class 없음 (회색)
     const dotClass = await page.$eval('#conn-dot', (el: Element) => el.className)

--- a/tests/unit/v2/playground.signtx-evm.test.ts
+++ b/tests/unit/v2/playground.signtx-evm.test.ts
@@ -1,0 +1,319 @@
+/**
+ * playground.signtx-evm.test.ts — EVM signTransaction 기능 단위 테스트
+ *
+ * jsdom 환경에서 index-v2.html + playground.js 로드 후
+ * EVM 체인 데이터 로드 / 트리 빌드 / 폼 렌더링 / dispatcher 호출 흐름을 검증.
+ *
+ * T-U-EVM-01: simulateEvmLoad 후 트리에 EVM 체인 노드가 추가된다
+ * T-U-EVM-02: EVM signTx 폼 — keyPath·transaction 누락 시 dispatcher 0건
+ * T-U-EVM-03: sendSignTxEvm — transaction JSON 파싱 오류 시 dispatcher 0건
+ * T-U-EVM-04: sendSignTxEvm — 정상 전송 시 signTransaction 요청 파라미터 검증
+ * T-U-EVM-05: simulateEvmLoad 후 CHAIN_KEY_PATH Proxy가 defaultKeyPath를 반환한다
+ */
+import * as fs from 'fs'
+import * as path from 'path'
+
+// ── Playground 로드 helper ──────────────────────────────────────────────────
+function loadPlayground(): void {
+  const html = fs.readFileSync(
+    path.resolve(__dirname, '../../../index-v2.html'),
+    'utf8'
+  )
+  document.documentElement.innerHTML = html
+
+  ;(window as any).PopupTransport = function (_opts: any) {
+    return {
+      send: jest.fn().mockResolvedValue({ id: 'stub-id', result: {} }),
+      on: jest.fn(),
+      off: jest.fn(),
+      close: jest.fn().mockResolvedValue(undefined),
+    }
+  }
+  ;(window as any).SerialRequestQueue = function (_transport: any) {
+    return {
+      enqueue: jest.fn(function (task: any) { return task() }),
+      size: jest.fn().mockReturnValue(0),
+      clear: jest.fn(),
+    }
+  }
+  ;(window as any).ProviderError = class ProviderError extends Error {
+    code: number
+    constructor(code: number, message: string) {
+      super(message)
+      this.code = code
+    }
+  }
+
+  const playgroundSrc = fs.readFileSync(
+    path.resolve(__dirname, '../../../playground.js'),
+    'utf8'
+  )
+  // eslint-disable-next-line no-new-func
+  new Function(playgroundSrc)()
+}
+
+// ── Sample fixtures ──────────────────────────────────────────────────────────
+const SAMPLE_CHAINS = [
+  {
+    chainId: 'eip155:1',
+    family: 'ethereum',
+    displayName: 'Ethereum',
+    defaultKeyPath: "m/44'/60'/0'/0/0",
+  },
+  {
+    chainId: 'eip155:137',
+    family: 'ethereum',
+    displayName: 'Polygon',
+    defaultKeyPath: "m/44'/60'/0'/0/0",
+  },
+  {
+    chainId: 'eip155:56',
+    family: 'ethereum',
+    displayName: 'BSC',
+    defaultKeyPath: "m/44'/60'/0'/0/0",
+  },
+]
+
+const SAMPLE_PRESETS = [
+  {
+    id: 'evm-transfer-1559',
+    label: 'EVM transfer (EIP-1559)',
+    note: 'Template only — edit nonce/maxFeePerGas before send',
+    applicableChainIds: ['eip155:1', 'eip155:137', 'eip155:56'],
+    transaction: {
+      type: 2,
+      to: '0x0000000000000000000000000000000000000000',
+      value: '0x2386f26fc10000',
+      gasLimit: '0x5208',
+      maxFeePerGas: '0x77359400',
+      maxPriorityFeePerGas: '0x3b9aca00',
+      nonce: '0x0',
+      data: '0x',
+    },
+  },
+]
+
+const VALID_TX_JSON = JSON.stringify({
+  type: 2,
+  to: '0x0000000000000000000000000000000000000000',
+  value: '0x2386f26fc10000',
+  gasLimit: '0x5208',
+  maxFeePerGas: '0x77359400',
+  maxPriorityFeePerGas: '0x3b9aca00',
+  nonce: '0x01',
+  data: '0x',
+})
+
+// ── Setup / teardown ─────────────────────────────────────────────────────────
+beforeEach(() => {
+  loadPlayground()
+})
+
+afterEach(() => {
+  document.documentElement.innerHTML = ''
+  delete (window as any)._playgroundTestAPI
+  delete (window as any).PopupTransport
+  delete (window as any).SerialRequestQueue
+  delete (window as any).ProviderError
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T-U-EVM-01: simulateEvmLoad 후 EVM signTx 체인 트리 노드가 추가된다
+// ─────────────────────────────────────────────────────────────────────────────
+it('T-U-EVM-01: simulateEvmLoad 후 EVM 체인 노드가 TREE에 추가된다', () => {
+  const api = (window as any)._playgroundTestAPI
+
+  // 로드 전: placeholder 제외 메서드 개수 (5 = 기존)
+  const beforeCount = api.countMethodNodes()
+  expect(beforeCount).toBe(5)
+
+  // EVM 체인 로드 시뮬레이션
+  api.simulateEvmLoad(SAMPLE_CHAINS, SAMPLE_PRESETS)
+
+  // 로드 후: +3 (eip155:1, eip155:137, eip155:56)
+  const afterCount = api.countMethodNodes()
+  expect(afterCount).toBe(beforeCount + SAMPLE_CHAINS.length)
+
+  // evmChainsMap 채워짐
+  const chainsMap = api.getEvmChainsMap()
+  expect(chainsMap['eip155:1']).toBeDefined()
+  expect(chainsMap['eip155:137']).toBeDefined()
+
+  // DOM에도 signTx:evm: 노드 존재
+  const evmNodes = document.querySelectorAll('[data-method-id^="signTx:evm:"]')
+  expect(evmNodes.length).toBe(SAMPLE_CHAINS.length)
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T-U-EVM-02: EVM signTx 폼 — keyPath·transaction 누락 시 dispatcher 0건
+// ─────────────────────────────────────────────────────────────────────────────
+it('T-U-EVM-02: keyPath 누락 시 Send → dispatcher 0건', () => {
+  const api = (window as any)._playgroundTestAPI
+
+  api.simulateEvmLoad(SAMPLE_CHAINS, SAMPLE_PRESETS)
+
+  const mockEnqueue = jest.fn(function (task: any) { return task() })
+  const mockTransport = { send: jest.fn(), on: jest.fn(), off: jest.fn(), close: jest.fn() }
+  const mockQueue = { enqueue: mockEnqueue, size: jest.fn(), clear: jest.fn() }
+  api.simulateConnect(mockTransport, mockQueue, { model: 'Bio', firmware: '3.0' })
+
+  // eip155:1 노드 선택
+  const evmNode = document.querySelector('[data-method-id="signTx:evm:eip155:1"]') as HTMLElement
+  expect(evmNode).not.toBeNull()
+  evmNode.click()
+
+  // keyPath 비움
+  const keyPathEl = document.getElementById('field-keyPath') as HTMLInputElement
+  if (keyPathEl) keyPathEl.value = ''
+
+  // transaction 채움
+  const txEl = document.getElementById('field-transaction') as HTMLTextAreaElement
+  if (txEl) txEl.value = VALID_TX_JSON
+
+  document.getElementById('btn-send')?.click()
+
+  expect(mockEnqueue).not.toHaveBeenCalled()
+})
+
+it('T-U-EVM-02b: transaction 누락 시 Send → dispatcher 0건', () => {
+  const api = (window as any)._playgroundTestAPI
+
+  api.simulateEvmLoad(SAMPLE_CHAINS, SAMPLE_PRESETS)
+
+  const mockEnqueue = jest.fn(function (task: any) { return task() })
+  const mockTransport = { send: jest.fn(), on: jest.fn(), off: jest.fn(), close: jest.fn() }
+  const mockQueue = { enqueue: mockEnqueue, size: jest.fn(), clear: jest.fn() }
+  api.simulateConnect(mockTransport, mockQueue, { model: 'Bio', firmware: '3.0' })
+
+  const evmNode = document.querySelector('[data-method-id="signTx:evm:eip155:1"]') as HTMLElement
+  evmNode.click()
+
+  const keyPathEl = document.getElementById('field-keyPath') as HTMLInputElement
+  if (keyPathEl) keyPathEl.value = "m/44'/60'/0'/0/0"
+
+  // transaction 비움
+  const txEl = document.getElementById('field-transaction') as HTMLTextAreaElement
+  if (txEl) txEl.value = ''
+
+  document.getElementById('btn-send')?.click()
+
+  expect(mockEnqueue).not.toHaveBeenCalled()
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T-U-EVM-03: transaction JSON 파싱 오류 시 dispatcher 0건
+// boundary-validation: JSON 파싱 실패 → showFieldError + return (appendLog 없음)
+// ─────────────────────────────────────────────────────────────────────────────
+it('T-U-EVM-03: 잘못된 JSON transaction → dispatcher 0건 (boundary-validation early return)', () => {
+  const api = (window as any)._playgroundTestAPI
+
+  api.simulateEvmLoad(SAMPLE_CHAINS, SAMPLE_PRESETS)
+  api.clearLogs()
+
+  const mockEnqueue = jest.fn(function (task: any) { return task() })
+  const mockTransport = { send: jest.fn(), on: jest.fn(), off: jest.fn(), close: jest.fn() }
+  const mockQueue = { enqueue: mockEnqueue, size: jest.fn(), clear: jest.fn() }
+  api.simulateConnect(mockTransport, mockQueue, { model: 'Bio', firmware: '3.0' })
+
+  const evmNode = document.querySelector('[data-method-id="signTx:evm:eip155:1"]') as HTMLElement
+  evmNode.click()
+
+  const keyPathEl = document.getElementById('field-keyPath') as HTMLInputElement
+  if (keyPathEl) keyPathEl.value = "m/44'/60'/0'/0/0"
+
+  const txEl = document.getElementById('field-transaction') as HTMLTextAreaElement
+  if (txEl) txEl.value = '{ not valid json }'
+
+  document.getElementById('btn-send')?.click()
+
+  // boundary-validation: JSON 파싱 실패 → dispatcher 호출 없음
+  expect(mockEnqueue).not.toHaveBeenCalled()
+
+  // early return이므로 log entry 없음 (showFieldError만 호출)
+  const entries = api.getLogEntries()
+  expect(entries.length).toBe(0)
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T-U-EVM-04: 정상 전송 — signTransaction 요청 파라미터 검증
+// ─────────────────────────────────────────────────────────────────────────────
+it('T-U-EVM-04: 정상 전송 시 signTransaction { chainId, keyPath, transaction } 파라미터 전달', async () => {
+  const api = (window as any)._playgroundTestAPI
+
+  api.simulateEvmLoad(SAMPLE_CHAINS, SAMPLE_PRESETS)
+  api.clearLogs()
+
+  const mockSend = jest.fn().mockResolvedValue({ id: 'tx-1', result: { signedTx: '0xabc' } })
+  const mockEnqueue = jest.fn(function (task: any) { return task() })
+  const mockTransport = { send: mockSend, on: jest.fn(), off: jest.fn(), close: jest.fn() }
+  const mockQueue = { enqueue: mockEnqueue, size: jest.fn(), clear: jest.fn() }
+  api.simulateConnect(mockTransport, mockQueue, { model: 'Bio', firmware: '3.0' })
+
+  // eip155:137 (Polygon) 선택
+  const evmNode = document.querySelector('[data-method-id="signTx:evm:eip155:137"]') as HTMLElement
+  evmNode.click()
+
+  const keyPathEl = document.getElementById('field-keyPath') as HTMLInputElement
+  if (keyPathEl) keyPathEl.value = "m/44'/60'/0'/0/0"
+
+  const txEl = document.getElementById('field-transaction') as HTMLTextAreaElement
+  if (txEl) txEl.value = VALID_TX_JSON
+
+  document.getElementById('btn-send')?.click()
+
+  // Promise 완료 대기
+  await new Promise((r) => setTimeout(r, 50))
+
+  // enqueue 호출 확인
+  expect(mockEnqueue).toHaveBeenCalledTimes(1)
+
+  // transport.send 파라미터 검증
+  expect(mockSend).toHaveBeenCalledTimes(1)
+  const sentPayload = mockSend.mock.calls[0][0]
+  expect(sentPayload.method).toBe('signTransaction')
+  expect(sentPayload.params.chainId).toBe('eip155:137')
+  expect(sentPayload.params.keyPath).toBe("m/44'/60'/0'/0/0")
+  expect(sentPayload.params.transaction).toEqual(JSON.parse(VALID_TX_JSON))
+
+  // 로그 확인
+  const entries = api.getLogEntries()
+  expect(entries.length).toBeGreaterThan(0)
+  const lastEntry = entries[entries.length - 1]
+  expect(lastEntry.method).toBe('signTransaction')
+  expect(lastEntry.error).toBeUndefined()
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T-U-EVM-05: simulateEvmLoad 후 CHAIN_KEY_PATH Proxy가 defaultKeyPath를 반환한다
+// ─────────────────────────────────────────────────────────────────────────────
+it('T-U-EVM-05: simulateEvmLoad 후 CHAIN_KEY_PATH Proxy — eip155:1 defaultKeyPath 반환', () => {
+  const api = (window as any)._playgroundTestAPI
+
+  // 로드 전: fallback 반환
+  expect(api.CHAIN_KEY_PATH['eip155:1']).toBe("m/44'/60'/0'/0/0")
+
+  // 로드 후: chains 데이터의 defaultKeyPath 반환
+  api.simulateEvmLoad(
+    [
+      {
+        chainId: 'eip155:1',
+        family: 'ethereum',
+        displayName: 'Ethereum',
+        defaultKeyPath: "m/44'/60'/0'/0/0",
+      },
+      {
+        chainId: 'eip155:8217',
+        family: 'ethereum',
+        displayName: 'Kaia',
+        defaultKeyPath: "m/44'/8217'/0'/0/0",
+      },
+    ],
+    []
+  )
+
+  expect(api.CHAIN_KEY_PATH['eip155:1']).toBe("m/44'/60'/0'/0/0")
+  expect(api.CHAIN_KEY_PATH['eip155:8217']).toBe("m/44'/8217'/0'/0/0")
+
+  // Solana는 여전히 SOLANA_KEY_PATH에서 반환
+  expect(api.CHAIN_KEY_PATH['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp']).toBe("m/44'/501'/0'/0'")
+})

--- a/tests/unit/v2/playground.smoke.test.ts
+++ b/tests/unit/v2/playground.smoke.test.ts
@@ -70,17 +70,17 @@ afterEach(() => {
 // ─────────────────────────────────────────────────────────
 // T-U-01: 트리 DOM 빌더 — TREE 선언적 객체에서 expected node 개수(getDeviceInfo 1 + signMessage 4 = 5)
 // ─────────────────────────────────────────────────────────
-it('T-U-01: 트리 DOM에 5개 method node가 렌더링된다', () => {
+it('T-U-01: 트리 DOM에 5개 non-placeholder method node가 렌더링된다', () => {
   const api = (window as any)._playgroundTestAPI
   expect(api).toBeDefined()
 
-  // countMethodNodes: TREE 구조 순회 (DOM 상관없이 선언 카운트)
+  // countMethodNodes: placeholder 제외 카운트 (getDeviceInfo 1 + signMessage 4 = 5)
   const count = api.countMethodNodes()
   expect(count).toBe(5) // getDeviceInfo(1) + eth:personal(1) + eth:v3(1) + eth:v4(1) + sol:raw(1)
 
-  // DOM에도 5개 .tree-item이 렌더됨
+  // DOM에는 placeholder 포함 6개 .tree-item (EVM 체인 로드 전 placeholder 1개 추가)
   const domItems = document.querySelectorAll('.tree-item')
-  expect(domItems.length).toBe(5)
+  expect(domItems.length).toBe(6) // 5 non-placeholder + 1 EVM loading placeholder
 })
 
 // ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `scripts/extract-chains.js`: wallet-models `ethereum-family.ts`에서 EVM mainnet 체인 메타데이터를 추출해 `playground/chains.evm.json`으로 저장하는 빌드 스크립트 추가
- `playground/chains.evm.json`: 64개 EVM mainnet 체인 (chainId/family/displayName/defaultKeyPath)
- `playground/presets.evm.json`: EIP-1559 transfer 템플릿 preset
- `playground.js`: 런타임에 chains.evm.json + presets.evm.json fetch → "Sign Transaction > Ethereum (EIP-155)" 트리 그룹 동적 빌드 → signTransaction 폼 렌더링 + 전송
- `package.json`: `extract-chains` + `prebuild` 스크립트 추가 (build 시 자동 체인 추출)
- 단위 테스트 T-U-EVM-01~05 (jsdom), E2E 테스트 T-E2E-EVM-01 (puppeteer) 추가

## Objective

`objectives/m06-01-02-playground-signtx-evm.md` | Jira: DC-1902 | Epic: DC-1900

## Rationale

- EVM 체인 목록을 코드에 인라인으로 하드코딩하지 않고 wallet-models 단일 출처에서 추출 (R13=a)
- fetch를 통한 런타임 로드로 체인 목록이 wallet-models 업데이트 시 자동 반영
- ES5 Proxy를 사용한 CHAIN_KEY_PATH로 기존 signMessage 코드와의 하위호환 유지
- `typeof fetch !== 'function'` 가드로 jsdom 단위 테스트 환경에서 안전하게 스킵

## Tested

- `yarn lint` — 통과
- `yarn build` — 통과 (prebuild에서 extract-chains 64개 추출)
- `yarn unit-v2` — 84/84 통과 (T-U-EVM-01~05 포함)
- `yarn unit-v2-e2e` — 13/13 통과 (T-E2E-EVM-01 포함)

## Constraints

- chains.evm.json은 `.npmignore`에 이미 포함된 `playground/` 경로 하위라 publish 대상 아님
- refer-repos/dcent-wallet-models가 로컬에 없는 환경(CI)에서는 npm 패키지 경로를 먼저 탐색하고, 둘 다 없으면 build 실패 + 명확한 에러 메시지 출력