### PR TITLE
[DC-1904] feat(playground): signTransaction 비-EVM 6종 family 확장 (m06-01-03)

### DIFF
--- a/playground.js
+++ b/playground.js
@@ -16,32 +16,64 @@
  *   - CHAIN_KEY_PATH inline 테이블 제거 (R13=a) → chains.evm.json runtime fetch lookup
  *   - EVM 트리 그룹: Sign Transaction > Ethereum (EIP-155) > chain variants
  *   - presets.evm.json 로드 (runtime fetch)
+ *
+ * m06-01-03: signTransaction 비-EVM 6 family 추가
+ *   - chains.evm.json → chains.json 통합 (EVM + Bitcoin/Solana/XRP/Hedera/Stellar/Tron)
+ *   - FAMILY_LABELS: family → 표시명 매핑
+ *   - NON_EVM_FAMILIES: 비-EVM family ID 배열 (트리 그룹 동적 생성)
+ *   - loadChainsData(): chains.json + presets.evm.json + presets.non-evm.json 통합 로드
+ *   - buildNonEvmSignTxGroup(): 비-EVM family별 트리 그룹 동적 빌드
+ *   - sendSignTxNonEvm(): 비-EVM signTransaction dispatcher
  */
 ;(function () {
   'use strict'
 
-  // ── EVM chains runtime state (chains.evm.json 로드 후 채워짐) ──
-  // chainId → { displayName, defaultKeyPath }
+  // ── EVM chains runtime state (chains.json 로드 후 채워짐) ──
+  // chainId → { displayName, defaultKeyPath, family }
   var evmChainsMap = {} // 로드 완료 전: 빈 객체
   var evmChainsList = [] // 순서 유지용 배열
   var evmPresetsMap = {} // presetId → preset object
-  var evmPresetsList = [] // 전체 preset 배열
+  var evmPresetsList = [] // 전체 EVM preset 배열
 
-  // ── Solana chainId → keyPath (non-EVM 고정값; EVM은 chains.evm.json) ──
-  var SOLANA_KEY_PATH = {
-    'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp': "m/44'/501'/0'/0'", // Solana Mainnet
-    'solana:4sGjMW1sUnHzSxGspuhpqLDx6wiys6fWEeD': "m/44'/501'/0'/0'", // Solana Devnet
+  // ── 비-EVM chains runtime state (chains.json 로드 후 채워짐) ──
+  // family → ChainEntry[]
+  var nonEvmChainsByFamily = {} // e.g. { bitcoin: [...], solana: [...] }
+  // chainId → ChainEntry (전체 lookup용)
+  var allChainsMap = {} // m06-01-03: EVM + non-EVM 통합 map
+  // 비-EVM preset
+  var nonEvmPresetsMap = {} // presetId → preset object
+  var nonEvmPresetsList = [] // 전체 비-EVM preset 배열
+
+  // ── FAMILY_LABELS: family → 트리 표시명 ──
+  // m06-01-03 추가
+  var FAMILY_LABELS = {
+    ethereum: 'Ethereum (EIP-155)',
+    bitcoin: 'Bitcoin',
+    solana: 'Solana',
+    xrp: 'XRP Ledger',
+    hedera: 'Hedera',
+    stellar: 'Stellar',
+    tron: 'Tron',
   }
 
-  // ── chainId → default keyPath lookup (EVM: chains.evm.json, Solana: 고정값) ──
-  // CHAIN_KEY_PATH 인라인 테이블은 chains.evm.json lookup으로 교체됨 (R13=a)
+  // ── NON_EVM_FAMILIES: 비-EVM family 목록 (트리 그룹 생성 순서) ──
+  // m06-01-03 추가
+  var NON_EVM_FAMILIES = ['bitcoin', 'solana', 'xrp', 'hedera', 'stellar', 'tron']
+
+  // ── chainId → default keyPath lookup (chains.json runtime data) ──
+  // m06-01-03: allChainsMap으로 통합 (EVM + 비-EVM)
+  // CHAIN_KEY_PATH Proxy: chains.json 로드 전에도 안전하게 접근 가능
   var CHAIN_KEY_PATH = new Proxy({}, {
     get: function (_, chainId) {
-      if (evmChainsMap[chainId]) return evmChainsMap[chainId].defaultKeyPath
-      return SOLANA_KEY_PATH[chainId] || "m/44'/60'/0'/0/0"
+      if (allChainsMap[chainId]) return allChainsMap[chainId].defaultKeyPath
+      // EVM fallback
+      if (chainId && chainId.startsWith('eip155:')) return "m/44'/60'/0'/0/0"
+      // Solana fallback
+      if (chainId && chainId.startsWith('solana:')) return "m/44'/501'/0'"
+      return "m/44'/60'/0'/0/0"
     },
     has: function (_, chainId) {
-      return !!(evmChainsMap[chainId] || SOLANA_KEY_PATH[chainId])
+      return !!allChainsMap[chainId]
     },
   })
 
@@ -113,7 +145,7 @@
           kind: 'family',
           id: 'signTx-evm-family',
           label: 'Ethereum (EIP-155)',
-          // items는 chains.evm.json 로드 후 buildEvmSignTxGroup()이 채운다
+          // items는 chains.json 로드 후 buildEvmSignTxGroup()이 채운다
           items: [
             {
               kind: 'method',
@@ -124,6 +156,8 @@
             },
           ],
         },
+        // m06-01-03: 비-EVM family 그룹은 buildNonEvmSignTxGroups()이 동적으로 추가한다
+        // (NON_EVM_FAMILIES 배열 순서: bitcoin, solana, xrp, hedera, stellar, tron)
       ],
     },
   ]
@@ -193,7 +227,8 @@
     logs: [], // append-only LogEntry[]
     pauseAutoScroll: false,
     sdkVersion: null, // dist에서 추출한 packageVersion (있으면)
-    evmChainsLoaded: false, // chains.evm.json 로드 완료 여부
+    evmChainsLoaded: false, // chains.json 로드 완료 여부 (EVM + 비-EVM 통합)
+    nonEvmChainsLoaded: false, // 비-EVM chains/presets 로드 완료 여부 (m06-01-03)
   }
 
   // ── DOM refs ──
@@ -259,32 +294,49 @@
     })
   }
 
-  // ── chains.evm.json + presets.evm.json 런타임 로드 ──
-  function loadEvmData () {
+  // ── chains.json + presets.evm.json + presets.non-evm.json 런타임 로드 ──
+  // m06-01-03: chains.evm.json → chains.json 통합 (EVM + 비-EVM)
+  function loadChainsData () {
     // fetch 미지원 환경 (jsdom unit test 등) — 조용히 스킵
     if (typeof fetch !== 'function') return
 
-    // chains.evm.json
-    var chainsPromise = fetch('/playground/chains.evm.json')
+    // chains.json (통합 — EVM + 비-EVM)
+    var chainsPromise = fetch('/playground/chains.json')
       .then(function (r) {
-        if (!r.ok) throw new Error('chains.evm.json fetch failed: ' + r.status)
+        if (!r.ok) throw new Error('chains.json fetch failed: ' + r.status)
         return r.json()
       })
       .then(function (chains) {
-        evmChainsList = chains
+        // allChainsMap: 전체 chainId → entry 통합 lookup
+        allChainsMap = {}
+        chains.forEach(function (c) { allChainsMap[c.chainId] = c })
+
+        // EVM 분류
+        var evmChains = chains.filter(function (c) { return c.family === 'ethereum' })
+        evmChainsList = evmChains
         evmChainsMap = {}
-        chains.forEach(function (c) {
+        evmChains.forEach(function (c) {
           evmChainsMap[c.chainId] = { displayName: c.displayName, defaultKeyPath: c.defaultKeyPath }
+        })
+
+        // 비-EVM 분류: family별 그룹핑
+        nonEvmChainsByFamily = {}
+        NON_EVM_FAMILIES.forEach(function (fam) { nonEvmChainsByFamily[fam] = [] })
+        chains.forEach(function (c) {
+          if (c.family !== 'ethereum' && nonEvmChainsByFamily[c.family]) {
+            nonEvmChainsByFamily[c.family].push(c)
+          }
         })
       })
       .catch(function () {
-        // 로드 실패 시 트리에 안내 노드 유지 (placeholder)
         evmChainsList = []
         evmChainsMap = {}
+        allChainsMap = {}
+        nonEvmChainsByFamily = {}
       })
 
     // presets.evm.json
-    var presetsPromise = fetch('/playground/presets.evm.json')
+    var evmPresetsPromise = fetch('/playground/presets.evm.json')
       .then(function (r) {
         if (!r.ok) throw new Error('presets.evm.json fetch failed: ' + r.status)
         return r.json()
@@ -292,19 +344,34 @@
       .then(function (presets) {
         evmPresetsList = presets
         evmPresetsMap = {}
-        presets.forEach(function (p) {
-          evmPresetsMap[p.id] = p
-        })
+        presets.forEach(function (p) { evmPresetsMap[p.id] = p })
       })
       .catch(function () {
         evmPresetsList = []
         evmPresetsMap = {}
       })
 
-    // 둘 다 완료 후 트리 재빌드
-    Promise.all([chainsPromise, presetsPromise]).then(function () {
+    // presets.non-evm.json
+    var nonEvmPresetsPromise = fetch('/playground/presets.non-evm.json')
+      .then(function (r) {
+        if (!r.ok) throw new Error('presets.non-evm.json fetch failed: ' + r.status)
+        return r.json()
+      })
+      .then(function (presets) {
+        nonEvmPresetsList = presets
+        nonEvmPresetsMap = {}
+        presets.forEach(function (p) { nonEvmPresetsMap[p.id] = p })
+      })
+      .catch(function () {
+        nonEvmPresetsList = []
+        nonEvmPresetsMap = {}
+      })
+
+    // 셋 다 완료 후 트리 재빌드
+    Promise.all([chainsPromise, evmPresetsPromise, nonEvmPresetsPromise]).then(function () {
       state.evmChainsLoaded = true
       buildEvmSignTxGroup()
+      buildNonEvmSignTxGroups()
       buildTree()
     }).catch(function () {
       buildTree()
@@ -346,6 +413,56 @@
     })
   }
 
+  // ── 비-EVM SignTx 트리 그룹 빌드 (chains.json 로드 후) ──
+  // m06-01-03: NON_EVM_FAMILIES 배열 순서대로 Sign Transaction 그룹에 family 추가
+  function buildNonEvmSignTxGroups () {
+    var signTxGroup = TREE.find(function (g) { return g.id === 'signTx-evm-group' })
+    if (!signTxGroup) return
+
+    // 기존 비-EVM family 항목 제거 (재빌드)
+    signTxGroup.items = signTxGroup.items.filter(function (f) {
+      return f.id === 'signTx-evm-family'
+    })
+
+    NON_EVM_FAMILIES.forEach(function (family) {
+      var familyLabel = FAMILY_LABELS[family] || family
+      var familyId = 'signTx-' + family + '-family'
+      var chains = nonEvmChainsByFamily[family] || []
+
+      var familyItems
+      if (chains.length === 0) {
+        familyItems = [
+          {
+            kind: 'method',
+            id: 'signTx:' + family + ':error',
+            label: '⚠ Run yarn extract-chains first',
+            chainId: '',
+            family: family,
+            _placeholder: true,
+          },
+        ]
+      } else {
+        familyItems = chains.map(function (c) {
+          return {
+            kind: 'method',
+            id: 'signTx:' + family + ':' + c.chainId,
+            label: c.displayName,
+            chainId: c.chainId,
+            family: family,
+            defaultKeyPath: c.defaultKeyPath,
+          }
+        })
+      }
+
+      signTxGroup.items.push({
+        kind: 'family',
+        id: familyId,
+        label: familyLabel,
+        items: familyItems,
+      })
+    })
+  }
+
   // ── Select method → populate form ──
   function selectMethod (methodDef) {
     if (methodDef._placeholder) return // placeholder는 선택 불가
@@ -370,6 +487,9 @@
       renderSignMessageForm(methodDef)
     } else if (methodDef.id.startsWith('signTx:evm:')) {
       renderSignTxEvmForm(methodDef)
+    } else if (methodDef.family && NON_EVM_FAMILIES.indexOf(methodDef.family) !== -1) {
+      // m06-01-03: 비-EVM signTx — family 공용 폼
+      renderSignTxNonEvmForm(methodDef)
     }
 
     // Update Send button state
@@ -526,6 +646,86 @@
     }
   }
 
+  // ── renderSignTxNonEvmForm (m06-01-03) ──
+  // 비-EVM family 공용 폼: chainId(read-only) + keyPath + transaction(JSON) + preset selector
+  function renderSignTxNonEvmForm (methodDef) {
+    // chainId (read-only)
+    appendFormRow('chainId', 'Chain ID', 'input', {
+      value: methodDef.chainId,
+      readOnly: true,
+    })
+
+    // keyPath (chains.json defaultKeyPath 초기값)
+    appendFormRow('keyPath', 'Key Path', 'input', {
+      value: methodDef.defaultKeyPath || CHAIN_KEY_PATH[methodDef.chainId] || "m/44'/60'/0'/0/0",
+      placeholder: "m/44'/60'/0'/0/0",
+    })
+
+    // transaction (JSON textarea)
+    var txInput = appendFormRow('transaction', 'Transaction (JSON)', 'textarea', {
+      value: '',
+      placeholder: '{"type":"Payment","Account":"r...","Destination":"r..."}',
+    })
+    if (txInput) txInput.rows = 10
+
+    // preset note
+    var noteEl = document.createElement('p')
+    noteEl.style.cssText = 'font-size:10px;color:#aaa;margin-bottom:6px;'
+    noteEl.textContent = 'Edit addresses/amounts before send — preset is a template only'
+    formFields.appendChild(noteEl)
+
+    // preset selector: family 또는 chainId 기준 필터링
+    var applicablePresets = nonEvmPresetsList.filter(function (p) {
+      if (p.applicableChainIds && p.applicableChainIds.length > 0) {
+        return p.applicableChainIds.indexOf(methodDef.chainId) !== -1
+      }
+      return p.family === methodDef.family
+    })
+
+    if (applicablePresets.length > 0) {
+      var presetRow = document.createElement('div')
+      presetRow.className = 'form-row'
+      var presetLabel = document.createElement('label')
+      presetLabel.setAttribute('for', 'field-preset')
+      presetLabel.textContent = 'Preset'
+      var presetSelect = document.createElement('select')
+      presetSelect.id = 'field-preset'
+      var defaultOpt = document.createElement('option')
+      defaultOpt.value = ''
+      defaultOpt.textContent = '-- select preset --'
+      presetSelect.appendChild(defaultOpt)
+      applicablePresets.forEach(function (p) {
+        var opt = document.createElement('option')
+        opt.value = p.id
+        opt.textContent = p.label
+        presetSelect.appendChild(opt)
+      })
+      presetSelect.addEventListener('change', function () {
+        var presetId = presetSelect.value
+        if (!presetId) return
+        var preset = nonEvmPresetsMap[presetId]
+        if (!preset) return
+        var txEl = document.getElementById('field-transaction')
+        if (txEl) txEl.value = JSON.stringify(preset.transaction, null, 2)
+      })
+      presetRow.appendChild(presetLabel)
+      presetRow.appendChild(presetSelect)
+      formFields.appendChild(presetRow)
+      // 첫 번째 applicable preset 자동 선택 (UX 편의 + T-U-NEVM-02)
+      var firstPreset = applicablePresets[0]
+      if (firstPreset) {
+        presetSelect.value = firstPreset.id
+        var txAutoEl = document.getElementById('field-transaction')
+        if (txAutoEl) txAutoEl.value = JSON.stringify(firstPreset.transaction, null, 2)
+      }
+    } else {
+      var noPresetEl2 = document.createElement('p')
+      noPresetEl2.style.cssText = 'font-size:10px;color:#888;margin-bottom:4px;'
+      noPresetEl2.textContent = 'No presets available for this chain. Enter transaction JSON manually.'
+      formFields.appendChild(noPresetEl2)
+    }
+  }
+
   function appendFormRow (id, labelText, type, opts) {
     var row = document.createElement('div')
     row.className = 'form-row'
@@ -671,6 +871,10 @@
       sendSignMessage()
     } else if (methodId.startsWith('signTx:evm:')) {
       sendSignTxEvm()
+    } else if (state.selectedMethodDef && state.selectedMethodDef.family &&
+               NON_EVM_FAMILIES.indexOf(state.selectedMethodDef.family) !== -1) {
+      // m06-01-03: 비-EVM signTx dispatcher
+      sendSignTxNonEvm()
     }
   })
 
@@ -784,6 +988,69 @@
     var txEl = document.getElementById('field-transaction')
 
     var chainId = chainIdEl ? chainIdEl.value : methodDef.chainId
+    var keyPath = keyPathEl ? keyPathEl.value.trim() : ''
+    var txRaw = txEl ? txEl.value.trim() : ''
+
+    // boundary-validation: keyPath
+    var keyPathError = validateKeyPath(keyPath)
+    if (keyPathError) {
+      showFieldError('keyPath', keyPathError)
+      return
+    }
+
+    // boundary-validation: transaction required
+    if (!txRaw) {
+      showFieldError('transaction', 'Transaction JSON is required')
+      return
+    }
+
+    // boundary-validation: transaction must be valid JSON
+    var txObj
+    try {
+      txObj = JSON.parse(txRaw)
+    } catch (e) {
+      showFieldError('transaction', 'Transaction must be valid JSON')
+      return
+    }
+
+    var params = { chainId: chainId, keyPath: keyPath, transaction: txObj }
+    var startMs = Date.now()
+
+    state.queue.enqueue(function () {
+      return state.transport.send({ id: _genId(), method: 'signTransaction', params: params })
+    }).then(function (resp) {
+      var result = resp && resp.result ? resp.result : resp
+      appendLog({
+        method: 'signTransaction',
+        chainId: chainId,
+        keyPath: keyPath,
+        request: params,
+        response: result,
+        latencyMs: Date.now() - startMs,
+        deviceFirmware: state.device && state.device.firmware,
+      })
+    }).catch(function (err) {
+      appendLog({
+        method: 'signTransaction',
+        chainId: chainId,
+        keyPath: keyPath,
+        request: params,
+        error: normalizeError(err),
+        latencyMs: Date.now() - startMs,
+      })
+    })
+  }
+
+  // ── sendSignTxNonEvm (m06-01-03) ──
+  function sendSignTxNonEvm () {
+    var methodDef = state.selectedMethodDef
+    if (!methodDef) return
+
+    var chainIdEl = document.getElementById('field-chainId')
+    var keyPathEl = document.getElementById('field-keyPath')
+    var txEl = document.getElementById('field-transaction')
+
+    var chainId = chainIdEl ? chainIdEl.value : (methodDef.chainId || '')
     var keyPath = keyPathEl ? keyPathEl.value.trim() : ''
     var txRaw = txEl ? txEl.value.trim() : ''
 
@@ -978,8 +1245,8 @@
     }
     buildTree()
     updateSendBtn()
-    // Load EVM chain + preset data asynchronously (non-blocking)
-    loadEvmData()
+    // Load chain + preset data asynchronously (non-blocking)
+    loadChainsData()
   }
 
   init()
@@ -1049,7 +1316,10 @@
     simulateEvmLoad: function (chains, presets) {
       evmChainsMap = {}
       evmChainsList = chains || []
-      evmChainsList.forEach(function (c) { evmChainsMap[c.chainId] = c })
+      evmChainsList.forEach(function (c) {
+        evmChainsMap[c.chainId] = c
+        allChainsMap[c.chainId] = c
+      })
       evmPresetsMap = {}
       evmPresetsList = presets || []
       evmPresetsList.forEach(function (p) { evmPresetsMap[p.id] = p })
@@ -1058,5 +1328,29 @@
       buildTree()
     },
     buildEvmSignTxGroup: buildEvmSignTxGroup,
+    // ── Non-EVM SignTx test helpers (m06-01-03) ──
+    getNonEvmChainsByFamily: function () { return nonEvmChainsByFamily },
+    getNonEvmPresetsList: function () { return nonEvmPresetsList },
+    simulateNonEvmLoad: function (chains, presets) {
+      nonEvmChainsByFamily = {}
+      allChainsMap = {}
+      // re-populate allChainsMap from existing EVM data
+      evmChainsList.forEach(function (c) { allChainsMap[c.chainId] = c })
+      var chainsList = chains || []
+      chainsList.forEach(function (c) {
+        allChainsMap[c.chainId] = c
+        if (!nonEvmChainsByFamily[c.family]) nonEvmChainsByFamily[c.family] = []
+        nonEvmChainsByFamily[c.family].push(c)
+      })
+      nonEvmPresetsMap = {}
+      nonEvmPresetsList = presets || []
+      nonEvmPresetsList.forEach(function (p) { nonEvmPresetsMap[p.id] = p })
+      state.nonEvmChainsLoaded = true
+      buildNonEvmSignTxGroups()
+      buildTree()
+    },
+    buildNonEvmSignTxGroups: buildNonEvmSignTxGroups,
+    NON_EVM_FAMILIES: NON_EVM_FAMILIES,
+    FAMILY_LABELS: FAMILY_LABELS,
   }
 })()

--- a/playground/chains.json
+++ b/playground/chains.json
@@ -1,0 +1,440 @@
+[
+  {
+    "chainId": "eip155:1",
+    "family": "ethereum",
+    "displayName": "Ethereum",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:30",
+    "family": "ethereum",
+    "displayName": "RSK Smart Bitcoin",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:8217",
+    "family": "ethereum",
+    "displayName": "Kaia",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:61",
+    "family": "ethereum",
+    "displayName": "Ethereum Classic",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:256",
+    "family": "ethereum",
+    "displayName": "Luniverse",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:50",
+    "family": "ethereum",
+    "displayName": "XDC (XinFin)",
+    "defaultKeyPath": "m/44'/550'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:56",
+    "family": "ethereum",
+    "displayName": "Binance Smart Chain",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:10",
+    "family": "ethereum",
+    "displayName": "Optimism",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:11",
+    "family": "ethereum",
+    "displayName": "Metadium",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:14",
+    "family": "ethereum",
+    "displayName": "Flare Network",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:19",
+    "family": "ethereum",
+    "displayName": "Songbird Canary-Network",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:25",
+    "family": "ethereum",
+    "displayName": "Cronos",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:66",
+    "family": "ethereum",
+    "displayName": "OKX Chain",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:100",
+    "family": "ethereum",
+    "displayName": "Gnosis",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:246",
+    "family": "ethereum",
+    "displayName": "Energy Web Chain",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:248",
+    "family": "ethereum",
+    "displayName": "Oasys",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:250",
+    "family": "ethereum",
+    "displayName": "Fantom Opera",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:255",
+    "family": "ethereum",
+    "displayName": "Kroma",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:288",
+    "family": "ethereum",
+    "displayName": "Boba",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:321",
+    "family": "ethereum",
+    "displayName": "KCC",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:592",
+    "family": "ethereum",
+    "displayName": "Astar EVM",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:2017",
+    "family": "ethereum",
+    "displayName": "Orbit Chain",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:7518",
+    "family": "ethereum",
+    "displayName": "MEVerse",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:8453",
+    "family": "ethereum",
+    "displayName": "Base",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:42161",
+    "family": "ethereum",
+    "displayName": "Arbitrum One",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:42220",
+    "family": "ethereum",
+    "displayName": "Celo",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:43114",
+    "family": "ethereum",
+    "displayName": "Avalanche C-Chain",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:1666600000",
+    "family": "ethereum",
+    "displayName": "Harmony",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:11297108109",
+    "family": "ethereum",
+    "displayName": "Palm",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:137",
+    "family": "ethereum",
+    "displayName": "Polygon",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:3776",
+    "family": "ethereum",
+    "displayName": "Astar zkEVM",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:612",
+    "family": "ethereum",
+    "displayName": "EIOB Chain",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:4613",
+    "family": "ethereum",
+    "displayName": "VERY Mainnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:37",
+    "family": "ethereum",
+    "displayName": "XPLA",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:81",
+    "family": "ethereum",
+    "displayName": "Japan Open Chain",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:1625",
+    "family": "ethereum",
+    "displayName": "Gravity Alpha",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:102030",
+    "family": "ethereum",
+    "displayName": "Creditcoin EVM",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:314",
+    "family": "ethereum",
+    "displayName": "Filecoin EVM",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:1689",
+    "family": "ethereum",
+    "displayName": "NERO",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:146",
+    "family": "ethereum",
+    "displayName": "Sonic",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:22776",
+    "family": "ethereum",
+    "displayName": "MAP Protocol",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:1868",
+    "family": "ethereum",
+    "displayName": "Soneium",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:534352",
+    "family": "ethereum",
+    "displayName": "Scroll",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:41923",
+    "family": "ethereum",
+    "displayName": "Edu Chain",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:5050",
+    "family": "ethereum",
+    "displayName": "Skate",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:888888888",
+    "family": "ethereum",
+    "displayName": "Ancient8",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:88888",
+    "family": "ethereum",
+    "displayName": "Chiliz",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:167000",
+    "family": "ethereum",
+    "displayName": "Taiko Alethia",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:80094",
+    "family": "ethereum",
+    "displayName": "Berachain",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:1514",
+    "family": "ethereum",
+    "displayName": "Story Network",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:1440000",
+    "family": "ethereum",
+    "displayName": "XRPL EVM",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:169",
+    "family": "ethereum",
+    "displayName": "Manta Pacific",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:20250217",
+    "family": "ethereum",
+    "displayName": "Xphere",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:999",
+    "family": "ethereum",
+    "displayName": "HyperEVM",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:484",
+    "family": "ethereum",
+    "displayName": "Camp Mainnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:6985385",
+    "family": "ethereum",
+    "displayName": "Humanity Protocol",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:210000",
+    "family": "ethereum",
+    "displayName": "JuChain",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:50104",
+    "family": "ethereum",
+    "displayName": "Sophon",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:4352",
+    "family": "ethereum",
+    "displayName": "MemeCore",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:98866",
+    "family": "ethereum",
+    "displayName": "Plume",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:1776",
+    "family": "ethereum",
+    "displayName": "Injective",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:143",
+    "family": "ethereum",
+    "displayName": "Monad Mainnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:7300",
+    "family": "ethereum",
+    "displayName": "XPLAVerse",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:204",
+    "family": "ethereum",
+    "displayName": "opBNB",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "bip122:000000000019d6689c085ae165831e93",
+    "family": "bitcoin",
+    "displayName": "Bitcoin",
+    "defaultKeyPath": "m/84'/0'/0'/0/0"
+  },
+  {
+    "chainId": "bip122:000000000000000000651ef99cb9fcbe",
+    "family": "bitcoin",
+    "displayName": "Bitcoin Cash",
+    "defaultKeyPath": "m/84'/145'/0'/0/0"
+  },
+  {
+    "chainId": "bip122:12a765e31ffd4059bada1e25190f6e98",
+    "family": "bitcoin",
+    "displayName": "Litecoin",
+    "defaultKeyPath": "m/84'/2'/0'/0/0"
+  },
+  {
+    "chainId": "bip122:1a91e3dace36e2be3bf030a65679fe82",
+    "family": "bitcoin",
+    "displayName": "Dogecoin",
+    "defaultKeyPath": "m/84'/3'/0'/0/0"
+  },
+  {
+    "chainId": "xrpl:0",
+    "family": "xrp",
+    "displayName": "XRPL",
+    "defaultKeyPath": "m/44'/144'/0'/0/0"
+  },
+  {
+    "chainId": "stellar:pubnet",
+    "family": "stellar",
+    "displayName": "Stellar",
+    "defaultKeyPath": "m/44'/148'/0'"
+  },
+  {
+    "chainId": "hedera:mainnet",
+    "family": "hedera",
+    "displayName": "Hedera Hashgraph",
+    "defaultKeyPath": "m/44'/3030'/0'"
+  },
+  {
+    "chainId": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+    "family": "solana",
+    "displayName": "Solana",
+    "defaultKeyPath": "m/44'/501'/0'"
+  },
+  {
+    "chainId": "tron:mainnet",
+    "family": "tron",
+    "displayName": "Tron",
+    "defaultKeyPath": "m/44'/195'/0'/0/0"
+  }
+]

--- a/playground/presets.non-evm.json
+++ b/playground/presets.non-evm.json
@@ -1,0 +1,149 @@
+[
+  {
+    "id": "btc-transfer",
+    "label": "Bitcoin native-segwit transfer",
+    "family": "bitcoin",
+    "applicableChainIds": [
+      "bip122:000000000019d6689c085ae165831e93"
+    ],
+    "note": "P2WPKH native SegWit output. Amounts in satoshi. Edit inputs/outputs before send.",
+    "sourceUrl": "https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/test/transaction_builder.spec.js",
+    "transaction": {
+      "inputs": [
+        {
+          "txid": "0000000000000000000000000000000000000000000000000000000000000001",
+          "vout": 0,
+          "amount": 100000,
+          "sequence": 4294967295
+        }
+      ],
+      "outputs": [
+        {
+          "address": "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+          "amount": 90000
+        }
+      ],
+      "feeRate": 10,
+      "locktime": 0
+    }
+  },
+  {
+    "id": "sol-transfer",
+    "label": "Solana SOL transfer",
+    "family": "solana",
+    "applicableChainIds": [
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+    ],
+    "note": "Versioned Transaction (version: 0) format. Edit to/lamports before send.",
+    "sourceUrl": "https://solana-labs.github.io/solana-web3.js/classes/VersionedTransaction.html",
+    "transaction": {
+      "version": 0,
+      "feePayer": "11111111111111111111111111111111",
+      "instructions": [
+        {
+          "programId": "11111111111111111111111111111111",
+          "keys": [
+            { "pubkey": "11111111111111111111111111111111", "isSigner": true, "isWritable": true },
+            { "pubkey": "11111111111111111111111111111112", "isSigner": false, "isWritable": true }
+          ],
+          "data": {
+            "instruction": 2,
+            "lamports": 1000000
+          }
+        }
+      ],
+      "recentBlockhash": "11111111111111111111111111111111"
+    }
+  },
+  {
+    "id": "xrp-payment",
+    "label": "XRP Payment",
+    "family": "xrp",
+    "applicableChainIds": [
+      "xrpl:0"
+    ],
+    "note": "XRP Ledger Payment transaction. Edit Destination/Amount before send.",
+    "sourceUrl": "https://js.xrpl.org/interfaces/Payment.html",
+    "transaction": {
+      "TransactionType": "Payment",
+      "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+      "Destination": "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
+      "Amount": "1000000",
+      "Fee": "12",
+      "Sequence": 1,
+      "Flags": 0
+    }
+  },
+  {
+    "id": "hbar-transfer",
+    "label": "Hedera HBAR transfer",
+    "family": "hedera",
+    "applicableChainIds": [
+      "hedera:mainnet"
+    ],
+    "note": "Hedera TransferTransaction (CryptoTransfer). Edit accountId/amount before send.",
+    "sourceUrl": "https://docs.hedera.com/hedera/sdks-and-apis/sdks/cryptocurrency/transfer-cryptocurrency",
+    "transaction": {
+      "type": "CryptoTransfer",
+      "transfers": [
+        { "accountId": "0.0.2", "amount": -100000000 },
+        { "accountId": "0.0.3", "amount": 100000000 }
+      ],
+      "memo": "",
+      "maxTransactionFee": 100000000,
+      "transactionValidDuration": 120
+    }
+  },
+  {
+    "id": "xlm-payment",
+    "label": "Stellar XLM payment",
+    "family": "stellar",
+    "applicableChainIds": [
+      "stellar:pubnet"
+    ],
+    "note": "Stellar Operation.payment for native XLM. Edit destination/amount before send.",
+    "sourceUrl": "https://stellar.github.io/js-stellar-sdk/Operation.payment.html",
+    "transaction": {
+      "type": "payment",
+      "destination": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+      "asset": { "code": "XLM", "issuer": null },
+      "amount": "10",
+      "memo": { "type": "none" },
+      "fee": 100,
+      "sequenceNumber": "0"
+    }
+  },
+  {
+    "id": "trx-transfer",
+    "label": "Tron TRX transfer",
+    "family": "tron",
+    "applicableChainIds": [
+      "tron:mainnet"
+    ],
+    "note": "TronWeb transactionBuilder.sendTrx format. Amount in SUN (1 TRX = 1,000,000 SUN). Edit to/amount before send.",
+    "sourceUrl": "https://developers.tron.network/docs/getting-started-with-tronweb",
+    "transaction": {
+      "to_address": "TPswDDCAWhJAZGdHPidFiqHuoXXVKRiTZ2",
+      "owner_address": "TN3W4H6rK2ce4vX9YnFQHwKENnHjoxb3m9",
+      "amount": 1000000,
+      "raw_data": {
+        "contract": [
+          {
+            "type": "TransferContract",
+            "parameter": {
+              "value": {
+                "to_address": "TPswDDCAWhJAZGdHPidFiqHuoXXVKRiTZ2",
+                "owner_address": "TN3W4H6rK2ce4vX9YnFQHwKENnHjoxb3m9",
+                "amount": 1000000
+              }
+            }
+          }
+        ],
+        "ref_block_bytes": "0000",
+        "ref_block_hash": "0000000000000000",
+        "expiration": 1800000,
+        "timestamp": 0
+      }
+    }
+  }
+]

--- a/scripts/extract-chains.js
+++ b/scripts/extract-chains.js
@@ -1,21 +1,29 @@
 #!/usr/bin/env node
 /**
- * extract-chains.js — EVM chain metadata 추출 스크립트
+ * extract-chains.js — 모든 family chain metadata 추출 스크립트
  *
- * refer-repos/dcent-wallet-models/src/common/assets/coins/families/ethereum-family.ts
- * 또는 wallet-models npm 패키지에서 EVM mainnet 체인 목록을 추출하여
- * playground/chains.evm.json으로 저장한다.
+ * refer-repos/dcent-wallet-models/src/common/assets/coins/families/ 또는
+ * npm 패키지에서 mainnet 체인 목록을 추출하여 playground/chains.json으로 저장한다.
  *
  * 출력 shape (ChainEntry):
- *   chainId:       string  — CAIP-19 namespace only, e.g. "eip155:1"
- *   family:        'ethereum'
- *   displayName:   string  — human readable name
- *   defaultKeyPath: string — default BIP32 derivation path
+ *   chainId:        string  — CAIP-19 namespace only, e.g. "eip155:1", "bip122:000…", "solana:5eykt…"
+ *   family:         string  — 'ethereum' | 'bitcoin' | 'solana' | 'xrp' | 'hedera' | 'stellar' | 'tron'
+ *   displayName:    string  — human readable name
+ *   defaultKeyPath: string  — default BIP32 derivation path
  *
  * 실행: node scripts/extract-chains.js
  * 또는 yarn extract-chains (package.json scripts에 등록)
  *
- * 출력 경로: playground/chains.evm.json
+ * 출력 경로: playground/chains.json (통합 파일 — m06-01-03)
+ *
+ * FAMILY_FILTERS 맵:
+ *   ethereum → eip155: prefix (EVM 계열)
+ *   bitcoin  → bip122: prefix
+ *   solana   → solana: prefix
+ *   xrp      → xrpl: prefix
+ *   hedera   → hedera: prefix
+ *   stellar  → stellar: prefix
+ *   tron     → tron: prefix (wallet-models에 CAIP-19 미지정 → static entry fallback)
  */
 
 'use strict'
@@ -23,10 +31,22 @@
 const fs = require('fs')
 const path = require('path')
 
-const OUTPUT_PATH = path.resolve(__dirname, '..', 'playground', 'chains.evm.json')
+const OUTPUT_PATH = path.resolve(__dirname, '..', 'playground', 'chains.json')
 
-// ── 소스 결정: npm 패키지 우선, 없으면 refer-repos TypeScript 파싱 ──
-function findEthereumFamilySource () {
+// ── FAMILY_FILTERS: chainId prefix → family name ──────────────────────────────
+// 각 prefix로 시작하는 chainId를 해당 family로 분류한다.
+const FAMILY_FILTERS = {
+  ethereum: function (chainId) { return chainId.startsWith('eip155:') },
+  bitcoin:  function (chainId) { return chainId.startsWith('bip122:') },
+  solana:   function (chainId) { return chainId.startsWith('solana:') },
+  xrp:      function (chainId) { return chainId.startsWith('xrpl:') },
+  hedera:   function (chainId) { return chainId.startsWith('hedera:') },
+  stellar:  function (chainId) { return chainId.startsWith('stellar:') },
+  tron:     function (chainId) { return chainId.startsWith('tron:') },
+}
+
+// ── 소스 결정: npm 패키지 우선, 없으면 refer-repos TypeScript 파싱 ──────────────
+function findFamilySource (fileName) {
   // 1) npm 패키지 (빌드 환경)
   const npmCandidates = [
     path.resolve(__dirname, '..', 'node_modules', '@iotrustgithub', 'dcent-wallet-models'),
@@ -34,8 +54,8 @@ function findEthereumFamilySource () {
   ]
   for (const base of npmCandidates) {
     const candidates = [
-      path.join(base, 'lib', 'common', 'assets', 'coins', 'families', 'ethereum-family.js'),
-      path.join(base, 'src', 'common', 'assets', 'coins', 'families', 'ethereum-family.ts'),
+      path.join(base, 'lib', 'common', 'assets', 'coins', 'families', fileName.replace('.ts', '.js')),
+      path.join(base, 'src', 'common', 'assets', 'coins', 'families', fileName),
     ]
     for (const p of candidates) {
       if (fs.existsSync(p)) return { path: p, type: fs.extname(p) === '.ts' ? 'ts' : 'js' }
@@ -46,25 +66,19 @@ function findEthereumFamilySource () {
   // scripts/ → connector/ → main-repos/ → dcent-web-sdk-uap/ → refer-repos/
   const referReposTs = path.resolve(
     __dirname, '..', '..', '..', 'refer-repos', 'dcent-wallet-models',
-    'src', 'common', 'assets', 'coins', 'families', 'ethereum-family.ts'
+    'src', 'common', 'assets', 'coins', 'families', fileName
   )
   if (fs.existsSync(referReposTs)) return { path: referReposTs, type: 'ts' }
 
   return null
 }
 
-// ── TypeScript 소스를 regex 파싱하여 EVM mainnet 체인 추출 ──
-function parseEthereumFamilyTs (tsPath) {
+// ── TypeScript 소스를 regex 파싱하여 family별 체인 추출 ───────────────────────
+// caip19 line을 pivot으로, entry block 경계 안에서만 필드를 스캔한다.
+function parseFamilyTs (tsPath) {
   const src = fs.readFileSync(tsPath, 'utf8')
   const chains = []
   const seen = new Set()
-
-  // 전략:
-  // caip19 line을 pivot으로, 해당 entry block 경계 안에서만 필드를 스캔한다.
-  // entry block 시작: caip19 이전에 나오는 가장 가까운 "  'KEY': {" 또는 "  KEY: {" 패턴
-  // entry block 종료: caip19 이후에 나오는 가장 가까운 단독 "  }," 또는 "  }"
-  // 이렇게 하면 다른 entry의 필드(예: 파일 상단 공유 units 상수)가 섞이지 않는다.
-
   const lines = src.split('\n')
 
   for (let i = 0; i < lines.length; i++) {
@@ -73,10 +87,20 @@ function parseEthereumFamilyTs (tsPath) {
     if (!caip19Match) continue
 
     const caip19Full = caip19Match[1]
-    if (!caip19Full.startsWith('eip155:')) continue
-
+    // namespace:chainRef/slip44:N → namespace:chainRef
     const chainId = caip19Full.replace(/\/slip44:\d+$/, '')
-    if (isNaN(parseInt(chainId.replace('eip155:', ''), 10))) continue
+
+    // family 판별
+    let family = null
+    for (const [fam, filter] of Object.entries(FAMILY_FILTERS)) {
+      if (filter(chainId)) { family = fam; break }
+    }
+    if (!family) continue
+
+    // EVM: numeric chainId 필수
+    if (family === 'ethereum') {
+      if (isNaN(parseInt(chainId.replace('eip155:', ''), 10))) continue
+    }
 
     // entry block 시작을 뒤로 탐색 (indent 2칸 + id key 패턴)
     let blockStart = i
@@ -88,8 +112,9 @@ function parseEthereumFamilyTs (tsPath) {
     }
 
     // entry block 끝을 앞으로 탐색 (indent 2칸의 닫는 괄호)
+    // 탐색 범위를 150줄로 확대 — BITCOIN entry는 90줄 이상 (feeRateRule 등 nested 구조)
     let blockEnd = i
-    for (let j = i + 1; j < Math.min(lines.length, i + 80); j++) {
+    for (let j = i + 1; j < Math.min(lines.length, i + 150); j++) {
       if (/^  \},?$/.test(lines[j])) {
         blockEnd = j
         break
@@ -98,16 +123,20 @@ function parseEthereumFamilyTs (tsPath) {
 
     let isTestnet = false
     let displayName = null
-    let bip44CoinType = 60
+    let bip44CoinType = null
+    let derivationFormat = null
 
     for (let j = blockStart; j <= blockEnd; j++) {
       const l = lines[j]
       if (/isTestnet:\s*true/.test(l)) isTestnet = true
-      // name 필드: indent 4칸 이상의 "name:" (공유 units 상수는 파일 상단 indent 0)
+      // name 필드: indent 4칸 이상
       const nameMatch = l.match(/^    name:\s*['"]([^'"]+)['"]/)
       if (nameMatch && displayName === null) displayName = nameMatch[1]
       const bip44Match = l.match(/bip44CoinType:\s*(\d+)/)
-      if (bip44Match) bip44CoinType = parseInt(bip44Match[1], 10)
+      if (bip44Match && bip44CoinType === null) bip44CoinType = parseInt(bip44Match[1], 10)
+      // derivationFormat: e.g. "m/44'/501'/<accountIdx>'" (double-quote only — path contains single quotes)
+      const derivFmtMatch = l.match(/derivationFormat:\s*"([^"]+)"/)
+      if (derivFmtMatch && derivationFormat === null) derivationFormat = derivFmtMatch[1]
     }
 
     if (isTestnet) continue
@@ -115,68 +144,155 @@ function parseEthereumFamilyTs (tsPath) {
     if (seen.has(chainId)) continue
     seen.add(chainId)
 
-    const defaultKeyPath = `m/44'/${bip44CoinType}'/0'/0/0`
-    chains.push({ chainId, family: 'ethereum', displayName, defaultKeyPath })
+    // defaultKeyPath 결정
+    let defaultKeyPath
+    if (derivationFormat) {
+      // <accountIdx> → 0 으로 치환해 구체 path 생성
+      defaultKeyPath = derivationFormat.replace(/<accountIdx>/g, '0')
+    } else if (bip44CoinType !== null) {
+      if (family === 'ethereum') {
+        defaultKeyPath = `m/44'/${bip44CoinType}'/0'/0/0`
+      } else if (family === 'bitcoin') {
+        // Native SegWit (BIP-84): m/84'/0'/0'/0/0 for mainnet, legacy m/44'/0'/0'/0/0
+        // objective §3 비스코프: native segwit 단일 — m/84'/0'/0'/0/0
+        defaultKeyPath = `m/84'/${bip44CoinType}'/0'/0/0`
+      } else if (family === 'solana') {
+        defaultKeyPath = `m/44'/${bip44CoinType}'/0'`
+      } else if (family === 'xrp') {
+        defaultKeyPath = `m/44'/${bip44CoinType}'/0'/0/0`
+      } else if (family === 'hedera') {
+        defaultKeyPath = `m/44'/${bip44CoinType}'/0'/0/0`
+      } else if (family === 'stellar') {
+        defaultKeyPath = `m/44'/${bip44CoinType}'/0'`
+      } else {
+        defaultKeyPath = `m/44'/${bip44CoinType}'/0'/0/0`
+      }
+    } else {
+      continue // bip44CoinType 없으면 skip
+    }
+
+    chains.push({ chainId, family, displayName, defaultKeyPath })
   }
 
   return chains
 }
 
-// ── JS 모듈에서 추출 (npm 패키지 빌드 결과) ──
-function parseEthereumFamilyJs (jsPath) {
+// ── JS 모듈에서 추출 (npm 패키지 빌드 결과) ────────────────────────────────────
+function parseFamilyJs (jsPath) {
   // eslint-disable-next-line import/no-dynamic-require
   const mod = require(jsPath)
-  const currencies = mod.ethereumFamilyCurrencies || mod.default || {}
+  // 파일마다 export 이름이 다름 — 여러 후보 시도
+  const currencies = mod.ethereumFamilyCurrencies
+    || mod.bitcoinFamilyCurrencies
+    || mod.otherNetworksCurrencies
+    || mod.default
+    || {}
   const chains = []
   const seen = new Set()
 
   for (const [, entry] of Object.entries(currencies)) {
     if (!entry || !entry.caip19) continue
-    if (!entry.caip19.startsWith('eip155:')) continue
     if (entry.isTestnet) continue
 
     const chainId = entry.caip19.replace(/\/slip44:\d+$/, '')
+
+    let family = null
+    for (const [fam, filter] of Object.entries(FAMILY_FILTERS)) {
+      if (filter(chainId)) { family = fam; break }
+    }
+    if (!family) continue
+
+    if (family === 'ethereum') {
+      if (isNaN(parseInt(chainId.replace('eip155:', ''), 10))) continue
+    }
+
     if (seen.has(chainId)) continue
     seen.add(chainId)
 
-    const bip44 = entry.bip44CoinType || 60
-    chains.push({
-      chainId,
-      family: 'ethereum',
-      displayName: entry.name,
-      defaultKeyPath: `m/44'/${bip44}'/0'/0/0`,
-    })
+    const bip44 = entry.bip44CoinType || 0
+    let defaultKeyPath
+    if (entry.derivationFormat) {
+      defaultKeyPath = entry.derivationFormat.replace(/<accountIdx>/g, '0')
+    } else if (family === 'ethereum') {
+      defaultKeyPath = `m/44'/${bip44}'/0'/0/0`
+    } else if (family === 'bitcoin') {
+      defaultKeyPath = `m/84'/${bip44}'/0'/0/0`
+    } else if (family === 'solana') {
+      defaultKeyPath = `m/44'/${bip44}'/0'`
+    } else if (family === 'stellar') {
+      defaultKeyPath = `m/44'/${bip44}'/0'`
+    } else {
+      defaultKeyPath = `m/44'/${bip44}'/0'/0/0`
+    }
+
+    chains.push({ chainId, family, displayName: entry.name, defaultKeyPath })
   }
   return chains
 }
 
-// ── Main ──
+// ── TRON static fallback (wallet-models에 CAIP-19 미지정) ─────────────────────
+// TVM namespace는 아직 ChainAgnostic에 정의되지 않았으므로 static entry 사용
+// ref: wallet-models other-networks.ts TRON entry comment
+// ref: https://developers.tron.network/docs/dapp-integration-guide
+const TRON_STATIC = [
+  {
+    chainId: 'tron:mainnet',
+    family: 'tron',
+    displayName: 'Tron',
+    defaultKeyPath: "m/44'/195'/0'/0/0",
+    // Source: SLIP-0044 coin type 195 for TRON
+    // https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+  },
+]
+
+// ── Main ──────────────────────────────────────────────────────────────────────
 function main () {
-  const source = findEthereumFamilySource()
-  if (!source) {
-    console.error([
-      'extract-chains: wallet-models source not found.',
-      '  Expected one of:',
-      '    node_modules/@iotrustgithub/dcent-wallet-models/...',
-      '    ../../../../refer-repos/dcent-wallet-models/src/...',
-      '',
-      '  In CI: npm/yarn install with wallet-models in devDependencies.',
-      '  Locally: clone refer-repos/dcent-wallet-models (see refer-repos/README.md).',
-    ].join('\n'))
-    process.exit(1)
+  const allChains = []
+  const familyFiles = [
+    { file: 'ethereum-family.ts' },
+    { file: 'bitcoin-family.ts' },
+    { file: 'other-networks.ts' },
+  ]
+
+  for (const { file } of familyFiles) {
+    const source = findFamilySource(file)
+    if (!source) {
+      console.warn('extract-chains: source not found for', file, '— skipping')
+      continue
+    }
+
+    console.log('extract-chains: reading', source.path)
+
+    let chains
+    if (source.type === 'js') {
+      chains = parseFamilyJs(source.path)
+    } else {
+      chains = parseFamilyTs(source.path)
+    }
+    allChains.push(...chains)
   }
 
-  console.log('extract-chains: reading', source.path)
-
-  let chains
-  if (source.type === 'js') {
-    chains = parseEthereumFamilyJs(source.path)
-  } else {
-    chains = parseEthereumFamilyTs(source.path)
+  // TRON static fallback (caip19 없는 family)
+  // 중복 방지: allChains에 tron:mainnet이 이미 있으면 skip
+  const existingChainIds = new Set(allChains.map(function (c) { return c.chainId }))
+  for (const entry of TRON_STATIC) {
+    if (!existingChainIds.has(entry.chainId)) {
+      // entry에서 source comment 제거 후 push
+      allChains.push({ chainId: entry.chainId, family: entry.family, displayName: entry.displayName, defaultKeyPath: entry.defaultKeyPath })
+    }
   }
 
-  if (chains.length < 5) {
-    console.error('extract-chains: suspiciously few chains extracted (' + chains.length + '). Aborting.')
+  // 각 family 최소 1개 이상 있는지 확인
+  const familyNames = Object.keys(FAMILY_FILTERS)
+  const missing = familyNames.filter(function (fam) {
+    return !allChains.some(function (c) { return c.family === fam })
+  })
+  if (missing.length > 0) {
+    console.warn('extract-chains: WARNING — missing families:', missing.join(', '))
+  }
+
+  if (allChains.length < 5) {
+    console.error('extract-chains: suspiciously few chains extracted (' + allChains.length + '). Aborting.')
     process.exit(1)
   }
 
@@ -184,8 +300,17 @@ function main () {
   const outDir = path.dirname(OUTPUT_PATH)
   if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true })
 
-  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(chains, null, 2) + '\n')
-  console.log('extract-chains: wrote ' + chains.length + ' chains to ' + OUTPUT_PATH)
+  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(allChains, null, 2) + '\n')
+
+  // family별 통계 출력
+  const stats = {}
+  for (const c of allChains) {
+    stats[c.family] = (stats[c.family] || 0) + 1
+  }
+  console.log('extract-chains: wrote ' + allChains.length + ' chains to ' + OUTPUT_PATH)
+  for (const [fam, count] of Object.entries(stats)) {
+    console.log('  ' + fam + ': ' + count)
+  }
 }
 
 main()

--- a/tests/unit/2_v2_e2e/playground.signtx-non-evm.spec.ts
+++ b/tests/unit/2_v2_e2e/playground.signtx-non-evm.spec.ts
@@ -1,0 +1,330 @@
+/**
+ * playground.signtx-non-evm.spec.ts — 비-EVM signTransaction e2e 테스트 (m06-01-03)
+ *
+ * puppeteer로 index-v2.html 로드 후 비-EVM signTx 전체 흐름 검증:
+ * 1. simulateNonEvmLoad로 체인 데이터 주입
+ * 2. 트리에 family 그룹 노출 확인
+ * 3. 폼 렌더링 + 입력 + Send → signTransaction request 파라미터 검증
+ *
+ * T-E2E-NEVM-01: Bitcoin transfer round-trip (MockDeviceTransport)
+ * T-E2E-NEVM-02: Solana transfer round-trip (MockDeviceTransport)
+ *
+ * 전제조건:
+ * - globalSetup이 harness server (port 9091) 구동 중
+ * - Mock transport 패턴 사용 (실제 디바이스 불필요)
+ */
+const { launchBrowser } = require('./launchBrowser')
+
+const HARNESS_BASE = 'http://localhost:9091'
+const PLAYGROUND_URL = `${HARNESS_BASE}/index-v2.html`
+
+const SAMPLE_NON_EVM_CHAINS = [
+  {
+    chainId: 'bip122:000000000019d6689c085ae165831e93',
+    family: 'bitcoin',
+    displayName: 'Bitcoin',
+    defaultKeyPath: "m/84'/0'/0'/0/0",
+  },
+  {
+    chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+    family: 'solana',
+    displayName: 'Solana',
+    defaultKeyPath: "m/44'/501'/0'",
+  },
+  {
+    chainId: 'xrpl:0',
+    family: 'xrp',
+    displayName: 'XRPL',
+    defaultKeyPath: "m/44'/144'/0'/0/0",
+  },
+  {
+    chainId: 'hedera:mainnet',
+    family: 'hedera',
+    displayName: 'Hedera Hashgraph',
+    defaultKeyPath: "m/44'/3030'/0'",
+  },
+  {
+    chainId: 'stellar:pubnet',
+    family: 'stellar',
+    displayName: 'Stellar',
+    defaultKeyPath: "m/44'/148'/0'",
+  },
+  {
+    chainId: 'tron:mainnet',
+    family: 'tron',
+    displayName: 'Tron',
+    defaultKeyPath: "m/44'/195'/0'/0/0",
+  },
+]
+
+const SAMPLE_NON_EVM_PRESETS = [
+  {
+    id: 'btc-transfer',
+    label: 'Bitcoin native-segwit transfer',
+    family: 'bitcoin',
+    applicableChainIds: ['bip122:000000000019d6689c085ae165831e93'],
+    note: 'P2WPKH native SegWit',
+    sourceUrl: 'https://github.com/bitcoinjs/bitcoinjs-lib',
+    transaction: {
+      inputs: [
+        {
+          txid: '0000000000000000000000000000000000000000000000000000000000000001',
+          vout: 0,
+          amount: 100000,
+          sequence: 4294967295,
+        },
+      ],
+      outputs: [{ address: 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq', amount: 90000 }],
+      feeRate: 10,
+      locktime: 0,
+    },
+  },
+  {
+    id: 'sol-transfer',
+    label: 'Solana SOL transfer',
+    family: 'solana',
+    applicableChainIds: ['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
+    note: 'Versioned Transaction (version: 0)',
+    sourceUrl: 'https://solana-labs.github.io/solana-web3.js/',
+    transaction: {
+      version: 0,
+      feePayer: '11111111111111111111111111111111',
+      instructions: [
+        {
+          programId: '11111111111111111111111111111111',
+          keys: [
+            { pubkey: '11111111111111111111111111111111', isSigner: true, isWritable: true },
+            { pubkey: '11111111111111111111111111111112', isSigner: false, isWritable: true },
+          ],
+          data: { instruction: 2, lamports: 1000000 },
+        },
+      ],
+      recentBlockhash: '11111111111111111111111111111111',
+    },
+  },
+]
+
+const BTC_TX_JSON = JSON.stringify({
+  inputs: [
+    {
+      txid: '0000000000000000000000000000000000000000000000000000000000000001',
+      vout: 0,
+      amount: 100000,
+      sequence: 4294967295,
+    },
+  ],
+  outputs: [{ address: 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq', amount: 90000 }],
+  feeRate: 10,
+  locktime: 0,
+})
+
+const SOL_TX_JSON = JSON.stringify({
+  version: 0,
+  feePayer: '11111111111111111111111111111111',
+  instructions: [
+    {
+      programId: '11111111111111111111111111111111',
+      keys: [
+        { pubkey: '11111111111111111111111111111111', isSigner: true, isWritable: true },
+        { pubkey: '11111111111111111111111111111112', isSigner: false, isWritable: true },
+      ],
+      data: { instruction: 2, lamports: 1000000 },
+    },
+  ],
+  recentBlockhash: '11111111111111111111111111111111',
+})
+
+describe('[v2 e2e] playground signTx non-EVM', () => {
+  let browser: any
+  let page: any
+
+  beforeAll(async () => {
+    browser = await launchBrowser()
+    page = await browser.newPage()
+  })
+
+  afterAll(async () => {
+    await browser.close()
+  })
+
+  // Helper: inject mock transport + connect
+  async function setupMockTransport() {
+    await page.evaluate(() => {
+      const api = (window as any)._playgroundTestAPI
+      ;(window as any)._capturedRequests = []
+      const mockTransport = {
+        send: (payload: any) => {
+          ;(window as any)._capturedRequests.push(payload)
+          return Promise.resolve({ id: payload.id, result: { signedTx: 'mock-signed-tx-hex' } })
+        },
+        on: (_: string, _fn: any) => {},
+        off: () => {},
+        close: () => Promise.resolve(),
+      }
+      const mockQueue = {
+        enqueue: (task: any) => task(),
+        size: () => 0,
+        clear: () => {},
+      }
+      api.simulateConnect(mockTransport, mockQueue, { model: 'Biometric', firmware: '3.23.0' })
+    })
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // T-E2E-NEVM-01: Bitcoin transfer round-trip (MockDeviceTransport)
+  // ────────────────────────────────────────────────────────────────────────────
+  it('T-E2E-NEVM-01: Bitcoin transfer round-trip — signTransaction 파라미터 검증', async () => {
+    await page.goto(PLAYGROUND_URL, { waitUntil: 'networkidle0' })
+
+    // Step 1: 비-EVM 데이터 주입
+    await page.evaluate(
+      (chains: typeof SAMPLE_NON_EVM_CHAINS, presets: typeof SAMPLE_NON_EVM_PRESETS) => {
+        const api = (window as any)._playgroundTestAPI
+        api.simulateNonEvmLoad(chains, presets)
+      },
+      SAMPLE_NON_EVM_CHAINS,
+      SAMPLE_NON_EVM_PRESETS
+    )
+
+    // Step 2: Bitcoin 체인 노드 존재 확인
+    const btcNodeCount = await page.$$eval(
+      '[data-method-id^="signTx:bitcoin:"]',
+      (nodes: Element[]) => nodes.length
+    )
+    expect(btcNodeCount).toBeGreaterThan(0)
+
+    // Step 3: Mock transport 주입
+    await setupMockTransport()
+
+    // Step 4: Bitcoin 노드 클릭
+    await page.click('[data-method-id="signTx:bitcoin:bip122:000000000019d6689c085ae165831e93"]')
+
+    // Step 5: 폼 렌더링 확인
+    const hasKeyPath = await page.$('#field-keyPath')
+    expect(hasKeyPath).not.toBeNull()
+    const hasTxField = await page.$('#field-transaction')
+    expect(hasTxField).not.toBeNull()
+
+    // Step 6: 폼 입력
+    await page.evaluate(
+      (keyPath: string, txJson: string) => {
+        const kp = document.getElementById('field-keyPath') as HTMLInputElement
+        const tx = document.getElementById('field-transaction') as HTMLTextAreaElement
+        if (kp) { kp.value = keyPath; kp.dispatchEvent(new Event('input', { bubbles: true })) }
+        if (tx) { tx.value = txJson; tx.dispatchEvent(new Event('input', { bubbles: true })) }
+      },
+      "m/84'/0'/0'/0/0",
+      BTC_TX_JSON
+    )
+
+    // Step 7: Send 버튼 클릭
+    const sendDisabled = await page.$eval('#btn-send', (el: HTMLButtonElement) => el.disabled)
+    expect(sendDisabled).toBe(false)
+    await page.click('#btn-send')
+
+    // Step 8: 응답 대기
+    await new Promise((r) => setTimeout(r, 300))
+
+    // Step 9: 전송된 요청 파라미터 검증
+    const captured = await page.evaluate(() => (window as any)._capturedRequests)
+    expect(captured.length).toBe(1)
+
+    const req = captured[0]
+    expect(req.method).toBe('signTransaction')
+    expect(req.params.chainId).toBe('bip122:000000000019d6689c085ae165831e93')
+    expect(req.params.keyPath).toBe("m/84'/0'/0'/0/0")
+    expect(req.params.transaction).toBeDefined()
+    // Bitcoin transaction shape: inputs 배열
+    expect(Array.isArray(req.params.transaction.inputs)).toBe(true)
+    expect(Array.isArray(req.params.transaction.outputs)).toBe(true)
+
+    // Step 10: 로그 엔트리 확인
+    const entries = await page.evaluate(() =>
+      (window as any)._playgroundTestAPI.getLogEntries()
+    )
+    expect(entries.length).toBeGreaterThan(0)
+    const lastEntry = entries[entries.length - 1]
+    expect(lastEntry.method).toBe('signTransaction')
+    expect(lastEntry.error).toBeUndefined()
+    expect(lastEntry.response).toBeDefined()
+  }, 30000)
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // T-E2E-NEVM-02: Solana transfer round-trip (MockDeviceTransport)
+  // ────────────────────────────────────────────────────────────────────────────
+  it('T-E2E-NEVM-02: Solana transfer round-trip — signTransaction 파라미터 검증', async () => {
+    await page.goto(PLAYGROUND_URL, { waitUntil: 'networkidle0' })
+
+    // Step 1: 비-EVM 데이터 주입
+    await page.evaluate(
+      (chains: typeof SAMPLE_NON_EVM_CHAINS, presets: typeof SAMPLE_NON_EVM_PRESETS) => {
+        const api = (window as any)._playgroundTestAPI
+        api.simulateNonEvmLoad(chains, presets)
+      },
+      SAMPLE_NON_EVM_CHAINS,
+      SAMPLE_NON_EVM_PRESETS
+    )
+
+    // Step 2: Solana 체인 노드 존재 확인
+    const solNodeCount = await page.$$eval(
+      '[data-method-id^="signTx:solana:"]',
+      (nodes: Element[]) => nodes.length
+    )
+    expect(solNodeCount).toBeGreaterThan(0)
+
+    // Step 3: Mock transport 주입
+    await setupMockTransport()
+
+    // Step 4: Solana 노드 클릭
+    await page.click('[data-method-id="signTx:solana:solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"]')
+
+    // Step 5: 폼 렌더링 확인
+    const hasKeyPath = await page.$('#field-keyPath')
+    expect(hasKeyPath).not.toBeNull()
+    const hasTxField = await page.$('#field-transaction')
+    expect(hasTxField).not.toBeNull()
+
+    // Step 6: 폼 입력
+    await page.evaluate(
+      (keyPath: string, txJson: string) => {
+        const kp = document.getElementById('field-keyPath') as HTMLInputElement
+        const tx = document.getElementById('field-transaction') as HTMLTextAreaElement
+        if (kp) { kp.value = keyPath; kp.dispatchEvent(new Event('input', { bubbles: true })) }
+        if (tx) { tx.value = txJson; tx.dispatchEvent(new Event('input', { bubbles: true })) }
+      },
+      "m/44'/501'/0'",
+      SOL_TX_JSON
+    )
+
+    // Step 7: Send 버튼 클릭
+    const sendDisabled = await page.$eval('#btn-send', (el: HTMLButtonElement) => el.disabled)
+    expect(sendDisabled).toBe(false)
+    await page.click('#btn-send')
+
+    // Step 8: 응답 대기
+    await new Promise((r) => setTimeout(r, 300))
+
+    // Step 9: 전송된 요청 파라미터 검증
+    const captured = await page.evaluate(() => (window as any)._capturedRequests)
+    expect(captured.length).toBe(1)
+
+    const req = captured[0]
+    expect(req.method).toBe('signTransaction')
+    expect(req.params.chainId).toBe('solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp')
+    expect(req.params.keyPath).toBe("m/44'/501'/0'")
+    expect(req.params.transaction).toBeDefined()
+    // Solana Versioned Transaction shape: version 필드
+    expect(req.params.transaction.version).toBe(0)
+    expect(req.params.transaction.feePayer).toBeDefined()
+
+    // Step 10: 로그 엔트리 확인
+    const entries = await page.evaluate(() =>
+      (window as any)._playgroundTestAPI.getLogEntries()
+    )
+    expect(entries.length).toBeGreaterThan(0)
+    const lastEntry = entries[entries.length - 1]
+    expect(lastEntry.method).toBe('signTransaction')
+    expect(lastEntry.error).toBeUndefined()
+    expect(lastEntry.response).toBeDefined()
+  }, 30000)
+})

--- a/tests/unit/v2/playground.signtx-evm.test.ts
+++ b/tests/unit/v2/playground.signtx-evm.test.ts
@@ -314,6 +314,6 @@ it('T-U-EVM-05: simulateEvmLoad 후 CHAIN_KEY_PATH Proxy — eip155:1 defaultKey
   expect(api.CHAIN_KEY_PATH['eip155:1']).toBe("m/44'/60'/0'/0/0")
   expect(api.CHAIN_KEY_PATH['eip155:8217']).toBe("m/44'/8217'/0'/0/0")
 
-  // Solana는 여전히 SOLANA_KEY_PATH에서 반환
-  expect(api.CHAIN_KEY_PATH['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp']).toBe("m/44'/501'/0'/0'")
+  // m06-01-03: chains.json 통합 후 Solana keyPath는 wallet-models derivationFormat 기준 (m/44'/501'/0')
+  expect(api.CHAIN_KEY_PATH['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp']).toBe("m/44'/501'/0'")
 })

--- a/tests/unit/v2/playground.signtx-non-evm.test.ts
+++ b/tests/unit/v2/playground.signtx-non-evm.test.ts
@@ -1,0 +1,378 @@
+/**
+ * playground.signtx-non-evm.test.ts — 비-EVM signTransaction 기능 단위 테스트 (m06-01-03)
+ *
+ * jsdom 환경에서 index-v2.html + playground.js 로드 후
+ * 비-EVM 체인 데이터 로드 / 트리 빌드 / 폼 렌더링 / dispatcher 호출 흐름을 검증.
+ *
+ * T-U-NEVM-01: simulateNonEvmLoad 후 트리에 6 family 그룹 + chainId variant 출력
+ * T-U-NEVM-02: family별 preset 적용 — btc-transfer 선택 시 Bitcoin chainId 활성 + textarea Bitcoin shape
+ * T-U-NEVM-03: family별 keyPath default — Bitcoin/Solana/XRP/Hedera/Stellar/Tron 각 SLIP-44
+ * T-U-NEVM-04: preset fixture 6개 모두 valid JSON 파싱
+ * T-U-NEVM-05: chainId가 어느 family filter에도 매칭 안 되면 트리에서 제외
+ */
+import * as fs from 'fs'
+import * as path from 'path'
+
+// ── Playground 로드 helper ──────────────────────────────────────────────────
+function loadPlayground(): void {
+  const html = fs.readFileSync(
+    path.resolve(__dirname, '../../../index-v2.html'),
+    'utf8'
+  )
+  document.documentElement.innerHTML = html
+
+  ;(window as any).PopupTransport = function (_opts: any) {
+    return {
+      send: jest.fn().mockResolvedValue({ id: 'stub-id', result: {} }),
+      on: jest.fn(),
+      off: jest.fn(),
+      close: jest.fn().mockResolvedValue(undefined),
+    }
+  }
+  ;(window as any).SerialRequestQueue = function (_transport: any) {
+    return {
+      enqueue: jest.fn(function (task: any) { return task() }),
+      size: jest.fn().mockReturnValue(0),
+      clear: jest.fn(),
+    }
+  }
+  ;(window as any).ProviderError = class ProviderError extends Error {
+    code: number
+    constructor(code: number, message: string) {
+      super(message)
+      this.code = code
+    }
+  }
+
+  const playgroundSrc = fs.readFileSync(
+    path.resolve(__dirname, '../../../playground.js'),
+    'utf8'
+  )
+  // eslint-disable-next-line no-new-func
+  new Function(playgroundSrc)()
+}
+
+// ── Sample fixtures (6 non-EVM families) ────────────────────────────────────
+const SAMPLE_NON_EVM_CHAINS = [
+  {
+    chainId: 'bip122:000000000019d6689c085ae165831e93',
+    family: 'bitcoin',
+    displayName: 'Bitcoin',
+    defaultKeyPath: "m/84'/0'/0'/0/0",
+  },
+  {
+    chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+    family: 'solana',
+    displayName: 'Solana',
+    defaultKeyPath: "m/44'/501'/0'",
+  },
+  {
+    chainId: 'xrpl:0',
+    family: 'xrp',
+    displayName: 'XRPL',
+    defaultKeyPath: "m/44'/144'/0'/0/0",
+  },
+  {
+    chainId: 'hedera:mainnet',
+    family: 'hedera',
+    displayName: 'Hedera Hashgraph',
+    defaultKeyPath: "m/44'/3030'/0'",
+  },
+  {
+    chainId: 'stellar:pubnet',
+    family: 'stellar',
+    displayName: 'Stellar',
+    defaultKeyPath: "m/44'/148'/0'",
+  },
+  {
+    chainId: 'tron:mainnet',
+    family: 'tron',
+    displayName: 'Tron',
+    defaultKeyPath: "m/44'/195'/0'/0/0",
+  },
+]
+
+const SAMPLE_NON_EVM_PRESETS = [
+  {
+    id: 'btc-transfer',
+    label: 'Bitcoin native-segwit transfer',
+    family: 'bitcoin',
+    applicableChainIds: ['bip122:000000000019d6689c085ae165831e93'],
+    note: 'P2WPKH native SegWit',
+    sourceUrl: 'https://github.com/bitcoinjs/bitcoinjs-lib',
+    transaction: {
+      inputs: [{ txid: '0000000000000000000000000000000000000000000000000000000000000001', vout: 0, amount: 100000, sequence: 4294967295 }],
+      outputs: [{ address: 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq', amount: 90000 }],
+      feeRate: 10,
+      locktime: 0,
+    },
+  },
+  {
+    id: 'sol-transfer',
+    label: 'Solana SOL transfer',
+    family: 'solana',
+    applicableChainIds: ['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
+    note: 'Versioned Transaction (version: 0)',
+    sourceUrl: 'https://solana-labs.github.io/solana-web3.js/',
+    transaction: {
+      version: 0,
+      feePayer: '11111111111111111111111111111111',
+      instructions: [],
+      recentBlockhash: '11111111111111111111111111111111',
+    },
+  },
+  {
+    id: 'xrp-payment',
+    label: 'XRP Payment',
+    family: 'xrp',
+    applicableChainIds: ['xrpl:0'],
+    note: 'XRP Ledger Payment transaction',
+    sourceUrl: 'https://js.xrpl.org/',
+    transaction: {
+      TransactionType: 'Payment',
+      Account: 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh',
+      Destination: 'rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe',
+      Amount: '1000000',
+      Fee: '12',
+      Sequence: 1,
+      Flags: 0,
+    },
+  },
+  {
+    id: 'hbar-transfer',
+    label: 'Hedera HBAR transfer',
+    family: 'hedera',
+    applicableChainIds: ['hedera:mainnet'],
+    note: 'Hedera TransferTransaction',
+    sourceUrl: 'https://docs.hedera.com/',
+    transaction: {
+      type: 'CryptoTransfer',
+      transfers: [
+        { accountId: '0.0.2', amount: -100000000 },
+        { accountId: '0.0.3', amount: 100000000 },
+      ],
+      memo: '',
+      maxTransactionFee: 100000000,
+      transactionValidDuration: 120,
+    },
+  },
+  {
+    id: 'xlm-payment',
+    label: 'Stellar XLM payment',
+    family: 'stellar',
+    applicableChainIds: ['stellar:pubnet'],
+    note: 'Stellar Operation.payment for native XLM',
+    sourceUrl: 'https://stellar.github.io/js-stellar-sdk/',
+    transaction: {
+      type: 'payment',
+      destination: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN',
+      asset: { code: 'XLM', issuer: null },
+      amount: '10',
+      memo: { type: 'none' },
+      fee: 100,
+      sequenceNumber: '0',
+    },
+  },
+  {
+    id: 'trx-transfer',
+    label: 'Tron TRX transfer',
+    family: 'tron',
+    applicableChainIds: ['tron:mainnet'],
+    note: 'TronWeb transactionBuilder.sendTrx format',
+    sourceUrl: 'https://developers.tron.network/',
+    transaction: {
+      to_address: 'TPswDDCAWhJAZGdHPidFiqHuoXXVKRiTZ2',
+      owner_address: 'TN3W4H6rK2ce4vX9YnFQHwKENnHjoxb3m9',
+      amount: 1000000,
+    },
+  },
+]
+
+// ── Setup / teardown ─────────────────────────────────────────────────────────
+beforeEach(() => {
+  loadPlayground()
+})
+
+afterEach(() => {
+  document.documentElement.innerHTML = ''
+  delete (window as any)._playgroundTestAPI
+  delete (window as any).PopupTransport
+  delete (window as any).SerialRequestQueue
+  delete (window as any).ProviderError
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T-U-NEVM-01: simulateNonEvmLoad 후 트리에 6 family 그룹 + chainId variant 출력
+// ─────────────────────────────────────────────────────────────────────────────
+it('T-U-NEVM-01: simulateNonEvmLoad 후 TREE에 6 family 그룹과 chainId 노드가 추가된다', () => {
+  const api = (window as any)._playgroundTestAPI
+
+  // 로드 전: placeholder 포함 method 개수 기록
+  const beforeCount = api.countMethodNodes()
+
+  // 비-EVM 데이터 주입
+  api.simulateNonEvmLoad(SAMPLE_NON_EVM_CHAINS, SAMPLE_NON_EVM_PRESETS)
+
+  // 로드 후: 6개 family × 1 chain씩 추가됨 (+6)
+  const afterCount = api.countMethodNodes()
+  expect(afterCount).toBe(beforeCount + SAMPLE_NON_EVM_CHAINS.length)
+
+  // DOM: 각 family의 chain 노드 존재 확인
+  const btcNode = document.querySelector('[data-method-id^="signTx:bitcoin:"]')
+  const solNode = document.querySelector('[data-method-id^="signTx:solana:"]')
+  const xrpNode = document.querySelector('[data-method-id^="signTx:xrp:"]')
+  const hbarNode = document.querySelector('[data-method-id^="signTx:hedera:"]')
+  const xlmNode = document.querySelector('[data-method-id^="signTx:stellar:"]')
+  const trxNode = document.querySelector('[data-method-id^="signTx:tron:"]')
+
+  expect(btcNode).not.toBeNull()
+  expect(solNode).not.toBeNull()
+  expect(xrpNode).not.toBeNull()
+  expect(hbarNode).not.toBeNull()
+  expect(xlmNode).not.toBeNull()
+  expect(trxNode).not.toBeNull()
+
+  // 6 family 존재 확인
+  const families = api.NON_EVM_FAMILIES as string[]
+  expect(families).toHaveLength(6)
+  expect(families).toContain('bitcoin')
+  expect(families).toContain('solana')
+  expect(families).toContain('xrp')
+  expect(families).toContain('hedera')
+  expect(families).toContain('stellar')
+  expect(families).toContain('tron')
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T-U-NEVM-02: btc-transfer 선택 시 Bitcoin chainId만 활성, transaction textarea Bitcoin shape
+// ─────────────────────────────────────────────────────────────────────────────
+it('T-U-NEVM-02: btc-transfer preset 적용 → Bitcoin chain node 활성, textarea에 Bitcoin shape 채워짐', () => {
+  const api = (window as any)._playgroundTestAPI
+
+  api.simulateNonEvmLoad(SAMPLE_NON_EVM_CHAINS, SAMPLE_NON_EVM_PRESETS)
+
+  const mockTransport = { send: jest.fn(), on: jest.fn(), off: jest.fn(), close: jest.fn() }
+  const mockQueue = { enqueue: jest.fn(function (task: any) { return task() }), size: jest.fn(), clear: jest.fn() }
+  api.simulateConnect(mockTransport, mockQueue, { model: 'Bio', firmware: '3.0' })
+
+  // Bitcoin chain node 클릭
+  const btcNode = document.querySelector('[data-method-id="signTx:bitcoin:bip122:000000000019d6689c085ae165831e93"]') as HTMLElement
+  expect(btcNode).not.toBeNull()
+  btcNode.click()
+
+  // 폼 렌더링 확인
+  const keyPathEl = document.getElementById('field-keyPath') as HTMLInputElement
+  const txEl = document.getElementById('field-transaction') as HTMLTextAreaElement
+
+  expect(keyPathEl).not.toBeNull()
+  expect(txEl).not.toBeNull()
+
+  // defaultKeyPath 주입 확인 (Bitcoin native SegWit: m/84')
+  expect(keyPathEl.value).toMatch(/^m\//)
+
+  // transaction textarea에 Bitcoin 형태 preset이 채워졌는지 확인
+  const txValue = txEl.value.trim()
+  expect(txValue.length).toBeGreaterThan(0)
+
+  // valid JSON이어야 함
+  const txObj = JSON.parse(txValue)
+  // Bitcoin 형태: inputs/outputs 배열 또는 유사 구조
+  expect(txObj).toBeDefined()
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T-U-NEVM-03: family별 keyPath default — SLIP-44 파생 경로 확인
+// ─────────────────────────────────────────────────────────────────────────────
+it('T-U-NEVM-03: CHAIN_KEY_PATH Proxy — 비-EVM family별 defaultKeyPath 반환', () => {
+  const api = (window as any)._playgroundTestAPI
+
+  api.simulateNonEvmLoad(SAMPLE_NON_EVM_CHAINS, SAMPLE_NON_EVM_PRESETS)
+
+  const ckp = api.CHAIN_KEY_PATH
+
+  // Bitcoin (BIP-84 native SegWit: SLIP-44 coin_type=0)
+  expect(ckp['bip122:000000000019d6689c085ae165831e93']).toBe("m/84'/0'/0'/0/0")
+
+  // Solana (SLIP-44 coin_type=501)
+  expect(ckp['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp']).toBe("m/44'/501'/0'")
+
+  // XRP (SLIP-44 coin_type=144)
+  expect(ckp['xrpl:0']).toBe("m/44'/144'/0'/0/0")
+
+  // Hedera (SLIP-44 coin_type=3030)
+  expect(ckp['hedera:mainnet']).toBe("m/44'/3030'/0'")
+
+  // Stellar (SLIP-44 coin_type=148)
+  expect(ckp['stellar:pubnet']).toBe("m/44'/148'/0'")
+
+  // Tron (SLIP-44 coin_type=195)
+  expect(ckp['tron:mainnet']).toBe("m/44'/195'/0'/0/0")
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T-U-NEVM-04: preset fixture 6개 모두 valid JSON 파싱
+// ─────────────────────────────────────────────────────────────────────────────
+it('T-U-NEVM-04: presets.non-evm.json — 6 family preset fixture 모두 valid JSON', () => {
+  const presetsPath = path.resolve(__dirname, '../../../playground/presets.non-evm.json')
+  const raw = fs.readFileSync(presetsPath, 'utf8')
+
+  // JSON 파싱 성공해야 함
+  let presets: any[]
+  expect(() => { presets = JSON.parse(raw) }).not.toThrow()
+
+  presets = JSON.parse(raw)
+  expect(Array.isArray(presets)).toBe(true)
+  expect(presets.length).toBe(6)
+
+  // 각 preset의 필수 필드 확인
+  const requiredFields = ['id', 'label', 'family', 'applicableChainIds', 'transaction']
+  const expectedFamilies = ['bitcoin', 'solana', 'xrp', 'hedera', 'stellar', 'tron']
+
+  presets.forEach((p: any) => {
+    requiredFields.forEach((field) => {
+      expect(p).toHaveProperty(field)
+    })
+    expect(expectedFamilies).toContain(p.family)
+    expect(Array.isArray(p.applicableChainIds)).toBe(true)
+    expect(p.applicableChainIds.length).toBeGreaterThan(0)
+    expect(typeof p.transaction).toBe('object')
+  })
+
+  // family 중복 없이 6개 모두 존재
+  const families = presets.map((p: any) => p.family)
+  expectedFamilies.forEach((fam) => {
+    expect(families).toContain(fam)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T-U-NEVM-05: 미지원 chainId는 트리에서 제외 (비-EVM family 없음)
+// ─────────────────────────────────────────────────────────────────────────────
+it('T-U-NEVM-05: 알 수 없는 family chain은 트리 non-EVM 그룹에 포함되지 않는다', () => {
+  const api = (window as any)._playgroundTestAPI
+
+  // 알 수 없는 family chain 주입
+  const unknownFamilyChain = {
+    chainId: 'cosmos:cosmoshub-4',
+    family: 'cosmos', // NON_EVM_FAMILIES에 없음
+    displayName: 'Cosmos',
+    defaultKeyPath: "m/44'/118'/0'/0/0",
+  }
+
+  api.simulateNonEvmLoad(
+    [...SAMPLE_NON_EVM_CHAINS, unknownFamilyChain],
+    SAMPLE_NON_EVM_PRESETS
+  )
+
+  // cosmos 노드는 트리에 없어야 함 (NON_EVM_FAMILIES에 cosmos가 없으므로)
+  const cosmosNode = document.querySelector('[data-method-id^="signTx:cosmos:"]')
+  expect(cosmosNode).toBeNull()
+
+  // 정상 family 6개는 여전히 존재
+  expect(document.querySelector('[data-method-id^="signTx:bitcoin:"]')).not.toBeNull()
+  expect(document.querySelector('[data-method-id^="signTx:solana:"]')).not.toBeNull()
+  expect(document.querySelector('[data-method-id^="signTx:xrp:"]')).not.toBeNull()
+  expect(document.querySelector('[data-method-id^="signTx:hedera:"]')).not.toBeNull()
+  expect(document.querySelector('[data-method-id^="signTx:stellar:"]')).not.toBeNull()
+  expect(document.querySelector('[data-method-id^="signTx:tron:"]')).not.toBeNull()
+})

--- a/tests/unit/v2/playground.smoke.test.ts
+++ b/tests/unit/v2/playground.smoke.test.ts
@@ -113,7 +113,8 @@ it("T-U-03: chainId default keyPath 매핑 — eip155:1, solana mainnet", () => 
   const chainKeyPath = api.CHAIN_KEY_PATH
 
   expect(chainKeyPath['eip155:1']).toBe("m/44'/60'/0'/0/0")
-  expect(chainKeyPath['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp']).toBe("m/44'/501'/0'/0'")
+  // m06-01-03: chains.json 통합 후 Solana keyPath는 wallet-models derivationFormat 기준 (m/44'/501'/0')
+  expect(chainKeyPath['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp']).toBe("m/44'/501'/0'")
 })
 
 // ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `scripts/extract-chains.js`에 `FAMILY_FILTERS` 7-namespace 분기 추가 + 통합 `chains.json` 출력 (chains.evm.json 대체)
- `playground/presets.non-evm.json` 신규: Bitcoin/Solana/XRP/Hedera/Stellar/Tron family preset 1개씩 (출처 URL 포함)
- `playground.js`에 비-EVM family 트리 그룹 동적 렌더 (`buildNonEvmSignTxGroups`) + family 공용 폼 (`renderSignTxNonEvmForm`) + dispatcher (`sendSignTxNonEvm`) 추가
- 단위 테스트 T-U-NEVM-01~05 + e2e 테스트 T-E2E-NEVM-01(BTC) + T-E2E-NEVM-02(SOL) 추가

## Rationale

Child 2(EVM)에서 확립한 `signTransaction` 인프라를 비-EVM 6 family에 그대로 확장. `chains.json` 단일 통합 파일(Option B) 선택으로 Child 4 추가 family도 동일 파일에 누적 가능. TRON은 CAIP-2 namespace 미정의이므로 `tron:mainnet` static fallback 사용.

## Tested

- `yarn extract-chains` — exit 0, chains.json 73개 항목 (ethereum:64, bitcoin:4, xrp:1, stellar:1, hedera:1, solana:1, tron:1)
- `yarn lint` — exit 0 (0 errors)
- `yarn build` — exit 0
- `yarn unit-v2` — 89 passed (T-U-NEVM-01~05 포함, 기존 회귀 0)
- `yarn unit-v2-e2e` — 15 passed (T-E2E-NEVM-01 BTC round-trip, T-E2E-NEVM-02 SOL round-trip 포함)

## Constraints

- TRON: ChainAgnostic namespace 미정의 → wallet-models 코드베이스 확인 후 `tron:mainnet` static fallback 적용
- Solana defaultKeyPath: wallet-models derivationFormat 기준 `m/44'/501'/0'` (Child 2 SOLANA_KEY_PATH 하드코딩 `m/44'/501'/0'/0'` 와 다름 → 기존 테스트 2건 기대값 수정)
- Bitcoin: native SegWit 단일 scriptType (BIP-84, `m/84'/0'/0'/0/0`) — P2PKH/P2SH는 Child 4 이후

**objective**: m06-01-03-playground-signtx-non-evm
**Jira**: DC-1904
**base**: epic/DC-1900_m06-01-connector-v2-playground