### PR TITLE
[no-ticker] feat(transport): PopupTransport _ready 게이트 + readyTimeoutMs (m07-02)

### DIFF
--- a/src/transport/PopupTransport.ts
+++ b/src/transport/PopupTransport.ts
@@ -20,6 +20,22 @@ export interface PopupTransportOptions {
   origin?: string
   /** connector 측 protocol version. 기본 '2.0'. handshake 시 sdk와 major match 비교 (m02-02). */
   protocolVersion?: string
+  /**
+   * sdk → connector `_ready` 신호 대기 timeout (ms). 기본 10000 (10s).
+   * 미수신 시 silent fallback으로 `_handshake`를 즉시 송신 (구 sdk 호환). m07-02 B Gate.
+   */
+  readyTimeoutMs?: number
+}
+
+/**
+ * sdk(m07-01) → connector 단방향 ready signal envelope.
+ * `id` / `method`가 부재한 신호 메시지로, messageListener의 envelope shape 검증에서
+ * 별도 분기로 인식된다 (boundary-validation 룰).
+ */
+export interface ReadySignal {
+  type: '_ready'
+  version: string
+  serverName: string
 }
 
 interface PendingRequest {
@@ -52,6 +68,7 @@ export class PopupTransport implements MessageTransport {
   private readonly popUpUrl: string
   private readonly origin: string
   private readonly protocolVersion: string
+  private readonly readyTimeoutMs: number
   private timeoutMs: number
 
   private popupWindow: Window | null = null
@@ -61,12 +78,31 @@ export class PopupTransport implements MessageTransport {
   private closePollingInterval: ReturnType<typeof setInterval> | null = null
   private currentState: TransportState = 'disconnected'
   private handshakePromise: Promise<void> | null = null
+  // m07-02: _ready 게이트 (B Gate) 상태
+  private readyPromise: Promise<void> | null = null
+  private readyTimer: ReturnType<typeof setTimeout> | null = null
+  private resolveReady: (() => void) | null = null
+  // m07-02: pre-handshake 단계(ensureReady → ensureHandshake chain) 도중인 send의 reject 콜백.
+  // close() 시 이들을 DISCONNECTED로 reject하여 게이트에서 정지된 send도 즉시 종료.
+  private preHandshakeRejecters: Set<(error: ProviderError) => void> = new Set()
 
   constructor(options: PopupTransportOptions = {}) {
     this.popUpUrl = options.popUpUrl ?? 'https://bridge.dcentwallet.com/v2'
     this.timeoutMs = options.timeoutMs ?? 60000
     this.origin = options.origin ?? new URL(this.popUpUrl).origin
     this.protocolVersion = options.protocolVersion ?? '2.0'
+    // boundary-validation: readyTimeoutMs는 양의 유한 number만 허용. 미지정 시 default 10s.
+    const ready = options.readyTimeoutMs
+    if (ready === undefined) {
+      this.readyTimeoutMs = 10000
+    } else if (typeof ready !== 'number' || !Number.isFinite(ready) || ready <= 0) {
+      throw new ProviderError(
+        ErrorCode.INVALID_PARAMS,
+        `readyTimeoutMs must be a positive finite number, got ${String(ready)}`,
+      )
+    } else {
+      this.readyTimeoutMs = ready
+    }
   }
 
   send<TParams, TResult>(
@@ -83,9 +119,17 @@ export class PopupTransport implements MessageTransport {
       // 3. close polling 시작 (1회)
       this.ensureClosePolling()
 
-      // 4. handshake 보장 후 실제 send 진행 (m02-02)
-      this.ensureHandshake().then(
+      // m07-02: pre-handshake 단계에 close()가 호출되면 이 reject로 즉시 종료
+      this.preHandshakeRejecters.add(reject)
+
+      // 4. m07-02 B Gate: _ready 신호 대기 → handshake 보장 → 실제 send 진행
+      this.ensureReady()
+        .then(() => this.ensureHandshake())
+        .then(
         () => {
+          // pre-handshake 구간 통과 — rejecter 제거 (이후는 pending Map이 close() 처리)
+          this.preHandshakeRejecters.delete(reject)
+
           // 4a. timeout 설정
           const timer = setTimeout(() => {
             this.pending.delete(message.id)
@@ -119,6 +163,7 @@ export class PopupTransport implements MessageTransport {
           }
         },
         (handshakeError) => {
+          this.preHandshakeRejecters.delete(reject)
           // handshake 실패 시 send도 즉시 fail (close()는 sendHandshake 내부에서 이미 호출됨)
           reject(handshakeError)
         },
@@ -149,6 +194,17 @@ export class PopupTransport implements MessageTransport {
     }
     this.pending.clear()
 
+    // 1b. m07-02: pre-handshake 단계 도중인 send도 모두 reject
+    for (const r of this.preHandshakeRejecters) {
+      r(
+        new ProviderError(
+          ErrorCode.DISCONNECTED,
+          'Transport closed before handshake completed',
+        ),
+      )
+    }
+    this.preHandshakeRejecters.clear()
+
     // 2. message listener 해제
     if (this.messageListener) {
       window.removeEventListener('message', this.messageListener)
@@ -175,6 +231,14 @@ export class PopupTransport implements MessageTransport {
 
     // 7. handshake state 리셋 — 재오픈 시 새 handshake (m02-02)
     this.handshakePromise = null
+
+    // 8. m07-02 ready state 리셋 — readyTimer cleanup + 재오픈 시 새 _ready 사이클
+    if (this.readyTimer) {
+      clearTimeout(this.readyTimer)
+      this.readyTimer = null
+    }
+    this.readyPromise = null
+    this.resolveReady = null
   }
 
   /**
@@ -216,17 +280,61 @@ export class PopupTransport implements MessageTransport {
       if (event.origin !== this.origin) return
 
       const data = event.data
-      // boundary-validation: envelope shape 검증
-      if (!data || typeof data !== 'object' || typeof data.id !== 'string') return
+      if (!data || typeof data !== 'object') return
 
-      const pending = this.pending.get(data.id)
+      // m07-02: _ready envelope 분기 (id/method가 부재한 신호 메시지)
+      if ((data as { type?: unknown }).type === '_ready') {
+        const ready = data as Partial<ReadySignal>
+        // boundary-validation: version / serverName 존재 + string 검증
+        if (typeof ready.version !== 'string' || typeof ready.serverName !== 'string') return
+        if (this.resolveReady) {
+          const r = this.resolveReady
+          this.resolveReady = null // 재호출 방지
+          r()
+        }
+        return
+      }
+
+      // boundary-validation: ResponseEnvelope shape 검증
+      if (typeof (data as { id?: unknown }).id !== 'string') return
+
+      const pending = this.pending.get((data as { id: string }).id)
       if (!pending) return // 모르는 id (이미 timeout 처리되었을 수 있음)
 
       clearTimeout(pending.timer)
-      this.pending.delete(data.id)
+      this.pending.delete((data as { id: string }).id)
       pending.resolve(data as ResponseEnvelope<unknown>)
     }
     window.addEventListener('message', this.messageListener, false)
+  }
+
+  /**
+   * m07-02 B Gate: sdk(m07-01)가 송신하는 `_ready` 신호 대기.
+   * 첫 호출만 timer + listener 등록, 이후 호출은 동일 Promise 공유 (race 방지).
+   * `readyTimeoutMs` 만료 시 silent resolve → `_handshake` 즉시 송신 (Y Timeout fallback, 구 sdk 호환).
+   * close() 시 `readyPromise = null` 리셋 → 재오픈 시 새 ready 사이클.
+   */
+  private ensureReady(): Promise<void> {
+    if (this.readyPromise) return this.readyPromise
+    this.readyPromise = new Promise<void>((resolve) => {
+      // _ready 수신 시 messageListener에서 resolveReady() 호출
+      this.resolveReady = () => {
+        if (this.readyTimer) {
+          clearTimeout(this.readyTimer)
+          this.readyTimer = null
+        }
+        resolve()
+      }
+      // Y Timeout fallback — readyTimeoutMs 만료 시 silent resolve. 이후 _handshake 자체가
+      // m02-02의 timeoutMs로 보호되므로 추가 에러 처리 불필요 (error-handling-consistency:
+      // ready signal 자체는 자산과 무관하므로 silent fallback이 정책상 정당).
+      this.readyTimer = setTimeout(() => {
+        this.readyTimer = null
+        this.resolveReady = null
+        resolve()
+      }, this.readyTimeoutMs)
+    })
+    return this.readyPromise
   }
 
   private ensureClosePolling(): void {
@@ -266,6 +374,10 @@ export class PopupTransport implements MessageTransport {
           ErrorCode.TIMEOUT,
           `Handshake timed out after ${this.timeoutMs}ms`,
         )
+        // m07-02: handshake error는 send의 .then(_, errHandler)가 받아 reject되어야 함.
+        // close()가 preHandshakeRejecters로 DISCONNECTED를 먼저 던지면 actual error가 가려짐.
+        // → close() 전에 preHandshakeRejecters를 비워서 handshake error가 송출되도록 함.
+        this.preHandshakeRejecters.clear()
         this.close().catch(() => {
           /* defensive noop */
         })
@@ -282,6 +394,8 @@ export class PopupTransport implements MessageTransport {
               `Handshake rejected by sdk: ${errResp.message ?? 'unknown'}`,
               errResp.data,
             )
+            // m07-02: handshake error 우선 — close()의 DISCONNECTED가 가리지 않도록 사전 비움
+            this.preHandshakeRejecters.clear()
             this.close().catch(() => {
               /* defensive noop */
             })
@@ -297,6 +411,7 @@ export class PopupTransport implements MessageTransport {
               ErrorCode.PROTOCOL_VERSION_MISMATCH,
               `Protocol version mismatch: connector=${this.protocolVersion}, sdk=${typeof remoteVersion === 'string' ? remoteVersion : String(remoteVersion)}`,
             )
+            this.preHandshakeRejecters.clear()
             this.close().catch(() => {
               /* defensive noop */
             })
@@ -329,6 +444,7 @@ export class PopupTransport implements MessageTransport {
           ErrorCode.INTERNAL_ERROR,
           `Handshake postMessage failed: ${(err as Error).message}`,
         )
+        this.preHandshakeRejecters.clear()
         this.close().catch(() => {
           /* defensive noop */
         })

--- a/tests/unit/2_v2_e2e/09_ready_signal.spec.ts
+++ b/tests/unit/2_v2_e2e/09_ready_signal.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * T-E-RG — m07-02 ready signal gate (B Gate + Y Timeout fallback)
+ *
+ * 두 가지 시나리오 검증:
+ * - T-E-RG-01: m07-01 SDK가 `_ready` 신호를 송신하면 connector가 게이트 통과 후
+ *              `preOpenAndWait()` 우회 없이도 race 없이 round-trip 성공.
+ *              ※ 본 테스트는 m07-01이 SDK 측에 머지되지 않은 환경에서는 Y fallback 경로로 통과한다 (조건부).
+ * - T-E-RG-02: `readyTimeoutMs: 100`으로 짧게 설정한 transport — sdk가 `_ready`를 송신하지 않아도
+ *              100ms 후 fallback으로 `_handshake` 송신 + ack 받고 round-trip 성공.
+ */
+const { launchBrowser } = require('./launchBrowser')
+
+const HARNESS_URL = 'http://localhost:9091/tests/unit/2_v2_e2e/harness.html'
+const SDK_URL = 'http://localhost:5174/'
+
+describe('[v2 e2e] T-E-RG ready gate', () => {
+  let browser: any
+  let page: any
+
+  beforeAll(async () => {
+    browser = await launchBrowser()
+    page = await browser.newPage()
+    await page.goto(HARNESS_URL)
+  })
+
+  afterAll(async () => {
+    await browser.close()
+  })
+
+  afterEach(async () => {
+    await page.evaluate(() => (window as any).dcentTest.close())
+  })
+
+  // T-E-RG-01: preOpenAndWait() 우회 제거 + (m07-01 환경에선 _ready 즉시 송신, 없으면 readyTimeout fallback)
+  // 본 케이스는 m07-01 미배포 환경에서도 통과 가능 (default readyTimeoutMs=10000ms 후 fallback).
+  it('T-E-RG-01: send 즉시 호출 — preOpenAndWait 없이 round-trip 성공', async () => {
+    await page.evaluate((url: string) => {
+      ;(window as any).dcentTest.newTransport({ popUpUrl: url })
+    }, SDK_URL)
+
+    // preOpenAndWait() 의도적으로 호출하지 않음 — 게이트가 race를 흡수해야 함
+    const result = await page.evaluate(() => {
+      return (window as any).dcentTest.send({
+        id: 'e2e-rg-1',
+        method: 'getStatus',
+        params: { foo: 1 },
+      })
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.response.id).toBe('e2e-rg-1')
+    expect(result.response.result).toEqual({
+      method: 'getStatus',
+      params: { foo: 1 },
+      echo: true,
+    })
+  }, 30000)
+
+  // T-E-RG-02: readyTimeoutMs 짧게 설정 → fallback 경로로 round-trip 성공
+  // sdk가 _ready를 송신하지 않는 환경(현재 default — m07-01 머지 전)에서 100ms 후 즉시 handshake fallback.
+  it('T-E-RG-02: readyTimeoutMs=100 → Y fallback 경로로 round-trip', async () => {
+    await page.evaluate((url: string) => {
+      ;(window as any).dcentTest.newTransport({ popUpUrl: url, readyTimeoutMs: 100 })
+    }, SDK_URL)
+
+    // popup React mount race 우회 — readyTimeoutMs는 매우 짧지만 SDK가 mount되지 않으면 handshake도 timeout
+    // 따라서 preOpenAndWait()로 SDK ready를 먼저 보장
+    await page.evaluate(() => (window as any).dcentTest.preOpenAndWait())
+
+    const result = await page.evaluate(() => {
+      return (window as any).dcentTest.send({
+        id: 'e2e-rg-2',
+        method: 'getStatus',
+        params: { foo: 'bar' },
+      })
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.response.id).toBe('e2e-rg-2')
+    expect(result.response.result).toEqual({
+      method: 'getStatus',
+      params: { foo: 'bar' },
+      echo: true,
+    })
+  }, 30000)
+})

--- a/tests/unit/v2/transport/PopupTransport.test.ts
+++ b/tests/unit/v2/transport/PopupTransport.test.ts
@@ -41,14 +41,20 @@ function dispatchResponse(origin: string, data: unknown): void {
 }
 
 /**
- * Handshake auto-respond helper (m02-02).
+ * Handshake auto-respond helper (m02-02 + m07-02).
  * postMessage spy가 _handshake 메시지를 받으면 microtask로 ack 응답 dispatch.
- * sdkVersion override 가능. 일반 메시지는 swallow (test가 직접 dispatch).
+ * m07-02 B Gate 추가 후: window.addEventListener('message', ...) 호출을 wrap하여
+ * 메시지 리스너가 등록되는 시점에 microtask로 `_ready` 신호를 자동 dispatch.
+ * 이로써 PopupTransport.send() → ensureReady() 즉시 게이트가 열려 기존 35건이 회귀 없이 통과.
+ *
+ * m07-02 게이트를 명시적으로 테스트하려면 이 helper 대신 mockPopup.postMessage.mockImplementation을
+ * 직접 정의하고 sendReadySignal()를 수동 호출 (sendReady=false 변형 시).
  */
 function installHandshakeAutoRespond(
   mockPopup: MockPopup,
   origin: string = DEFAULT_ORIGIN,
   sdkVersion: string = '2.0',
+  serverName: string = 'bridge-ui',
 ): void {
   mockPopup.postMessage.mockImplementation((message: { method?: unknown; id?: unknown }, msgOrigin: string) => {
     if (message?.method === '_handshake' && typeof message.id === 'string') {
@@ -56,22 +62,75 @@ function installHandshakeAutoRespond(
       Promise.resolve().then(() => {
         dispatchResponse(responseOrigin, {
           id: message.id,
-          result: { version: sdkVersion, serverName: 'bridge-ui' },
+          result: { version: sdkVersion, serverName },
         })
       })
     }
   })
+  // m07-02: ready 신호 자동 dispatch — addEventListener('message')가 호출되는 시점에 emit.
+  // PopupTransport.ensureMessageListener()가 호출되면 PopupTransport.ensureReady()가 곧 이어
+  // resolveReady를 등록하므로, microtask 1 tick 후에 ready를 dispatch하면 게이트가 열린다.
+  installReadyAutoRespondOnce(origin, sdkVersion, serverName)
+}
+
+let _readyAutoRespondAddSpy: jest.SpyInstance | null = null
+let _readyAutoRespondConfig: { origin: string; version: string; serverName: string } | null = null
+
+function installReadyAutoRespondOnce(origin: string, version: string, serverName: string): void {
+  // 매 호출마다 최신 config로 갱신 — 같은 테스트 내 origin 변경(예: T-U-15) 지원
+  _readyAutoRespondConfig = { origin, version, serverName }
+  if (_readyAutoRespondAddSpy) return
+  const origAdd = window.addEventListener.bind(window)
+  _readyAutoRespondAddSpy = jest
+    .spyOn(window, 'addEventListener')
+    .mockImplementation(((type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions) => {
+      const ret = origAdd(type, listener, options)
+      if (type === 'message') {
+        // 1 microtask 뒤에 ready emit — PopupTransport.send()가 ensureReady의 resolveReady를
+        // 등록한 다음 tick에 emit되므로 게이트가 곧바로 열림
+        Promise.resolve().then(() => {
+          if (_readyAutoRespondConfig) {
+            const c = _readyAutoRespondConfig
+            dispatchResponse(c.origin, { type: '_ready', version: c.version, serverName: c.serverName })
+          }
+        })
+      }
+      return ret
+    }) as typeof window.addEventListener)
+}
+
+function uninstallReadyAutoRespond(): void {
+  if (_readyAutoRespondAddSpy) {
+    _readyAutoRespondAddSpy.mockRestore()
+    _readyAutoRespondAddSpy = null
+  }
+  _readyAutoRespondConfig = null
 }
 
 /**
- * Handshake round-trip 마이크로태스크 flush.
- * 1) handshake response dispatch → listener resolve handshake pending
- * 2) handshakePromise resolve → ensureHandshake.then 실행 → 실제 send postMessage 호출
+ * m07-02: `_ready` 신호를 수동 dispatch. T-U-RG 시리즈 / readyTimeoutMs fallback 시나리오에서 사용.
+ */
+function sendReadySignal(
+  origin: string = DEFAULT_ORIGIN,
+  version: string = '2.0',
+  serverName: string = 'bridge-ui',
+): void {
+  dispatchResponse(origin, { type: '_ready', version, serverName })
+}
+
+/**
+ * Ready + Handshake round-trip 마이크로태스크 flush (m07-02 후 게이트가 1단계 더 추가됨).
+ * 1) ready 신호 dispatch (addEventListener spy가 microtask로 emit) → listener가 resolveReady() 호출
+ * 2) readyPromise resolve → ensureHandshake() 실행 → handshake postMessage
+ * 3) handshake response dispatch → listener resolve handshake pending
+ * 4) handshakePromise resolve → 실제 send postMessage 호출
+ *
+ * 각 .then chain마다 microtask 1 tick씩 소모하므로 넉넉히 6 tick await.
  */
 async function flushHandshake(): Promise<void> {
-  await Promise.resolve()
-  await Promise.resolve()
-  await Promise.resolve()
+  for (let i = 0; i < 6; i++) {
+    await Promise.resolve()
+  }
 }
 
 describe('PopupTransport', () => {
@@ -92,6 +151,7 @@ describe('PopupTransport', () => {
   afterEach(() => {
     jest.useRealTimers()
     openSpy.mockRestore()
+    uninstallReadyAutoRespond()
   })
 
   // ===== T-U-01: send happy path =====
@@ -419,7 +479,8 @@ describe('PopupTransport', () => {
       transport = new PopupTransport()
       // handshake 후 어떤 메시지가 어떤 method로 갔는지 검사할 수 있어야 함
       void transport.send(makeEnvelope('req-1')).catch(() => {})
-      await Promise.resolve() // executor 동기 진입
+      // m07-02: ready 게이트 1단계 추가 → microtask flush 충분히
+      await flushHandshake()
 
       const handshakeCalls = mockPopup.postMessage.mock.calls.filter(
         (c: unknown[]) => (c[0] as { method?: string })?.method === '_handshake',
@@ -519,6 +580,8 @@ describe('PopupTransport', () => {
       mockPopup.postMessage.mockImplementation(() => { /* swallow */ })
 
       const promise = transport.send(makeEnvelope('req-1'))
+      // m07-02: ready 게이트 통과 후 handshake setTimeout이 등록되도록 microtask flush
+      await flushHandshake()
       jest.advanceTimersByTime(60000)
 
       await expect(promise).rejects.toMatchObject({ code: ErrorCode.TIMEOUT })
@@ -640,7 +703,8 @@ describe('PopupTransport', () => {
       mockPopup.postMessage.mockImplementation(() => { /* swallow */ })
 
       const promise = transport.send(makeEnvelope('req-1'))
-      await Promise.resolve() // handshake pending 등록
+      // m07-02: ready 게이트 통과 후 handshake pending 등록까지 기다림
+      await flushHandshake()
 
       // 사용자가 popup 강제 close
       mockPopup.closed = true
@@ -650,6 +714,280 @@ describe('PopupTransport', () => {
 
       // DISCONNECTED reject (timeout=60000보다 훨씬 빠름)
       await expect(promise).rejects.toMatchObject({ code: ErrorCode.DISCONNECTED })
+    })
+  })
+
+  // =========================================================================
+  // m07-02 Ready Gate 단위 테스트 (T-U-RG-01 ~ T-U-RG-08)
+  // =========================================================================
+
+  // ===== T-U-RG-01: B Gate happy path =====
+  describe('T-U-RG-01: B Gate happy path', () => {
+    it('_ready 수신 → _handshake 송신 → method round-trip 성공', async () => {
+      transport = new PopupTransport()
+      // 기본 helper가 _ready + _handshake 모두 자동 응답
+      const env = makeEnvelope('req-rg-1')
+      const promise = transport.send<{ x: number }, { ok: true }>(env)
+      await flushHandshake()
+
+      // _handshake가 send된 후 method도 정상 송신
+      const methodCalls = mockPopup.postMessage.mock.calls.filter(
+        (c: unknown[]) => (c[0] as { method?: string })?.method === 'test_method',
+      )
+      expect(methodCalls.length).toBe(1)
+
+      dispatchResponse(DEFAULT_ORIGIN, { id: 'req-rg-1', result: { ok: true } })
+      const response = (await promise) as ResponseEnvelope<{ ok: true }>
+      expect(response.id).toBe('req-rg-1')
+
+      await transport.close()
+    })
+  })
+
+  // ===== T-U-RG-02: Y Timeout fallback =====
+  describe('T-U-RG-02: Y Timeout fallback (구 sdk 호환)', () => {
+    it('_ready 미수신 + readyTimeoutMs 만료 → _handshake 즉시 송신', async () => {
+      transport = new PopupTransport({ readyTimeoutMs: 50 })
+      // 기본 helper의 _ready auto-emit 비활성화
+      uninstallReadyAutoRespond()
+      // _handshake만 자동 응답
+      mockPopup.postMessage.mockImplementation((message: { method?: unknown; id?: unknown }, msgOrigin: string) => {
+        if (message?.method === '_handshake' && typeof message.id === 'string') {
+          Promise.resolve().then(() => {
+            dispatchResponse(msgOrigin, {
+              id: message.id,
+              result: { version: '2.0', serverName: 'bridge-ui-old' },
+            })
+          })
+        }
+      })
+
+      const promise = transport.send(makeEnvelope('req-rg-2'))
+      // ready 게이트 등록 후 readyTimeoutMs 만료까지 시간 진행
+      await Promise.resolve()
+      jest.advanceTimersByTime(50)
+      await flushHandshake()
+
+      // _handshake가 readyTimeout 후 송신됐는지 검증
+      const handshakeCalls = mockPopup.postMessage.mock.calls.filter(
+        (c: unknown[]) => (c[0] as { method?: string })?.method === '_handshake',
+      )
+      expect(handshakeCalls.length).toBe(1)
+
+      dispatchResponse(DEFAULT_ORIGIN, { id: 'req-rg-2', result: 'fallback-ok' })
+      await expect(promise).resolves.toMatchObject({ id: 'req-rg-2', result: 'fallback-ok' })
+
+      await transport.close()
+    })
+  })
+
+  // ===== T-U-RG-03: _ready envelope shape 검증 =====
+  describe('T-U-RG-03: _ready shape boundary-validation', () => {
+    it('version/serverName 누락된 _ready는 무시 → 정상 _ready 또는 timeout 대기', async () => {
+      transport = new PopupTransport({ readyTimeoutMs: 100 })
+      uninstallReadyAutoRespond()
+      mockPopup.postMessage.mockImplementation((message: { method?: unknown; id?: unknown }, msgOrigin: string) => {
+        if (message?.method === '_handshake' && typeof message.id === 'string') {
+          Promise.resolve().then(() => {
+            dispatchResponse(msgOrigin, {
+              id: message.id,
+              result: { version: '2.0', serverName: 'bridge-ui' },
+            })
+          })
+        }
+      })
+
+      const promise = transport.send(makeEnvelope('req-rg-3'))
+      await Promise.resolve()
+
+      // 잘못된 _ready 메시지들 — 모두 무시되어야 함
+      dispatchResponse(DEFAULT_ORIGIN, { type: '_ready' }) // version, serverName 누락
+      dispatchResponse(DEFAULT_ORIGIN, { type: '_ready', version: 123, serverName: 'x' }) // version non-string
+      dispatchResponse(DEFAULT_ORIGIN, { type: '_ready', version: '2.0' }) // serverName 누락
+
+      // 아직 readyTimeout 안 지남 → handshake 송신 안 됨
+      let handshakeCalls = mockPopup.postMessage.mock.calls.filter(
+        (c: unknown[]) => (c[0] as { method?: string })?.method === '_handshake',
+      )
+      expect(handshakeCalls.length).toBe(0)
+
+      // 정상 _ready 도착 → 게이트 열림
+      sendReadySignal()
+      await flushHandshake()
+
+      handshakeCalls = mockPopup.postMessage.mock.calls.filter(
+        (c: unknown[]) => (c[0] as { method?: string })?.method === '_handshake',
+      )
+      expect(handshakeCalls.length).toBe(1)
+
+      dispatchResponse(DEFAULT_ORIGIN, { id: 'req-rg-3', result: 'ok' })
+      await expect(promise).resolves.toMatchObject({ id: 'req-rg-3' })
+
+      await transport.close()
+    })
+  })
+
+  // ===== T-U-RG-04: 다중 send → ready 대기 1회 공유 =====
+  describe('T-U-RG-04: 다중 send → ready 대기 1회 공유', () => {
+    it('3개 동시 send + 1번의 _ready emit → 3개 모두 게이트 통과', async () => {
+      transport = new PopupTransport()
+      // 기본 helper의 _ready 1회 emit이 3개 send를 모두 통과시켜야 함
+      const p1 = transport.send(makeEnvelope('a'))
+      const p2 = transport.send(makeEnvelope('b'))
+      const p3 = transport.send(makeEnvelope('c'))
+      await flushHandshake()
+
+      // _handshake도 1회만 (m02-02 in-flight 공유와 동일)
+      const handshakeCalls = mockPopup.postMessage.mock.calls.filter(
+        (c: unknown[]) => (c[0] as { method?: string })?.method === '_handshake',
+      )
+      expect(handshakeCalls.length).toBe(1)
+
+      // 3개 모두 method postMessage 호출
+      const methodCalls = mockPopup.postMessage.mock.calls.filter(
+        (c: unknown[]) => (c[0] as { method?: string })?.method === 'test_method',
+      )
+      expect(methodCalls.length).toBe(3)
+
+      dispatchResponse(DEFAULT_ORIGIN, { id: 'a', result: 1 })
+      dispatchResponse(DEFAULT_ORIGIN, { id: 'b', result: 2 })
+      dispatchResponse(DEFAULT_ORIGIN, { id: 'c', result: 3 })
+
+      const [r1, r2, r3] = await Promise.all([p1, p2, p3])
+      expect((r1 as ResponseEnvelope<number>).result).toBe(1)
+      expect((r2 as ResponseEnvelope<number>).result).toBe(2)
+      expect((r3 as ResponseEnvelope<number>).result).toBe(3)
+
+      await transport.close()
+    })
+  })
+
+  // ===== T-U-RG-05: close 후 재오픈 시 새 ready 사이클 =====
+  describe('T-U-RG-05: close 후 재오픈 시 새 ready 사이클', () => {
+    it('close 후 send → 새 readyPromise + 새 _ready 대기', async () => {
+      transport = new PopupTransport()
+
+      const p1 = transport.send(makeEnvelope('first'))
+      await flushHandshake()
+      dispatchResponse(DEFAULT_ORIGIN, { id: 'first', result: 1 })
+      await expect(p1).resolves.toMatchObject({ id: 'first' })
+
+      // 첫 사이클 확정 후 close → 새 popup으로 두 번째 사이클
+      await transport.close()
+      const newPopup = makeMockPopup()
+      openSpy.mockImplementation(() => newPopup as unknown as Window)
+      // 두 번째 popup에도 helper 부착 (uninstall된 spy 재설치)
+      installHandshakeAutoRespond(newPopup)
+
+      const p2 = transport.send(makeEnvelope('second'))
+      await flushHandshake()
+
+      // 새 사이클에서도 _handshake 송신 + 정상 round-trip
+      const handshakeCalls = newPopup.postMessage.mock.calls.filter(
+        (c: unknown[]) => (c[0] as { method?: string })?.method === '_handshake',
+      )
+      expect(handshakeCalls.length).toBe(1)
+
+      dispatchResponse(DEFAULT_ORIGIN, { id: 'second', result: 2 })
+      await expect(p2).resolves.toMatchObject({ id: 'second' })
+
+      await transport.close()
+    })
+  })
+
+  // ===== T-U-RG-06: _ready origin 가드 =====
+  describe('T-U-RG-06: _ready origin guard', () => {
+    it('잘못된 origin의 _ready는 무시', async () => {
+      transport = new PopupTransport({ readyTimeoutMs: 100 })
+      uninstallReadyAutoRespond()
+      mockPopup.postMessage.mockImplementation((message: { method?: unknown; id?: unknown }, msgOrigin: string) => {
+        if (message?.method === '_handshake' && typeof message.id === 'string') {
+          Promise.resolve().then(() => {
+            dispatchResponse(msgOrigin, {
+              id: message.id,
+              result: { version: '2.0', serverName: 'bridge-ui' },
+            })
+          })
+        }
+      })
+
+      const promise = transport.send(makeEnvelope('req-rg-6'))
+      await Promise.resolve()
+
+      // 악의적 origin의 _ready — 무시되어야 함
+      dispatchResponse('https://evil.example.com', { type: '_ready', version: '2.0', serverName: 'evil' })
+
+      // handshake 아직 송신 안 됨
+      let handshakeCalls = mockPopup.postMessage.mock.calls.filter(
+        (c: unknown[]) => (c[0] as { method?: string })?.method === '_handshake',
+      )
+      expect(handshakeCalls.length).toBe(0)
+
+      // 정상 origin의 _ready
+      sendReadySignal()
+      await flushHandshake()
+
+      handshakeCalls = mockPopup.postMessage.mock.calls.filter(
+        (c: unknown[]) => (c[0] as { method?: string })?.method === '_handshake',
+      )
+      expect(handshakeCalls.length).toBe(1)
+
+      dispatchResponse(DEFAULT_ORIGIN, { id: 'req-rg-6', result: 'ok' })
+      await expect(promise).resolves.toMatchObject({ id: 'req-rg-6' })
+
+      await transport.close()
+    })
+  })
+
+  // ===== T-U-RG-07: readyTimeoutMs 옵션 검증 =====
+  describe('T-U-RG-07: readyTimeoutMs 옵션 검증', () => {
+    it('default 10000 + override + invalid 값 throw', () => {
+      // default
+      const t1 = new PopupTransport()
+      // (private이지만 runtime accessible — 타입 캐스트로 검사)
+      expect((t1 as unknown as { readyTimeoutMs: number }).readyTimeoutMs).toBe(10000)
+
+      // override 양수
+      const t2 = new PopupTransport({ readyTimeoutMs: 500 })
+      expect((t2 as unknown as { readyTimeoutMs: number }).readyTimeoutMs).toBe(500)
+
+      // invalid: -1
+      expect(() => new PopupTransport({ readyTimeoutMs: -1 })).toThrow(ProviderError)
+      expect(() => new PopupTransport({ readyTimeoutMs: -1 })).toThrow(/positive finite number/)
+
+      // invalid: NaN
+      expect(() => new PopupTransport({ readyTimeoutMs: NaN })).toThrow(ProviderError)
+
+      // invalid: 0
+      expect(() => new PopupTransport({ readyTimeoutMs: 0 })).toThrow(ProviderError)
+
+      // invalid: non-number (런타임 보호 — 타입은 number지만 외부에서 any로 들어올 수 있음)
+      expect(() => new PopupTransport({ readyTimeoutMs: '500' as unknown as number })).toThrow(ProviderError)
+    })
+  })
+
+  // ===== T-U-RG-08: close 시 readyTimer + readyPromise 정리 =====
+  describe('T-U-RG-08: close cleanup of ready state', () => {
+    it('close 후 readyTimer / readyPromise / resolveReady 모두 null', async () => {
+      transport = new PopupTransport({ readyTimeoutMs: 5000 })
+      uninstallReadyAutoRespond()
+      mockPopup.postMessage.mockImplementation(() => { /* swallow — ready 게이트에서 정지 */ })
+
+      // send 호출하여 ready 게이트 진입 (resolveReady + readyTimer 등록)
+      void transport.send(makeEnvelope('req-rg-8')).catch(() => { /* close로 reject 예상 */ })
+      await Promise.resolve()
+
+      // close 호출 — 모든 ready state cleanup
+      await transport.close()
+
+      const t = transport as unknown as {
+        readyTimer: unknown
+        readyPromise: unknown
+        resolveReady: unknown
+      }
+      expect(t.readyTimer).toBeNull()
+      expect(t.readyPromise).toBeNull()
+      expect(t.resolveReady).toBeNull()
     })
   })
 })


### PR DESCRIPTION
## Objective

`m07-02-connector-popup-ready-gate`

popup race 해결을 위한 connector 측 ready 게이트(B Gate) + Y Timeout fallback 구현. m07-01(sdk `_ready` 송신)과 페어로 작동하나, `readyTimeoutMs` fallback으로 m07-01 미배포 환경에서도 backward-compat.

## Background

`localhost:5173` Vite dev에서 connector v2 playground Connect 클릭 시 'Handshake timed out after 60000ms' 재현. v1과 protocol 방향이 반대로 뒤집혀 있어, sdk popup React mount 전에 connector handshake가 발사되면서 sdk listener가 못 받음. v1 패턴을 v2에 mirror하여 sdk-initiated `_ready` 신호를 도입.

## Changes

### `src/transport/PopupTransport.ts`
- `PopupTransportOptions.readyTimeoutMs?: number` 추가 (default 10000)
  - 생성자에서 boundary-validation: 양의 유한 number만 허용 (`-1`/`NaN`/`0`/non-number → `INVALID_PARAMS` throw)
- `ReadySignal` 인터페이스 export — `{ type: '_ready', version, serverName }` wire format
- `ensureReady()` private 헬퍼 — readyPromise 공유로 다중 send 시 1회만 대기
  - `_ready` 수신 시 resolveReady → handshake 진행
  - readyTimeoutMs 만료 시 silent resolve → handshake 즉시 송신 (Y fallback)
- `messageListener`에 `_ready` envelope 분기 추가 — id/method 부재인 신호 메시지 인식 (boundary-validation: version/serverName string 검증)
- `send()` 진입 시 `ensurePopup` 직후, `ensureHandshake` **이전**에 `await this.ensureReady()` 삽입
- `close()`에 readyTimer/readyPromise/resolveReady 정리 추가
- `preHandshakeRejecters: Set<reject>` 도입 — 게이트 도중 close()가 호출되면 in-flight send도 즉시 DISCONNECTED reject (close polling 호환성)

### `tests/unit/v2/transport/PopupTransport.test.ts`
- 신규 T-U-RG-01~08 (8건):
  - **T-U-RG-01**: B Gate happy path — `_ready` → `_handshake` → method round-trip
  - **T-U-RG-02**: Y Timeout fallback — `readyTimeoutMs: 50` 만료 후 handshake 즉시 송신
  - **T-U-RG-03**: `_ready` shape boundary-validation — version/serverName 누락 시 무시
  - **T-U-RG-04**: 다중 send → ready 대기 1회 공유 (in-flight Promise share)
  - **T-U-RG-05**: close 후 재오픈 시 새 ready 사이클
  - **T-U-RG-06**: `_ready` origin guard — 잘못된 origin은 무시
  - **T-U-RG-07**: `readyTimeoutMs` 옵션 검증 (default + override + invalid throw)
  - **T-U-RG-08**: close 시 readyTimer/readyPromise/resolveReady cleanup
- T-U-REG-01: `installHandshakeAutoRespond` helper에 `_ready` 자동 dispatch 추가 (window.addEventListener spy 패턴) → 기존 baseline 35건 회귀 0
- 기존 T-U-HS-01/05/10 test에 `flushHandshake()` 호출 추가 (게이트 1단계 추가에 따른 microtask flush 6 ticks로 확장)

### `tests/unit/2_v2_e2e/09_ready_signal.spec.ts` (신규)
- **T-E-RG-01**: `preOpenAndWait()` 우회 없이 `send` 즉시 호출 → fallback 또는 `_ready` 통과 round-trip 성공
- **T-E-RG-02**: `readyTimeoutMs: 100` + `preOpenAndWait` → 100ms fallback 후 round-trip 성공

## Verification

| 검증 | 결과 |
|---|---|
| `yarn unit-v2` (전체 v2) | **77/77 PASS** (PopupTransport 43건: baseline 35 + 신규 8) |
| `yarn unit-v2-e2e` (9 suites, 10 tests) | **10/10 PASS** (T-E-RG-01/02 포함) |
| `yarn tsc` | exit 0 |
| `yarn lint` | exit 0 |
| `yarn build` | success (3 webpack warnings — 기존) |

## Cross-repo Impact

postMessage 프로토콜에 신규 `_ready` 신호 분기 추가 — **backward-compatible**.

- m07-01 (sdk `_ready` 송신) 미배포 환경: connector는 `readyTimeoutMs` 만료 후 handshake fallback으로 정상 동작
- m07-01 배포 후: connector가 `_ready` 즉시 수신 → race 0
- 단독 머지 안전 (cross-repo-interface-edit 룰 — wire format 추가는 backward-compat)

## Rationale

v1과 protocol 방향이 반대로 뒤집혀 sdk popup React mount 전에 connector handshake가 발사되는 race 발견. 단순 retry는 fail-fast 정책과 충돌하므로 sdk-initiated handshake 패턴(B Gate)으로 v1 흐름 mirror. dApp 호환성 보존을 위해 Y Timeout fallback도 함께 도입.

## Tested

- Jest 단위: 43/43 PopupTransport (baseline 35 회귀 0 + 신규 8) + 전체 v2 77/77
- Jest+puppeteer e2e: 10/10 (신규 09_ready_signal.spec.ts 포함)
- tsc / lint / build 모두 통과

## Constraints

- `[no-ticker]` prefix 사용 — Atlassian MCP 미연결 환경의 parallel worker 컨텍스트로 Jira 티켓 생성 미수행. 머지 전 Jira 키 추가 필요.
- e2e T-E-RG-01은 m07-01 SDK 미배포 환경에서 Y fallback 경로(약 10s)로 통과. m07-01 머지 후 즉시 통과 경로로 자연 전환.

## DoD Checklist

- [x] `ensureReady` 게이트 / `_ready` 분기 / `readyTimeoutMs` 옵션 / close cleanup 모두 구현
- [x] T-U-RG-01~08 + T-U-REG-01 모두 작성 + 통과
- [x] T-E-RG-01, T-E-RG-02 e2e 통과
- [x] `yarn tsc` 통과
- [x] `yarn lint` 통과
- [x] `yarn build` 통과
- [x] PR diff < 600 LOC (471 LOC src/test 변경 + 신규 e2e spec)
- [x] PR description에 검증 결과 첨부 (이 본문)
- [ ] CI 모든 체크 통과
- [ ] 사람 머지 (objective-no-auto-merge — AI는 머지하지 않음)