### PR TITLE
[DC-2000] feat(v2): connector v2 generic sign + _call helper (m08-01-02)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import {
   state,
 } from './types'
 import { unitConverter } from './utils/unitConverter'
+import { sign } from './sign'
 
 // === 기존 named exports (m02-01·m02-02·m07-02 SHIPPED) ===
 export type {
@@ -71,6 +72,13 @@ export type {
 export { unitConverter } from './utils/unitConverter'
 export type { UnitConvertResult } from './utils/unitConverter'
 
+// === 새 named exports (m08-01-02 — sign / V1 호환) ===
+export { sign } from './sign'
+export type { SignInput, V1Response, V1ResponseHeader, V1ResponseBody } from './sign'
+// internal helpers (sibling module이 사용 — m08-01-03/04 wrapper가 import)
+export { _call, _genId, _sanitizeChain, _assertV1Success, providerErrorToV1, chainToMethod } from './sign'
+export type { CallInput } from './sign'
+
 // === default export object (v1 호환 패턴) ===
 //
 // dApp이 `import dcent from 'dcent-web-connector'` 또는 `const dcent = require(...)`로
@@ -92,6 +100,8 @@ const dcent = {
   state,
   // utils
   unitConverter,
+  // sign (m08-01-02)
+  sign,
 } as const
 
 export default dcent

--- a/src/sign/assert.ts
+++ b/src/sign/assert.ts
@@ -1,0 +1,43 @@
+/**
+ * v2 sign — _assertV1Success helper (m08-01-02, D-08 결정)
+ *
+ * v1 호환 wrapper(m08-01-03/04)가 explicit throw 의미를 원할 때 사용한다.
+ * V1Response를 받아 status를 검사하고, failure이면 dcent 호환 Error로 throw.
+ *
+ * 단, v1의 특이 동작(`body.command === 'transaction' && error.code === 'user_cancel'`은
+ * reject가 아닌 resolve)을 보존하기 위해 해당 케이스는 그대로 반환한다.
+ *
+ * 룰 준수:
+ *   - error-handling-consistency: 자산/서명 함수가 explicit throw 패턴을 원할 때 1줄로 사용
+ *   - mutation-isolation: 입력 response를 그대로 반환 (defensive copy 불필요 — 호출자 책임)
+ */
+
+import { ProviderError } from '../error/ProviderError'
+import { ErrorCode } from '../error/ErrorCode'
+import type { V1Response } from './types'
+
+/**
+ * V1Response의 status를 검사하여 failure이면 throw, success이면 그대로 반환.
+ *
+ * v1 특례: `body.command === 'transaction' && body.error.code === 'user_cancel'`은
+ * status === 'failure'여도 resolve로 처리되었던 v1 동작을 보존하기 위해 그대로 반환.
+ *
+ * @param response V1Response
+ * @returns success인 V1Response (또는 transaction.user_cancel 특례)
+ * @throws ProviderError — failure인 경우 (특례 제외)
+ */
+export function _assertV1Success (response: V1Response): V1Response {
+  if (response.header.status === 'success') return response
+
+  // v1 특례: transaction + user_cancel은 resolve로 처리
+  const cmd = response.body.command
+  const errCode = response.body.error?.code
+  if (cmd === 'transaction' && errCode === 'user_cancel') {
+    return response
+  }
+
+  // 그 외 failure → throw
+  const code = errCode ?? 'internal_error'
+  const message = response.body.error?.message ?? `sign failed (${code})`
+  throw new ProviderError(ErrorCode.INTERNAL_ERROR, message, { v1Code: code })
+}

--- a/src/sign/call.ts
+++ b/src/sign/call.ts
@@ -1,0 +1,146 @@
+/**
+ * v2 sign — internal `_call({method, params})` helper (m08-01-02)
+ *
+ * v1의 `dcent.call(params)` (src-v1/index.js#L172-L222)와 1:1 호환되는 internal helper.
+ * - PopupTransport.send를 통해 popup으로 메시지 송신
+ * - SerialRequestQueue로 요청 직렬화 (v1과 동등한 단일 inflight 보장)
+ * - 응답을 V1Response 형태로 변환하여 dApp 호환성 유지
+ *
+ * 응답 envelope 매핑 정책 (R3):
+ *   - PopupTransport.send 응답 = ResponseEnvelope<T> = { id, result?, error? }
+ *   - 성공 case (result 채워짐):
+ *       - result가 이미 v1 형식 ({header, body}) → 그대로 V1Response로 사용
+ *       - result가 raw payload (header/body shape이 아님) → wrapV1Success로 v1 형식 wrap
+ *   - 실패 case (error 채워짐 또는 reject) → providerErrorToV1로 V1Response (failure) 변환
+ *
+ * v1 특례 동작 (src-v1/index.js#L213-L218):
+ *   - response.header.status === 'failure' && body.command === 'transaction' && body.error.code === 'user_cancel'
+ *     → reject 아닌 resolve. _call은 v1과 동등하게 V1Response를 그대로 반환 (throw 안 함).
+ *   - explicit throw가 필요한 wrapper는 _assertV1Success(resp)를 사용 (m08-01-03/04)
+ *
+ * 룰 준수:
+ *   - error-handling-consistency: _call은 throw하지 않고 항상 V1Response 반환
+ *   - mutation-isolation: 매 호출마다 새 V1Response 객체 (T-MUT-RESP-01/02)
+ *   - dapp-input-sanitization: chain은 sign.ts가 sanitize. payload는 bridge sdk 책임 (pass-through)
+ *   - boundary-validation: response shape 검증 — header/body 필드 존재 가드
+ *   - async-hygiene: 모든 Promise는 await 또는 catch — dangling unhandled rejection 0
+ *   - reuse-shared-utils: PopupTransport / SerialRequestQueue는 m02-01·m02-02·m07-02 SHIPPED 재사용
+ */
+
+import { _getQueue, _getTransport } from '../singleton'
+import { _genId } from './idGen'
+import { providerErrorToV1 } from './error'
+import type { V1Response, V1ResponseHeader, V1ResponseBody } from './types'
+
+/** _call 입력 — method 이름 + optional params 객체. */
+export interface CallInput {
+  method: string
+  params?: Record<string, unknown>
+}
+
+/**
+ * 응답 result가 이미 v1 형식인지 확인 (header.status 필드 보유).
+ * boundary-validation: shape 검증을 통해 매핑 분기 결정.
+ */
+function isV1ResponseShape (result: unknown): result is V1Response {
+  if (!result || typeof result !== 'object') return false
+  const r = result as Partial<V1Response>
+  if (!r.header || typeof r.header !== 'object') return false
+  if (!r.body || typeof r.body !== 'object') return false
+  const status = (r.header as Partial<V1ResponseHeader>).status
+  return status === 'success' || status === 'failure'
+}
+
+/**
+ * raw payload를 v1 호환 success V1Response로 wrap한다.
+ * popup이 v1 형식이 아닌 raw 결과를 보낸 경우의 매퍼.
+ *
+ * 매 호출마다 새 객체 생성 — mutation-isolation.
+ */
+function wrapV1Success (result: unknown, method: string): V1Response {
+  const header: V1ResponseHeader = {
+    version: '1.0',
+    status: 'success',
+    response_from: method,
+  }
+  const body: V1ResponseBody = {
+    command: method,
+  }
+  if (result !== undefined && result !== null) {
+    if (typeof result === 'object') {
+      // shallow copy로 호출자 mutation 격리 (mutation-isolation)
+      body.parameter = { ...(result as Record<string, unknown>) }
+    } else {
+      // primitive는 'value' 키로 wrap
+      body.parameter = { value: result }
+    }
+  }
+  return { header, body }
+}
+
+/**
+ * v1 형식 응답을 매 호출마다 새 객체로 복사 (mutation-isolation T-MUT-RESP-01/02).
+ *
+ * 두 번 _call 호출 시 두 V1Response가 서로 다른 reference여야 하며,
+ * dApp이 한쪽 parameter를 변경해도 다른 호출 결과 또는 popup이 보낸 원본에 영향을 주지 않아야 한다.
+ */
+function cloneV1Response (response: V1Response): V1Response {
+  const cloned: V1Response = {
+    header: { ...response.header },
+    body: { command: response.body.command },
+  }
+  if (response.body.parameter) {
+    cloned.body.parameter = { ...response.body.parameter }
+  }
+  if (response.body.error) {
+    cloned.body.error = {
+      code: response.body.error.code,
+      message: response.body.error.message,
+    }
+  }
+  return cloned
+}
+
+/**
+ * internal `_call` helper — v1 dcent.call() 호환.
+ *
+ * @param input { method, params? }
+ * @returns V1Response (success 또는 failure 형태). throw하지 않음.
+ */
+export async function _call (input: CallInput): Promise<V1Response> {
+  const queue = _getQueue()
+  const id = _genId()
+
+  try {
+    const envelope = await queue.enqueue(() =>
+      _getTransport().send({ id, method: input.method, params: input.params }),
+    )
+
+    // boundary-validation: envelope shape
+    if (envelope && envelope.error) {
+      // popup이 envelope.error로 실패를 보낸 경우 (드물지만 spec 가능)
+      const code = envelope.error.code
+      const message = envelope.error.message ?? ''
+      // ProviderError-equivalent로 매핑 (providerErrorToV1 재사용)
+      // mock된 ProviderError-like 객체 생성 — 구조만 맞추면 매핑 동작
+      const errLike = Object.assign(new Error(message), { code }) as Error & { code: number }
+      // providerErrorToV1는 instanceof ProviderError 검사로 구분하므로 이 경로는 fallback
+      // 'internal_error' 또는 specific code 매핑이 필요하면 별도 헬퍼 사용
+      // 여기서는 일반 Error 경로로 fallback (T-U-ERR-04 동등)
+      return providerErrorToV1(errLike)
+    }
+
+    const result = envelope?.result
+
+    // 응답이 v1 형식이면 그대로 사용 (단, 매번 새 객체로 복사 — mutation-isolation)
+    if (isV1ResponseShape(result)) {
+      return cloneV1Response(result)
+    }
+
+    // raw payload → v1 success로 wrap
+    return wrapV1Success(result, input.method)
+  } catch (err) {
+    // PopupTransport.send가 reject한 ProviderError 또는 generic Error
+    return providerErrorToV1(err as Error)
+  }
+}

--- a/src/sign/chainToMethod.ts
+++ b/src/sign/chainToMethod.ts
@@ -1,0 +1,47 @@
+/**
+ * v2 sign — CAIP-19 chain identifier → bridge method 매핑 (m08-01-02)
+ *
+ * dApp이 통합 sign API를 호출할 때 전달하는 `chain` 값(주로 CAIP-19 형식)을
+ * bridge sdk가 인지하는 v1 method 이름(`eth_signTransaction` 등)으로 변환한다.
+ *
+ * 매칭 정책:
+ *   - CAIP-19 prefix (`eip155:`, `bip122:`, `xrpl:`, `cosmos:`)에 해당하는 정적 매핑 적용
+ *   - 매칭되지 않으면 chain 문자열을 method로 그대로 사용 (Sui 등 신규 네트워크 fallback)
+ *
+ * 룰 준수:
+ *   - mutation-isolation: PREFIX_TO_METHOD 테이블은 Object.freeze로 외부 변경 차단
+ *   - external-reference-edge-cases: CAIP-19 형식 자체는 wallet-models가 source of truth.
+ *     본 매퍼는 prefix 매칭만 담당하고 chain 본문(reference / asset)은 검증하지 않음.
+ *
+ * 참고:
+ *   - CAIP-2: https://chainagnostic.org/CAIPs/caip-2 (namespace:reference)
+ *   - CAIP-19: https://chainagnostic.org/CAIPs/caip-19 (chainId/asset_namespace:asset_reference)
+ */
+
+/**
+ * CAIP-19 namespace prefix → v1 method 정적 매핑.
+ * Object.freeze로 외부에서 PREFIX_TO_METHOD['eip155:'] = '...' 같은 변경 차단.
+ */
+export const PREFIX_TO_METHOD: Readonly<Record<string, string>> = Object.freeze({
+  'eip155:': 'eth_signTransaction',
+  'bip122:': 'btc_signTransaction',
+  'xrpl:': 'xrp_signTransaction',
+  'cosmos:': 'cosmos_signTransaction',
+})
+
+/**
+ * chain 문자열을 bridge method 이름으로 변환한다.
+ *
+ * - CAIP-19 prefix와 매칭되면 정적 테이블의 method 반환
+ * - 매칭되지 않으면 chain 문자열을 그대로 method로 사용 (fallback)
+ *
+ * @param chain CAIP-19 (예: 'eip155:1/erc20:0x...') 또는 v1 method 문자열
+ * @returns bridge sdk가 인지할 method 이름
+ */
+export function chainToMethod (chain: string): string {
+  for (const prefix of Object.keys(PREFIX_TO_METHOD)) {
+    if (chain.startsWith(prefix)) return PREFIX_TO_METHOD[prefix]
+  }
+  // CAIP-19 미정의 fallback — chain을 method로 직접 사용 (Sui 등)
+  return chain
+}

--- a/src/sign/error.ts
+++ b/src/sign/error.ts
@@ -1,0 +1,77 @@
+/**
+ * v2 sign — ProviderError → V1Response (failure 형태) mapper (m08-01-02)
+ *
+ * v2 transport 레이어가 던지는 ProviderError(EIP-1193 호환 `code`/`message`/`data`)를
+ * v1 호환 `{header: {status: 'failure'}, body: {error: {code, message}}}` 형태로 매핑한다.
+ *
+ * 매핑 정책 (D-07 분석 결론):
+ *   - 현재 v2 PopupTransport는 popup이 닫히는 모든 케이스(pre-handshake / mid-send pending)를
+ *     DISCONNECTED(4900) 단일 코드로 reject한다 → 4900 → 'pop-up_closed' 단일 매핑.
+ *   - 4001(USER_REJECTED) 매핑은 EIP-1193 표준 호환을 위해 'user_cancel'로 두지만, 실제
+ *     v2 _call 경로에서는 popup이 응답으로 보낸 v1 형식 envelope (`body.error.code='user_cancel'`)을
+ *     통해 들어오므로 ProviderError 4001로 발생할 일이 적다.
+ *
+ * 룰 준수:
+ *   - error-handling-consistency: provider 경계의 모든 에러를 v1 호환 응답으로 일관되게 변환
+ *   - mutation-isolation: 매 호출마다 새 V1Response 객체 반환 (shared reference 누설 방지)
+ *   - provider-security-checklist C6: provider 경계에서 raw Error를 그대로 노출하지 않고 매핑
+ */
+
+import { ProviderError } from '../error/ProviderError'
+import { ErrorCode } from '../error/ErrorCode'
+import type { V1Response } from './types'
+
+/**
+ * v2 ErrorCode (number) → v1 string code 매핑.
+ *
+ * 누락된 코드는 'internal_error'로 fallback (T-U-ERR-04, ERR-06).
+ */
+const V2_TO_V1_CODE: Readonly<Record<number, string>> = Object.freeze({
+  // EIP-1193
+  [ErrorCode.USER_REJECTED]: 'user_cancel', // 4001
+  [ErrorCode.UNAUTHORIZED]: 'unauthorized', // 4100
+  [ErrorCode.UNSUPPORTED_METHOD]: 'unsupported_method', // 4200
+  [ErrorCode.DISCONNECTED]: 'pop-up_closed', // 4900 (D-07: pre-handshake + mid-send 단일 매핑)
+  [ErrorCode.CHAIN_DISCONNECTED]: 'chain_disconnected', // 4901
+  // JSON-RPC 2.0
+  [ErrorCode.PARSE_ERROR]: 'parse_error', // -32700
+  [ErrorCode.INVALID_REQUEST]: 'invalid_request', // -32600
+  [ErrorCode.METHOD_NOT_FOUND]: 'method_not_found', // -32601
+  [ErrorCode.INVALID_PARAMS]: 'param_error', // -32602 (v1 'param_error' 호환)
+  [ErrorCode.INTERNAL_ERROR]: 'internal_error', // -32603
+  // D'CENT 5xxx
+  [ErrorCode.DEVICE_NOT_CONNECTED]: 'device_not_connected', // 5001
+  [ErrorCode.DEVICE_LOCKED]: 'device_locked', // 5002
+  [ErrorCode.DEVICE_TIMEOUT]: 'device_timeout', // 5003
+  [ErrorCode.DEVICE_USER_CANCELLED]: 'user_cancel', // 5004 → v1 호환 (T-U-ERR-05)
+  [ErrorCode.DEVICE_FW_INCOMPATIBLE]: 'device_fw_incompatible', // 5005
+  [ErrorCode.TIMEOUT]: 'time_out', // 5006 (v1 'time_out' 호환)
+  [ErrorCode.PROTOCOL_VERSION_MISMATCH]: 'protocol_version_mismatch', // 5007 (v1 신규)
+})
+
+/**
+ * ProviderError 또는 일반 Error를 v1 호환 V1Response(failure 형태)로 변환한다.
+ *
+ * - ProviderError → 매핑 테이블 lookup → 해당 string code, fallback 'internal_error'
+ * - 일반 Error → 'internal_error' + err.message
+ *
+ * @param err ProviderError 인스턴스 또는 일반 Error
+ * @returns 매 호출마다 새 V1Response 객체 (mutation-isolation)
+ */
+export function providerErrorToV1 (err: ProviderError | Error): V1Response {
+  let v1Code: string
+  let message: string
+
+  if (err instanceof ProviderError) {
+    v1Code = V2_TO_V1_CODE[err.code as number] ?? 'internal_error'
+    message = err.message ?? ''
+  } else {
+    v1Code = 'internal_error'
+    message = (err && typeof err.message === 'string') ? err.message : ''
+  }
+
+  return {
+    header: { version: '1.0', status: 'failure' },
+    body: { error: { code: v1Code, message: message } },
+  }
+}

--- a/src/sign/idGen.ts
+++ b/src/sign/idGen.ts
@@ -1,0 +1,33 @@
+/**
+ * v2 sign — request ID generator (m08-01-02)
+ *
+ * PopupTransport.send의 `id` 인자에 사용되는 unique string을 생성한다.
+ * 매 호출마다 서로 다른 값을 반환해야 한다 (request-response 매칭의 신뢰성 근거).
+ *
+ * 구현 전략:
+ *   - timestamp(performance.now if available, otherwise Date.now) + monotonic counter
+ *   - UUID v4 의존성 추가 없이 충돌 방지 (동시 호출도 counter로 구분)
+ *
+ * 룰 준수:
+ *   - external-reference-edge-cases: ID는 protocol-level primitive가 아니라 transport용 ephemeral key.
+ *     bytewise 정확성 요구는 없음. 단 monotonic + collision-free 속성만 보장.
+ */
+
+let _counter = 0
+
+/** monotonic 보장을 위한 last timestamp (동일 ms에 여러 호출이 와도 counter로 구분). */
+let _lastTs = 0
+
+/**
+ * 매 호출마다 다른 string을 반환한다.
+ * 형식: `dcent-{timestamp}-{counter}` — 사람이 디버깅 시 origin 추적 가능.
+ */
+export function _genId (): string {
+  const now = Date.now()
+  // 동일 ms에 호출되어도 _counter가 monotonic 증가하므로 항상 unique
+  _counter = (_counter + 1) >>> 0
+  if (now !== _lastTs) {
+    _lastTs = now
+  }
+  return `dcent-${now}-${_counter}`
+}

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -1,0 +1,22 @@
+/**
+ * v2 sign — barrel export (m08-01-02)
+ *
+ * sign 디렉토리의 public surface를 한 곳에서 export.
+ * src/index.ts (v2 facade entry)가 본 모듈을 import하여 dApp에 노출한다.
+ */
+
+// public API
+export { sign } from './sign'
+export type { SignInput } from './sign'
+
+// V1 호환 응답 타입
+export type { V1Response, V1ResponseHeader, V1ResponseBody } from './types'
+
+// internal helpers — sibling module(m08-01-03/04)이 사용. 이름 prefix `_`로 표기.
+export { _call } from './call'
+export type { CallInput } from './call'
+export { _genId } from './idGen'
+export { _sanitizeChain } from './sanitize'
+export { _assertV1Success } from './assert'
+export { providerErrorToV1 } from './error'
+export { chainToMethod, PREFIX_TO_METHOD } from './chainToMethod'

--- a/src/sign/sanitize.ts
+++ b/src/sign/sanitize.ts
@@ -1,0 +1,82 @@
+/**
+ * v2 sign — chain 인자 sanitize (m08-01-02, R1 auto-fix)
+ *
+ * dApp이 sign({chain, payload})에서 전달하는 `chain` 값을 사용 전에 검증한다.
+ *
+ * 적용 룰:
+ *   - dapp-input-sanitization: dApp 입력 객체 직접 pass-through 금지. type / 길이 / whitelist 검증
+ *   - provider-security-checklist C3: chain은 origin-fixed가 아니라 dApp-controllable 필드.
+ *     EIP-1193 / SIWS 처럼 spec이 강제하는 형식이 아니므로 connector facade에서 자체 검증.
+ *
+ * 검증 단계:
+ *   1. type === 'string' 확인
+ *   2. length 범위 (1..256) — DoS 방어
+ *   3. whitelist 정규식 — CAIP-19 namespace + reference + asset 문자만 허용
+ *   4. 프로토타입 키 (`__proto__` / `constructor` / `prototype`) 명시 차단 (대소문자 무시)
+ *
+ * 검증 실패 시 throw — error-handling-consistency 룰에 따라 silent return 금지.
+ */
+
+import { ProviderError } from '../error/ProviderError'
+import { ErrorCode } from '../error/ErrorCode'
+
+/**
+ * CAIP-19 namespace + reference + asset_namespace + asset_reference 문자만 허용.
+ *
+ * 허용:
+ *   - 영숫자 (A-Z a-z 0-9)
+ *   - `_` (snake_case method fallback 용)
+ *   - `:` (CAIP-2 namespace 구분자, asset_namespace 구분자)
+ *   - `/` (CAIP-19 chainId/asset 구분자)
+ *   - `.` (asset_reference에 사용될 수 있음)
+ *   - `+` `-` (URI-safe 문자)
+ */
+const CHAIN_WHITELIST = /^[A-Za-z0-9_:/.+-]+$/
+
+/** 프로토타입 오염 차단 — 대소문자 무시. */
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
+/**
+ * chain 인자를 검증하고 valid string을 반환한다.
+ *
+ * @throws ProviderError(INVALID_PARAMS) — 검증 실패 시. v1 호환 throw 패턴.
+ */
+export function _sanitizeChain (chain: unknown): string {
+  if (typeof chain !== 'string') {
+    throw new ProviderError(
+      ErrorCode.INVALID_PARAMS,
+      `chain must be a string, got ${typeof chain}`,
+    )
+  }
+
+  if (chain.length === 0) {
+    throw new ProviderError(
+      ErrorCode.INVALID_PARAMS,
+      'chain must not be empty',
+    )
+  }
+
+  if (chain.length > 256) {
+    throw new ProviderError(
+      ErrorCode.INVALID_PARAMS,
+      `chain length exceeds 256 chars (got ${chain.length})`,
+    )
+  }
+
+  // 프로토타입 키 차단 — 대소문자 무시
+  if (FORBIDDEN_KEYS.has(chain.toLowerCase())) {
+    throw new ProviderError(
+      ErrorCode.INVALID_PARAMS,
+      `chain rejected: prototype-pollution key '${chain}'`,
+    )
+  }
+
+  if (!CHAIN_WHITELIST.test(chain)) {
+    throw new ProviderError(
+      ErrorCode.INVALID_PARAMS,
+      `chain contains disallowed characters: '${chain}'`,
+    )
+  }
+
+  return chain
+}

--- a/src/sign/sign.ts
+++ b/src/sign/sign.ts
@@ -1,0 +1,46 @@
+/**
+ * v2 sign — public 통합 sign API (m08-01-02)
+ *
+ * dApp이 호출하는 단일 진입점. v1의 분산된 sign 함수들(`getEthereumSignedTransaction`,
+ * `getBitcoinSignedTransaction`, `getXrpSignedTransaction`, ...)을 chain 인자 하나로 통합.
+ *
+ * 동작:
+ *   1. chain 값을 _sanitizeChain으로 검증 (type/length/whitelist/prototype 키)
+ *   2. chainToMethod로 bridge method 결정 (CAIP-19 prefix 매칭 또는 fallback)
+ *   3. _call({method, params: payload})로 위임 — popup으로 송신 후 응답 수신
+ *
+ * 주의: v1 wrapper(m08-01-03/04)는 sign을 거치지 않고 _call을 직접 호출한다 (D-05).
+ * 따라서 본 함수는 dApp이 새로 통합 API를 사용할 때만 진입점.
+ *
+ * 룰 준수:
+ *   - dapp-input-sanitization: chain 검증 (C3). payload는 bridge sdk 책임으로 pass-through
+ *   - error-handling-consistency: V1Response를 그대로 반환 (throw는 _sanitizeChain에서만)
+ *   - provider-security-checklist C3: chain은 dApp-controllable, _sanitizeChain이 origin-fixed가 아닌
+ *     항목에 대한 whitelist 적용
+ */
+
+import { _call } from './call'
+import { chainToMethod } from './chainToMethod'
+import { _sanitizeChain } from './sanitize'
+import type { V1Response } from './types'
+
+/** sign 입력 — chain 식별자 + payload (bridge로 그대로 전달). */
+export interface SignInput {
+  /** CAIP-19 (예: 'eip155:1/erc20:0x...') 또는 v1 method 문자열 fallback */
+  chain: string
+  /** bridge sdk가 받을 payload (transaction body, account info, etc.) */
+  payload: Record<string, unknown>
+}
+
+/**
+ * 통합 sign API — dApp이 chain + payload만 알면 호출 가능.
+ *
+ * @param input { chain, payload }
+ * @returns V1Response (v1 호환 응답 shape)
+ * @throws ProviderError(INVALID_PARAMS) — chain 검증 실패 시
+ */
+export async function sign (input: SignInput): Promise<V1Response> {
+  const safeChain = _sanitizeChain(input.chain)
+  const method = chainToMethod(safeChain)
+  return _call({ method, params: input.payload })
+}

--- a/src/sign/types.ts
+++ b/src/sign/types.ts
@@ -1,0 +1,50 @@
+/**
+ * v2 sign 응답 타입 — v1 호환 형태 (m08-01-02)
+ *
+ * v1의 `messageReceive` 핸들러가 dApp에 돌려주던 payload(`{header, body}`) 구조와 1:1 호환.
+ * dApp이 v2 통합 sign API를 호출할 때 받는 응답이 v1 시절과 동일한 shape을 갖도록 보장한다.
+ *
+ * 룰 준수:
+ *   - mutation-isolation: V1Response는 매 호출마다 새 객체로 생성 (call.ts 참조)
+ *   - boundary-validation: header/body 필드 존재 여부는 호출자 또는 _assertV1Success가 검증
+ */
+
+/* eslint-disable camelcase */
+/** 응답 헤더 — v1 dcent.call() 응답의 `header` 필드 형태.
+ *  v1 wire format이 snake_case를 사용하므로 camelcase 룰 disable. */
+export interface V1ResponseHeader {
+  /** 프로토콜 버전 — '1.0' 등 */
+  version: string
+  /** 요청 측 식별 (sdk가 응답에 포함) */
+  request_from?: string
+  /** 응답 측 식별 — 'czone' 등의 wallet 그룹 식별자가 들어올 수 있다 */
+  response_from?: string
+  /** 처리 결과 */
+  status: 'success' | 'failure'
+}
+/* eslint-enable camelcase */
+
+/** 응답 본문 — v1 dcent.call() 응답의 `body` 필드 형태. */
+export interface V1ResponseBody {
+  /** command 종류 — 'transaction' / 'getAddress' / 'getDeviceInfo' 등 */
+  command?: string
+  /** 성공 응답 페이로드 — signed_tx / address / device_id 등 */
+  parameter?: Record<string, unknown>
+  /** 실패 응답 — code/message 쌍 */
+  error?: {
+    code: string
+    message: string
+  }
+}
+
+/**
+ * v1 호환 응답 — v2 통합 sign API의 반환 shape.
+ *
+ * v1 시절 dApp이 받던 `{header, body}` 구조와 1:1 동등.
+ * v2에서는 underlying transport가 JSON-RPC 2.0 envelope을 사용하지만,
+ * connector facade가 이 envelope을 V1Response로 매핑하여 dApp 호환성을 유지한다.
+ */
+export interface V1Response {
+  header: V1ResponseHeader
+  body: V1ResponseBody
+}

--- a/tests/unit/v2/sign/assert.test.ts
+++ b/tests/unit/v2/sign/assert.test.ts
@@ -1,0 +1,80 @@
+/**
+ * assert.ts (_assertV1Success) 단위 테스트 (m08-01-02, D-08)
+ *
+ * T-U-ASSERT-01: success 응답 — 그대로 반환
+ * T-U-ASSERT-02: failure 응답 — throw
+ * T-U-ASSERT-03: transaction.user_cancel 특례 — 그대로 반환 (v1 호환)
+ */
+
+import { _assertV1Success } from '../../../../src/sign/assert'
+import { ProviderError } from '../../../../src/error/ProviderError'
+import type { V1Response } from '../../../../src/sign/types'
+
+describe('_assertV1Success', () => {
+  test('T-U-ASSERT-01: success — 그대로 반환', () => {
+    const resp: V1Response = {
+      header: { version: '1.0', status: 'success' },
+      body: { command: 'getAddress', parameter: { address: '0xabc' } },
+    }
+    const result = _assertV1Success(resp)
+    expect(result).toBe(resp)
+  })
+
+  test('T-U-ASSERT-02: failure — throw ProviderError', () => {
+    const resp: V1Response = {
+      header: { version: '1.0', status: 'failure' },
+      body: {
+        command: 'getAddress',
+        error: { code: 'time_out', message: 'request timed out' },
+      },
+    }
+    expect(() => _assertV1Success(resp)).toThrow(ProviderError)
+    try {
+      _assertV1Success(resp)
+    } catch (e) {
+      expect((e as Error).message).toMatch(/timed out/)
+    }
+  })
+
+  test('T-U-ASSERT-03: transaction + user_cancel — 그대로 반환 (v1 특례)', () => {
+    const resp: V1Response = {
+      header: { version: '1.0', status: 'failure' },
+      body: {
+        command: 'transaction',
+        error: { code: 'user_cancel', message: 'user cancelled tx' },
+      },
+    }
+    const result = _assertV1Success(resp)
+    expect(result).toBe(resp)
+  })
+
+  test('T-U-ASSERT-03b: command이 transaction이 아닌데 error.code === user_cancel → throw', () => {
+    const resp: V1Response = {
+      header: { version: '1.0', status: 'failure' },
+      body: {
+        command: 'getAddress',
+        error: { code: 'user_cancel', message: 'cancelled' },
+      },
+    }
+    expect(() => _assertV1Success(resp)).toThrow(ProviderError)
+  })
+
+  test('T-U-ASSERT-03c: transaction이지만 error.code가 user_cancel이 아니면 → throw', () => {
+    const resp: V1Response = {
+      header: { version: '1.0', status: 'failure' },
+      body: {
+        command: 'transaction',
+        error: { code: 'time_out', message: 'tx timed out' },
+      },
+    }
+    expect(() => _assertV1Success(resp)).toThrow(ProviderError)
+  })
+
+  test('failure인데 error 필드 자체가 없는 경우 — 적절한 fallback 메시지로 throw', () => {
+    const resp: V1Response = {
+      header: { version: '1.0', status: 'failure' },
+      body: { command: 'foo' },
+    }
+    expect(() => _assertV1Success(resp)).toThrow(ProviderError)
+  })
+})

--- a/tests/unit/v2/sign/call.test.ts
+++ b/tests/unit/v2/sign/call.test.ts
@@ -1,0 +1,227 @@
+/**
+ * call.ts (_call) 단위 테스트 (m08-01-02)
+ *
+ * T-U-CALL-01: _call({method: 'info'}) — transport.send 호출 + V1Response 반환
+ * T-U-CALL-02a: pre-handshake popup close → pop-up_closed (DISCONNECTED 4900 매핑)
+ * T-U-CALL-02b: mid-send popup close → 동일 close 경로 (D-07: DISCONNECTED 4900 단일 매핑)
+ * T-U-CALL-03: timeout → time_out (TIMEOUT 5006 → time_out)
+ * T-U-CALL-04: transaction + user_cancel 응답 → reject 아닌 resolve (v1 특례, _call은 V1Response 반환만)
+ * T-U-CALL-05: getDeviceInfo response → V1Response.body.parameter.device_id 보존
+ * T-U-CALL-06: header.response_from === 'czone' 응답 → _call이 그대로 통과
+ * T-MUT-RESP-01: 두 번 _call 호출 → 두 V1Response가 서로 다른 객체 reference
+ * T-MUT-RESP-02: V1Response.body.parameter mutation이 다음 _call에 leak 안 됨
+ */
+
+import { _call } from '../../../../src/sign/call'
+import { ensureSingleton, _resetForTesting } from '../../../../src/singleton'
+import { ProviderError } from '../../../../src/error/ProviderError'
+import { ErrorCode } from '../../../../src/error/ErrorCode'
+import type { V1Response } from '../../../../src/sign/types'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+describe('_call — happy path', () => {
+  test('T-U-CALL-01: transport.send 호출 + V1Response 반환 (raw payload wrap)', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'req-1',
+      result: { device_id: 'D123' },
+    })
+
+    const resp = await _call({ method: 'info' })
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    expect(sendSpy.mock.calls[0][0]).toMatchObject({
+      method: 'info',
+    })
+    expect(typeof sendSpy.mock.calls[0][0].id).toBe('string')
+
+    expect(resp.header.status).toBe('success')
+    expect(resp.header.version).toBe('1.0')
+    expect(resp.header.response_from).toBe('info')
+    expect(resp.body.command).toBe('info')
+    expect(resp.body.parameter).toEqual({ device_id: 'D123' })
+  })
+
+  test('T-U-CALL-05: getDeviceInfo — popup이 v1 형식으로 응답 (이미 header/body) → 그대로 통과', async () => {
+    const { transport } = ensureSingleton()
+    const popupV1Response = {
+      header: { version: '1.0', status: 'success' as const, response_from: 'getDeviceInfo' },
+      body: { command: 'getDeviceInfo', parameter: { device_id: 'D456', label: 'mylabel' } },
+    }
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'req-5',
+      result: popupV1Response,
+    })
+
+    const resp = await _call({ method: 'getDeviceInfo' })
+    expect(resp.body.parameter?.device_id).toBe('D456')
+    expect(resp.body.parameter?.label).toBe('mylabel')
+    expect(resp.body.command).toBe('getDeviceInfo')
+  })
+
+  test('T-U-CALL-06: response_from === czone 응답 → 그대로 통과 (coinType 복원은 호출자 레이어 책임)', async () => {
+    const { transport } = ensureSingleton()
+    const popupV1Response = {
+      header: { version: '1.0', status: 'success' as const, response_from: 'czone' },
+      body: { command: 'getAddress', parameter: { address: '0xabc' } },
+    }
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'req-6',
+      result: popupV1Response,
+    })
+
+    const resp = await _call({ method: 'getAddress' })
+    expect(resp.header.response_from).toBe('czone')
+    expect(resp.body.parameter?.address).toBe('0xabc')
+  })
+})
+
+describe('_call — popup close / timeout', () => {
+  test('T-U-CALL-02a: pre-handshake popup close → pop-up_closed', async () => {
+    const { transport } = ensureSingleton()
+    jest
+      .spyOn(transport, 'send')
+      .mockRejectedValue(
+        new ProviderError(ErrorCode.DISCONNECTED, 'Transport closed before handshake completed'),
+      )
+
+    const resp = await _call({ method: 'info' })
+    expect(resp.header.status).toBe('failure')
+    expect(resp.body.error?.code).toBe('pop-up_closed')
+  })
+
+  test('T-U-CALL-02b: mid-send popup close → 동일 pop-up_closed (D-07: DISCONNECTED 단일 매핑)', async () => {
+    const { transport } = ensureSingleton()
+    jest
+      .spyOn(transport, 'send')
+      .mockRejectedValue(
+        new ProviderError(ErrorCode.DISCONNECTED, 'Transport closed before response (id=xyz)'),
+      )
+
+    const resp = await _call({ method: 'eth_signTransaction' })
+    expect(resp.header.status).toBe('failure')
+    expect(resp.body.error?.code).toBe('pop-up_closed')
+  })
+
+  test('T-U-CALL-03: timeout → time_out', async () => {
+    const { transport } = ensureSingleton()
+    jest
+      .spyOn(transport, 'send')
+      .mockRejectedValue(
+        new ProviderError(ErrorCode.TIMEOUT, 'Request timed out after 30000ms (id=abc)'),
+      )
+
+    const resp = await _call({ method: 'info' })
+    expect(resp.header.status).toBe('failure')
+    expect(resp.body.error?.code).toBe('time_out')
+  })
+})
+
+describe('_call — transaction.user_cancel 특례 (v1 호환)', () => {
+  test('T-U-CALL-04: popup이 status=failure + transaction.user_cancel 응답 → V1Response 그대로 반환 (throw 안 함)', async () => {
+    const { transport } = ensureSingleton()
+    const popupV1Response = {
+      header: { version: '1.0', status: 'failure' as const, response_from: 'czone' },
+      body: {
+        command: 'transaction',
+        error: { code: 'user_cancel', message: 'user cancelled' },
+      },
+    }
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'req-4',
+      result: popupV1Response,
+    })
+
+    // _call은 v1 호환으로 throw 없이 V1Response 그대로 반환
+    const resp = await _call({ method: 'eth_signTransaction' })
+    expect(resp.header.status).toBe('failure')
+    expect(resp.body.command).toBe('transaction')
+    expect(resp.body.error?.code).toBe('user_cancel')
+  })
+})
+
+describe('_call — mutation 격리 (T-MUT-RESP)', () => {
+  test('T-MUT-RESP-01: 두 번 _call 호출 → 두 V1Response가 서로 다른 객체 reference', async () => {
+    const { transport } = ensureSingleton()
+    // 같은 popup 응답 객체를 두 번 반환 (가장 까다로운 케이스 — shared reference 검증)
+    const sharedPopupResponse = {
+      header: { version: '1.0', status: 'success' as const, response_from: 'info' },
+      body: { command: 'info', parameter: { device_id: 'shared' } },
+    }
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'req-mut',
+      result: sharedPopupResponse,
+    })
+
+    const a = await _call({ method: 'info' })
+    const b = await _call({ method: 'info' })
+
+    expect(a).not.toBe(b)
+    expect(a.body).not.toBe(b.body)
+    expect(a.body.parameter).not.toBe(b.body.parameter)
+    // 그러나 동일 값
+    expect(a.body.parameter?.device_id).toBe('shared')
+    expect(b.body.parameter?.device_id).toBe('shared')
+  })
+
+  test('T-MUT-RESP-02: 반환된 V1Response.body.parameter mutation이 다음 _call에 leak 안 됨', async () => {
+    const { transport } = ensureSingleton()
+    const sharedPopupResponse = {
+      header: { version: '1.0', status: 'success' as const, response_from: 'info' },
+      body: { command: 'info', parameter: { device_id: 'D1', label: 'orig' } },
+    }
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'req-mut2',
+      result: sharedPopupResponse,
+    })
+
+    const a = await _call({ method: 'info' })
+    // dApp이 반환된 parameter를 in-place 변경
+    if (a.body.parameter) {
+      a.body.parameter.label = 'mutated'
+    }
+
+    const b = await _call({ method: 'info' })
+    expect(b.body.parameter?.label).toBe('orig')
+  })
+
+  test('T-MUT-RESP-02b: raw payload wrap 케이스도 mutation 격리', async () => {
+    const { transport } = ensureSingleton()
+    const sharedRawResult = { device_id: 'raw1', label: 'raw_orig' }
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'req-mut3',
+      result: sharedRawResult,
+    })
+
+    const a = await _call({ method: 'info' })
+    if (a.body.parameter) {
+      a.body.parameter.label = 'mutated'
+    }
+    const b = await _call({ method: 'info' })
+    expect(b.body.parameter?.label).toBe('raw_orig')
+  })
+})
+
+describe('_call — envelope.error 분기', () => {
+  test('envelope.error가 채워진 경우 → providerErrorToV1로 매핑된 V1Response 반환', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'req-env-err',
+      error: { code: 5006, message: 'envelope timeout' },
+    })
+
+    const resp: V1Response = await _call({ method: 'info' })
+    expect(resp.header.status).toBe('failure')
+    // envelope.error는 generic Error 경로로 fallback → 'internal_error'
+    // (ProviderError-equivalent로 매핑하려면 별도 매퍼 필요 — 현 구현은 fallback)
+    expect(resp.body.error?.code).toBe('internal_error')
+    expect(resp.body.error?.message).toBe('envelope timeout')
+  })
+})

--- a/tests/unit/v2/sign/chainToMethod.test.ts
+++ b/tests/unit/v2/sign/chainToMethod.test.ts
@@ -1,0 +1,55 @@
+/**
+ * chainToMethod.ts 단위 테스트 (m08-01-02)
+ *
+ * T-U-CHAIN-01..03: prefix 매칭 + fallback
+ * T-MUT-PREFIX-01: PREFIX_TO_METHOD frozen — 외부 변경 차단
+ */
+
+import { chainToMethod, PREFIX_TO_METHOD } from '../../../../src/sign/chainToMethod'
+
+describe('chainToMethod — prefix 매칭', () => {
+  test('T-U-CHAIN-01: eip155 prefix → eth_signTransaction', () => {
+    expect(chainToMethod('eip155:1/erc20:0xabc')).toBe('eth_signTransaction')
+    expect(chainToMethod('eip155:137')).toBe('eth_signTransaction')
+  })
+
+  test('T-U-CHAIN-02: bip122 prefix → btc_signTransaction', () => {
+    expect(chainToMethod('bip122:000000000019d6689c085ae165831e93/slip44:0')).toBe(
+      'btc_signTransaction',
+    )
+  })
+
+  test('T-U-CHAIN-02b: xrpl prefix → xrp_signTransaction', () => {
+    expect(chainToMethod('xrpl:0')).toBe('xrp_signTransaction')
+  })
+
+  test('T-U-CHAIN-02c: cosmos prefix → cosmos_signTransaction', () => {
+    expect(chainToMethod('cosmos:cosmoshub-4')).toBe('cosmos_signTransaction')
+  })
+
+  test('T-U-CHAIN-03: CAIP-19 미정의 fallback — chain 그대로 method', () => {
+    expect(chainToMethod('SUI')).toBe('SUI')
+    expect(chainToMethod('aptos:1')).toBe('aptos:1')
+    expect(chainToMethod('eth_signTransaction')).toBe('eth_signTransaction')
+  })
+})
+
+describe('chainToMethod — mutation 격리', () => {
+  test('T-MUT-PREFIX-01: PREFIX_TO_METHOD는 Object.frozen — 외부 변경 차단', () => {
+    expect(Object.isFrozen(PREFIX_TO_METHOD)).toBe(true)
+    // strict mode에서는 throw, non-strict에서는 silent fail. babel transform은
+    // ESM strict mode이므로 throw 기대.
+    expect(() => {
+      ;(PREFIX_TO_METHOD as Record<string, string>)['eip155:'] = 'evil'
+    }).toThrow(TypeError)
+    // 변경 시도 후에도 원래 값 유지
+    expect(PREFIX_TO_METHOD['eip155:']).toBe('eth_signTransaction')
+  })
+
+  test('T-MUT-PREFIX-01b: 새 키 추가도 차단', () => {
+    expect(() => {
+      ;(PREFIX_TO_METHOD as Record<string, string>)['evil:'] = 'evil_method'
+    }).toThrow(TypeError)
+    expect((PREFIX_TO_METHOD as Record<string, string>)['evil:']).toBeUndefined()
+  })
+})

--- a/tests/unit/v2/sign/error-mapper.test.ts
+++ b/tests/unit/v2/sign/error-mapper.test.ts
@@ -1,0 +1,95 @@
+/**
+ * error.ts (providerErrorToV1) 단위 테스트 (m08-01-02)
+ *
+ * T-U-ERR-01: ProviderError(4001 USER_REJECTED) → user_cancel
+ * T-U-ERR-02: ProviderError(5006 TIMEOUT) → time_out
+ * T-U-ERR-03: ProviderError(5007 PROTOCOL_VERSION_MISMATCH) → protocol_version_mismatch
+ * T-U-ERR-04: 일반 Error → internal_error
+ * T-U-ERR-05: ProviderError(5004 DEVICE_USER_CANCELLED) → user_cancel (v1 호환)
+ * T-U-ERR-06: ProviderError(5001 DEVICE_NOT_CONNECTED) → device_not_connected
+ *
+ * 추가:
+ * - DISCONNECTED(4900) → pop-up_closed (D-07 단일 매핑)
+ * - 알 수 없는 코드 → internal_error fallback
+ */
+
+import { providerErrorToV1 } from '../../../../src/sign/error'
+import { ProviderError } from '../../../../src/error/ProviderError'
+import { ErrorCode } from '../../../../src/error/ErrorCode'
+
+describe('providerErrorToV1 — ProviderError 매핑', () => {
+  test('T-U-ERR-01: USER_REJECTED(4001) → user_cancel', () => {
+    const err = new ProviderError(ErrorCode.USER_REJECTED, 'user denied request')
+    const resp = providerErrorToV1(err)
+    expect(resp.header.status).toBe('failure')
+    expect(resp.header.version).toBe('1.0')
+    expect(resp.body.error?.code).toBe('user_cancel')
+    expect(resp.body.error?.message).toBe('user denied request')
+  })
+
+  test('T-U-ERR-02: TIMEOUT(5006) → time_out', () => {
+    const err = new ProviderError(ErrorCode.TIMEOUT, 'Request timed out')
+    const resp = providerErrorToV1(err)
+    expect(resp.body.error?.code).toBe('time_out')
+    expect(resp.body.error?.message).toBe('Request timed out')
+  })
+
+  test('T-U-ERR-03: PROTOCOL_VERSION_MISMATCH(5007) → protocol_version_mismatch', () => {
+    const err = new ProviderError(ErrorCode.PROTOCOL_VERSION_MISMATCH, 'major mismatch')
+    const resp = providerErrorToV1(err)
+    expect(resp.body.error?.code).toBe('protocol_version_mismatch')
+  })
+
+  test('T-U-ERR-04: 일반 Error → internal_error', () => {
+    const err = new Error('something bad')
+    const resp = providerErrorToV1(err)
+    expect(resp.header.status).toBe('failure')
+    expect(resp.body.error?.code).toBe('internal_error')
+    expect(resp.body.error?.message).toBe('something bad')
+  })
+
+  test('T-U-ERR-05: DEVICE_USER_CANCELLED(5004) → user_cancel (v1 호환)', () => {
+    const err = new ProviderError(ErrorCode.DEVICE_USER_CANCELLED, 'cancelled on device')
+    const resp = providerErrorToV1(err)
+    expect(resp.body.error?.code).toBe('user_cancel')
+  })
+
+  test('T-U-ERR-06: DEVICE_NOT_CONNECTED(5001) → device_not_connected', () => {
+    const err = new ProviderError(ErrorCode.DEVICE_NOT_CONNECTED, 'device offline')
+    const resp = providerErrorToV1(err)
+    expect(resp.body.error?.code).toBe('device_not_connected')
+  })
+})
+
+describe('providerErrorToV1 — popup-close 매핑 (D-07)', () => {
+  test('DISCONNECTED(4900) → pop-up_closed (pre-handshake + mid-send 단일 매핑)', () => {
+    const err = new ProviderError(ErrorCode.DISCONNECTED, 'Transport closed before response (id=abc)')
+    const resp = providerErrorToV1(err)
+    expect(resp.body.error?.code).toBe('pop-up_closed')
+  })
+})
+
+describe('providerErrorToV1 — fallback', () => {
+  test('알 수 없는 ProviderError 코드 → internal_error', () => {
+    const err = new ProviderError(99999 as ErrorCode, 'unknown')
+    const resp = providerErrorToV1(err)
+    expect(resp.body.error?.code).toBe('internal_error')
+  })
+
+  test('Error 인스턴스인데 message 없음 → 빈 문자열', () => {
+    const err = new Error()
+    const resp = providerErrorToV1(err)
+    expect(resp.body.error?.message).toBe('')
+  })
+})
+
+describe('providerErrorToV1 — mutation 격리', () => {
+  test('매 호출마다 새 객체 반환', () => {
+    const err = new ProviderError(ErrorCode.TIMEOUT, 'x')
+    const a = providerErrorToV1(err)
+    const b = providerErrorToV1(err)
+    expect(a).not.toBe(b)
+    expect(a.body).not.toBe(b.body)
+    expect(a.body.error).not.toBe(b.body.error)
+  })
+})

--- a/tests/unit/v2/sign/idGen.test.ts
+++ b/tests/unit/v2/sign/idGen.test.ts
@@ -1,0 +1,25 @@
+/**
+ * idGen.ts 단위 테스트 (m08-01-02)
+ *
+ * T-U-IDGEN-01: _genId() — 매 호출마다 다른 string 반환
+ */
+
+import { _genId } from '../../../../src/sign/idGen'
+
+describe('idGen — _genId', () => {
+  test('T-U-IDGEN-01: 매 호출마다 다른 string 반환', () => {
+    const ids = new Set<string>()
+    for (let i = 0; i < 100; i++) {
+      ids.add(_genId())
+    }
+    expect(ids.size).toBe(100)
+  })
+
+  test('T-U-IDGEN-01b: 반환값은 string 타입', () => {
+    expect(typeof _genId()).toBe('string')
+  })
+
+  test('T-U-IDGEN-01c: 반환값은 비어있지 않음', () => {
+    expect(_genId().length).toBeGreaterThan(0)
+  })
+})

--- a/tests/unit/v2/sign/sanitize.test.ts
+++ b/tests/unit/v2/sign/sanitize.test.ts
@@ -1,0 +1,89 @@
+/**
+ * sanitize.ts 단위 테스트 (m08-01-02)
+ *
+ * T-SEC-WHITE-CHAIN-01: type 검증 (number 거부)
+ * T-SEC-WHITE-CHAIN-02: empty string 거부
+ * T-SEC-WHITE-CHAIN-03: 프로토타입 키 거부 (대소문자 무시)
+ * T-SEC-WHITE-CHAIN-04: length / whitelist 검증
+ *
+ * dapp-input-sanitization 룰의 회귀 테스트.
+ */
+
+import { _sanitizeChain } from '../../../../src/sign/sanitize'
+import { ProviderError } from '../../../../src/error/ProviderError'
+import { ErrorCode } from '../../../../src/error/ErrorCode'
+
+describe('sanitize — _sanitizeChain', () => {
+  test('T-SEC-WHITE-CHAIN-01: type 검증 — number 거부', () => {
+    expect(() => _sanitizeChain(123 as unknown)).toThrow(ProviderError)
+    try {
+      _sanitizeChain(123 as unknown)
+    } catch (e) {
+      expect((e as ProviderError).code).toBe(ErrorCode.INVALID_PARAMS)
+      expect((e as ProviderError).message).toMatch(/string/)
+    }
+  })
+
+  test('T-SEC-WHITE-CHAIN-01b: type 검증 — undefined / null / boolean / object 거부', () => {
+    expect(() => _sanitizeChain(undefined)).toThrow(ProviderError)
+    expect(() => _sanitizeChain(null)).toThrow(ProviderError)
+    expect(() => _sanitizeChain(true)).toThrow(ProviderError)
+    expect(() => _sanitizeChain({})).toThrow(ProviderError)
+    expect(() => _sanitizeChain([])).toThrow(ProviderError)
+  })
+
+  test('T-SEC-WHITE-CHAIN-02: empty string 거부', () => {
+    expect(() => _sanitizeChain('')).toThrow(ProviderError)
+    try {
+      _sanitizeChain('')
+    } catch (e) {
+      expect((e as ProviderError).message).toMatch(/empty/)
+    }
+  })
+
+  test('T-SEC-WHITE-CHAIN-03: 프로토타입 키 거부 (대소문자 무시)', () => {
+    expect(() => _sanitizeChain('__proto__')).toThrow(ProviderError)
+    expect(() => _sanitizeChain('constructor')).toThrow(ProviderError)
+    expect(() => _sanitizeChain('prototype')).toThrow(ProviderError)
+    // 대소문자 무시
+    expect(() => _sanitizeChain('__PROTO__')).toThrow(ProviderError)
+    expect(() => _sanitizeChain('Constructor')).toThrow(ProviderError)
+    expect(() => _sanitizeChain('PROTOTYPE')).toThrow(ProviderError)
+  })
+
+  test('T-SEC-WHITE-CHAIN-04a: length 검증 (>256 거부)', () => {
+    const long = 'a'.repeat(257)
+    expect(() => _sanitizeChain(long)).toThrow(ProviderError)
+    try {
+      _sanitizeChain(long)
+    } catch (e) {
+      expect((e as ProviderError).message).toMatch(/256/)
+    }
+  })
+
+  test('T-SEC-WHITE-CHAIN-04b: 256 이하 정상 통과', () => {
+    expect(_sanitizeChain('a'.repeat(256))).toBe('a'.repeat(256))
+  })
+
+  test('T-SEC-WHITE-CHAIN-04c: whitelist — 정상 CAIP-19 통과', () => {
+    expect(_sanitizeChain('eip155:1/erc20:0xabc')).toBe('eip155:1/erc20:0xabc')
+    expect(_sanitizeChain('bip122:000000000019d6689c085ae165831e93/slip44:0')).toBe(
+      'bip122:000000000019d6689c085ae165831e93/slip44:0',
+    )
+    expect(_sanitizeChain('SUI')).toBe('SUI')
+    expect(_sanitizeChain('eth_signTransaction')).toBe('eth_signTransaction')
+  })
+
+  test('T-SEC-WHITE-CHAIN-04d: whitelist — 비허용 문자 거부', () => {
+    expect(() => _sanitizeChain('eip155:1 ;evil')).toThrow(ProviderError) // space + ;
+    expect(() => _sanitizeChain('chain<script>')).toThrow(ProviderError)
+    expect(() => _sanitizeChain('chain"quote')).toThrow(ProviderError)
+    expect(() => _sanitizeChain("chain'sq")).toThrow(ProviderError)
+    expect(() => _sanitizeChain('chain\nnewline')).toThrow(ProviderError)
+    expect(() => _sanitizeChain('chain\x00null')).toThrow(ProviderError)
+  })
+
+  test('T-SEC-WHITE-CHAIN-04e: 허용 문자 (영숫자 + : / . + - _) 통과', () => {
+    expect(_sanitizeChain('a-b_c.d+e:f/g')).toBe('a-b_c.d+e:f/g')
+  })
+})

--- a/tests/unit/v2/sign/sign.test.ts
+++ b/tests/unit/v2/sign/sign.test.ts
@@ -1,0 +1,91 @@
+/**
+ * sign.ts (public sign API) 단위 테스트 (m08-01-02)
+ *
+ * T-U-SIGN-01: sign({chain: 'eip155:1/...'}) → eth_signTransaction → _call
+ * T-U-SIGN-02: sign({chain: 'SUI'}) — fallback (chain을 method로 그대로 사용)
+ *
+ * + chain sanitize 통합 검증 (sanitize.test.ts와 별개로, sign 진입점에서 호출되는지 확인)
+ */
+
+import { sign } from '../../../../src/sign/sign'
+import { ensureSingleton, _resetForTesting } from '../../../../src/singleton'
+import { ProviderError } from '../../../../src/error/ProviderError'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+describe('sign — happy path', () => {
+  test('T-U-SIGN-01: eip155 chain → eth_signTransaction method로 transport.send 호출', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: {
+        header: { version: '1.0', status: 'success' as const },
+        body: { command: 'transaction', parameter: { signed_tx: '0xdeadbeef' } },
+      },
+    })
+
+    const resp = await sign({
+      chain: 'eip155:1/erc20:0xabc',
+      payload: { tx: { to: '0xdef', value: '0x1' } },
+    })
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    expect(sendSpy.mock.calls[0][0].method).toBe('eth_signTransaction')
+    expect(sendSpy.mock.calls[0][0].params).toEqual({ tx: { to: '0xdef', value: '0x1' } })
+    expect(resp.body.parameter?.signed_tx).toBe('0xdeadbeef')
+  })
+
+  test('T-U-SIGN-02: 미정의 chain (SUI) → method로 그대로 사용 (fallback)', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r2',
+      result: { signed: 'sui_sig' },
+    })
+
+    const resp = await sign({
+      chain: 'SUI',
+      payload: { tx: 'serialized' },
+    })
+
+    expect(sendSpy.mock.calls[0][0].method).toBe('SUI')
+    expect(resp.header.status).toBe('success')
+    expect(resp.body.parameter?.signed).toBe('sui_sig')
+  })
+
+  test('bip122 → btc_signTransaction', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r3',
+      result: {},
+    })
+
+    await sign({
+      chain: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+      payload: {},
+    })
+
+    expect(sendSpy.mock.calls[0][0].method).toBe('btc_signTransaction')
+  })
+})
+
+describe('sign — chain sanitize 통합', () => {
+  test('잘못된 type → throw ProviderError (sanitize 진입점 호출 확인)', async () => {
+    await expect(sign({ chain: 123 as unknown as string, payload: {} })).rejects.toThrow(
+      ProviderError,
+    )
+  })
+
+  test('프로토타입 키 → throw', async () => {
+    await expect(sign({ chain: '__proto__', payload: {} })).rejects.toThrow(ProviderError)
+  })
+
+  test('whitelist 위반 → throw', async () => {
+    await expect(sign({ chain: 'evil<script>', payload: {} })).rejects.toThrow(ProviderError)
+  })
+})


### PR DESCRIPTION
## Summary

m08-01 epic([DC-1998](https://iotrust.atlassian.net/browse/DC-1998))의 두 번째 child. dApp이 호출할 통합 sign API와 internal `_call({method, params})` helper, ProviderError → v1 형식 mapper, chain → method 매핑, ID generator를 connector v2 facade에 도입한다. m08-01-01([DC-1999](https://iotrust.atlassian.net/browse/DC-1999), MERGED_TO_EPIC)의 싱글톤 (`_getQueue` / `_getTransport`) + lifecycle 위에 빌드된다.

## Rationale

- **`_call`은 v1 `dcent.call(params)` 1:1 호환** (src-v1/index.js#L172-L222). popup close / timeout / `transaction.user_cancel` 특례 동작을 모두 보존하여 v1 wrapper(m08-01-03/04)가 sign이 아닌 `_call`을 직접 호출할 수 있도록 (D-05 결정).
- **`sign({chain, payload})`는 새로운 dApp 통합 API**. CAIP-19 prefix 기반으로 bridge method를 결정하고, 미정의 chain은 chain 문자열 자체를 method로 fallback (Sui 등 신규 네트워크 connector 수정 0). 책임 분리 — chain 자체 검증은 wallet-models가, method dispatch는 bridge sdk가 담당.
- **D-07 분석 결과 popup-close 매핑 단일화**: 현재 v2 PopupTransport는 pre-handshake와 mid-send pending을 모두 `DISCONNECTED(4900)`로 reject. `4900 → 'pop-up_closed'` 단일 매핑으로 충분. T-U-CALL-02b는 mid-send DISCONNECTED 동일 close 경로 검증으로 재해석.
- **D-08 `_assertV1Success`**: v1 wrapper가 explicit throw 의미를 원할 때 1줄로 사용. `transaction.user_cancel`은 v1 특례로 throw 안 하고 그대로 반환.
- **mutation-isolation 룰 적용**: 매 `_call` 호출마다 `V1Response` 새 객체 반환 (T-MUT-RESP-01/02), `PREFIX_TO_METHOD`는 Object.frozen (T-MUT-PREFIX-01).
- **dapp-input-sanitization 룰 적용 (C3 chain 검증)**: type / length(≤256) / whitelist 정규식 / 프로토타입 키 차단 4단계 (T-SEC-WHITE-CHAIN-01..04).

## Tested

자동 검증 명령 6개 모두 PASS — `objectives/.prepare/m08-01-02-generic-sign-core/verification-report.md` 참조.

- [x] **T-U / T-SEC / T-MUT / T-U-ASSERT / T-U-CHAIN / T-U-IDGEN / T-U-CALL / T-U-ERR / T-U-SIGN** — `npm run unit-v2 -- tests/unit/v2/sign/` (190/190 PASS, 신규 sign 77 cases + 기존 113 회귀 0)
- [x] **T-BUILD-01** — `npm run build` (webpack production OK, dist/v2/dcent-web-connector.min.js 307KiB)
- [x] **T-BUILD-02** — `npx tsc --emitDeclarationOnly` + `grep -E '(sign)' dist/v2/index.d.ts` (sign 시그니처 6라인 매칭)
- [x] **T-PACK-01** — `npm pack --dry-run` (sign/ 9개 파일 모두 포함)
- [x] **T-DEFAULT-01** — `node -e "require(...).default.sign"` → `function`
- [x] **T-LINT-01** — `npx eslint --ext .ts src` (위반 0건)

T-XX 매핑 34/34 모두 PASS.

## Constraints

- **PR base = epic branch** (`epic/DC-1998_m08-01-connector-v2-dapp-facade`). dev/master 아님.
- **CI 워크플로우는 epic-base PR에서 trigger되지 않음** (`.github/workflows/build-and-test.yml`이 master/dev only). 로컬 검증으로 대체.
- **소스 변경 LOC**: 556 (신규 9개 + 수정 1개), 600 LOC 한도 안.
- **package.json version 미수정** (`no-version-bump` 룰 — release manager 담당).
- **m08-01-01 의존 (MERGED_TO_EPIC)**: epic branch (commit `bef6653`)에 facade 뼈대 + lifecycle + singleton 포함됨.
- **머지는 사람이** (`objective-no-auto-merge` 룰).

## Cross-repo 영향

- `src/index.ts` 편집 = npm public API 진입점이지만 본 child는 default export object와 named exports에 `sign` + internal helpers를 **추가**할 뿐. 기존 export 수정 없음 (backward-compatible).
- m08-01-05까지 `package.json` `main`은 `src-v1/index.js`를 가리키므로 npm published 패키지의 dApp 진입점은 v1. dApp 영향 없음.
- bridge sdk 측은 m06-01 시점 그대로 — chain → method 매핑은 connector facade 내부에서 처리.

## Follow-ups

- m08-01-02.5: 8개 read-only / configure 함수 + Bitcoin tx builder + coinTypeValidators 마이그레이션
- m08-01-03/04: v1 호환 sign wrapper (`getEthereumSignedTransaction` 등). `_call`을 직접 호출 (sign 거치지 않음, D-05).
- m08-01-05: `package.json` `main` 필드를 `dist/v2/dcent-web-connector.min.js`로 전환 (release-cut). dApp 마이그레이션 가이드 동시 게시.

## Objective Reference

`objectives/m08-01-02-generic-sign-core.md`