### PR TITLE
[DC-2001] feat(v2): connector v2 read-only / configure / Bitcoin tx-builder + v1 validators (m08-01-02.5)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,31 @@ import {
   state,
 } from './types'
 import { unitConverter } from './utils/unitConverter'
-import { sign } from './sign'
+import {
+  sign,
+  // m08-01-02.5: read-only / configure / Bitcoin tx-builder
+  info,
+  getDeviceInfo,
+  getAccountInfo,
+  getAddress,
+  getXPUB,
+  setLabel,
+  syncAccount,
+  selectAddress,
+  getBitcoinTransactionObject,
+  addBitcoinTransactionInput,
+  addBitcoinTransactionOutput,
+  // m08-01-02.5: v1 validator helpers (export 표면 보존 — v1 typo 포함)
+  isAvaliableCoinType,
+  isCzoneCoinType,
+  isParachainCoinType,
+  isBitcoinTxCoinType,
+  isTokenType,
+  getCzonePrifix,
+  isAvaliableLabel,
+  isAvaliableCoinGroup,
+  isAvailableSyncAccountCoinName,
+} from './sign'
 
 // === 기존 named exports (m02-01·m02-02·m07-02 SHIPPED) ===
 export type {
@@ -79,6 +103,34 @@ export type { SignInput, V1Response, V1ResponseHeader, V1ResponseBody } from './
 export { _call, _genId, _sanitizeChain, _assertV1Success, providerErrorToV1, chainToMethod } from './sign'
 export type { CallInput } from './sign'
 
+// === 새 named exports (m08-01-02.5 — read-only / configure / Bitcoin tx-builder + v1 validators) ===
+export {
+  info,
+  getDeviceInfo,
+  getAccountInfo,
+  getAddress,
+  getXPUB,
+  setLabel,
+  syncAccount,
+  selectAddress,
+  getBitcoinTransactionObject,
+  addBitcoinTransactionInput,
+  addBitcoinTransactionOutput,
+} from './sign'
+export type { SyncAccountInfo, BitcoinTxObject, BitcoinTxParameter } from './sign'
+// v1 validator helpers — dApp 표면 1:1 보존 (v1 typo `getCzonePrifix` 포함)
+export {
+  isAvaliableCoinType,
+  isCzoneCoinType,
+  isParachainCoinType,
+  isBitcoinTxCoinType,
+  isTokenType,
+  getCzonePrifix,
+  isAvaliableLabel,
+  isAvaliableCoinGroup,
+  isAvailableSyncAccountCoinName,
+} from './sign'
+
 // === default export object (v1 호환 패턴) ===
 //
 // dApp이 `import dcent from 'dcent-web-connector'` 또는 `const dcent = require(...)`로
@@ -102,6 +154,28 @@ const dcent = {
   unitConverter,
   // sign (m08-01-02)
   sign,
+  // m08-01-02.5: read-only / configure / Bitcoin tx-builder
+  info,
+  getDeviceInfo,
+  getAccountInfo,
+  getAddress,
+  getXPUB,
+  setLabel,
+  syncAccount,
+  selectAddress,
+  getBitcoinTransactionObject,
+  addBitcoinTransactionInput,
+  addBitcoinTransactionOutput,
+  // m08-01-02.5: v1 validator helpers (dApp 표면 1:1 보존 — v1 typo 포함)
+  isAvaliableCoinType,
+  isCzoneCoinType,
+  isParachainCoinType,
+  isBitcoinTxCoinType,
+  isTokenType,
+  getCzonePrifix,
+  isAvaliableLabel,
+  isAvaliableCoinGroup,
+  isAvailableSyncAccountCoinName,
 } as const
 
 export default dcent

--- a/src/sign/address.ts
+++ b/src/sign/address.ts
@@ -1,0 +1,91 @@
+/**
+ * v1 getAddress / getXPUB port (m08-01-02.5)
+ *
+ * v1 src-v1/index.js의 `dcent.getAddress` (l781-813), `dcent.getXPUB` (l822-830)를 1:1 port.
+ *
+ * getAddress 핵심 동작:
+ *   1. coinType 검증 (`isAvaliableCoinType`) — fail 시 `coin_type_error` throw
+ *   2. params 구성 — czone이면 `coinType: 'czone'`, 아니면 원본 coinType
+ *   3. czone이면 `optionParam = getCzonePrifix(coinType)` (Buffer hex)
+ *   4. parachain이면 `optionParam = Number(prefix)` — `!Number(prefix)` true이면 `param_error` throw
+ *   5. `_call({method: 'getAddress', params})` 호출
+ *   6. 응답 `header.response_from === 'czone'` → 원본 coinType으로 복원
+ *
+ * **v1 1:1 보존 디테일**:
+ *   - czone과 parachain은 별도 if 두 개 (mutually exclusive 강제 안 함 — v1 동작 그대로)
+ *   - parachain prefix 검증은 `!Number(prefix)` (0/''/null/undefined/NaN/non-numeric string 모두 reject)
+ *   - response_from 복원은 mutation으로 수행 (`_call`이 매 호출마다 새 객체 반환하므로 안전 — mutation-isolation)
+ *
+ * 룰 준수:
+ *   - boundary-validation: coinType / parachain prefix 모두 검증
+ *   - error-handling-consistency: 모든 검증 실패는 `dcentException` throw (v1 1:1)
+ *   - mutation-isolation: `_call` 결과의 header 수정은 호출자 view에 영향 없음 (cloned)
+ */
+
+import { _call } from './call'
+import {
+  isAvaliableCoinType,
+  isCzoneCoinType,
+  isParachainCoinType,
+  getCzonePrifix,
+} from './coinTypeValidators'
+import { dcentException } from '../v1/dcent-exception'
+import type { V1Response } from './types'
+
+/**
+ * v1 dcent.getAddress (src-v1/index.js#l781-813) 1:1 port.
+ *
+ * @param coinType 지원되는 coinType (`isAvaliableCoinType` 검증)
+ * @param path BIP44 key path
+ * @param prefix parachain의 경우 필수 (`Number(prefix)` truthy)
+ * @returns address가 담긴 V1Response
+ */
+export async function getAddress (
+  coinType: string,
+  path: string,
+  prefix: string | number | null = null,
+): Promise<V1Response> {
+  if (!isAvaliableCoinType(coinType)) {
+    throw dcentException('coin_type_error', 'not supported coin type')
+  }
+
+  const params: Record<string, unknown> = {
+    coinType: isCzoneCoinType(coinType) ? 'czone' : coinType,
+    path,
+  }
+
+  // v1과 동일하게 별도 if 두 개 (mutually exclusive 강제 안 함)
+  if (isCzoneCoinType(coinType)) {
+    params.optionParam = getCzonePrifix(coinType)
+  }
+
+  if (isParachainCoinType(coinType)) {
+    // v1 src-v1/index.js#l796-801: `if (!Number(prefix)) throw`
+    // → '', null, undefined, 0, NaN, 비숫자 문자열 모두 reject
+    if (!Number(prefix)) {
+      throw dcentException('param_error', 'Invaild Parameter')
+    }
+    params.optionParam = Number(prefix)
+  }
+
+  const res = await _call({ method: 'getAddress', params })
+
+  // czone 응답에서 response_from을 원래 coinType으로 복원 (v1 src-v1/index.js#l808)
+  if (res.header.response_from === 'czone') {
+    res.header.response_from = coinType
+  }
+  return res
+}
+
+/**
+ * v1 dcent.getXPUB (src-v1/index.js#l822-830) 1:1 port.
+ *
+ * Extended Public Key 조회. BIP44 key path가 최소 두 depth로 hardened되어야 함.
+ *
+ * @param key BIP44 key path
+ * @param bip32name BIP32 master key 파생용 string (default 'Bitcoin seed')
+ * @returns XPUB가 담긴 V1Response
+ */
+export function getXPUB (key: string, bip32name: string): Promise<V1Response> {
+  return _call({ method: 'getXPUB', params: { key, bip32name } })
+}

--- a/src/sign/bitcoinTxBuilder.ts
+++ b/src/sign/bitcoinTxBuilder.ts
@@ -1,0 +1,151 @@
+/**
+ * v1 Bitcoin transaction builder port (m08-01-02.5)
+ *
+ * v1 src-v1/index.js의 `dcent.getBitcoinTransactionObject` (l837-859),
+ * `dcent.addBitcoinTransactionInput` (l873-893), `dcent.addBitcoinTransactionOutput` (l904-921)를
+ * 1:1 port한다.
+ *
+ * **v1 nested envelope 1:1 보존**:
+ *   - `request.header.{version, request_to}` (snake_case)
+ *   - `request.body.{command, parameter}`
+ *   - `parameter.input[].{prev_tx, utxo_idx, type, key}` (snake_case)
+ *   - `parameter.output[].{type, value, to}`
+ *
+ * Bridge sdk가 이 nested envelope을 wire format으로 기대하므로, schema 변경 시 silent fail.
+ * v1 호환 sign wrapper(`getBitcoinSignedTransaction`, m08-01-04)가 본 schema를 그대로 bridge로 송신.
+ *
+ * 룰 준수:
+ *   - boundary-validation: coinType 검증 (`isBitcoinTxCoinType`)
+ *   - error-handling-consistency: 검증 실패 시 dcentException throw
+ *   - mutation-isolation (T-MUT-TX-01/02): `getBitcoinTransactionObject`는 매 호출마다 새 객체 반환.
+ *     `addBitcoinTransactionInput/Output`은 명시적으로 in-place mutation (v1 1:1) — 호출자가 같은
+ *     객체를 여러 번 push 가능. 두 개의 별도 호출 결과는 서로 독립.
+ *   - cross-repo-interface-edit: BitcoinTxObject schema는 bridge sdk와의 wire format 계약. 변경 금지.
+ */
+
+import { isBitcoinTxCoinType } from './coinTypeValidators'
+import { dcentException } from '../v1/dcent-exception'
+
+/* eslint-disable camelcase */
+/** Bitcoin tx parameter — v1 wire format snake_case 보존. */
+export interface BitcoinTxParameter {
+  version: number
+  locktime: number
+  input?: Array<{
+    prev_tx: string
+    utxo_idx: number
+    type: string
+    key: string
+  }>
+  output?: Array<{
+    type: string
+    value: number | string
+    to: string
+  }>
+}
+
+/** Bitcoin tx envelope — v1 nested shape 1:1. */
+export interface BitcoinTxObject {
+  request: {
+    header: {
+      version: string
+      request_to: string
+    }
+    body: {
+      command: string
+      parameter: BitcoinTxParameter
+    }
+  }
+}
+/* eslint-enable camelcase */
+
+/**
+ * v1 dcent.getBitcoinTransactionObject (src-v1/index.js#l837-859) 1:1 port.
+ *
+ * Bitcoin tx 빌드용 nested envelope 생성. 매 호출마다 새 객체 (mutation-isolation).
+ *
+ * @param coinType BITCOIN/BITCOIN_TESTNET/MONACOIN/MONACOIN_TESTNET 중 하나
+ * @returns 비어 있는 input/output을 가진 BitcoinTxObject
+ * @throws dcentException('coin_type_error') Bitcoin tx 호환 coinType이 아닌 경우
+ */
+export function getBitcoinTransactionObject (coinType: string): BitcoinTxObject {
+  if (!isBitcoinTxCoinType(coinType)) {
+    throw dcentException('coin_type_error', 'not supported coin type')
+  }
+
+  // v1과 동일한 초기화 — request.header / request.body.parameter
+  const txObject: BitcoinTxObject = {
+    request: {
+      header: {
+        version: '1.0',
+        request_to: '',
+      },
+      body: {
+        command: '',
+        parameter: { version: 1, locktime: 0 },
+      },
+    },
+  }
+  txObject.request.header.request_to = coinType
+  txObject.request.body.command = 'transaction'
+  // v1은 parameter를 한 번 더 reset 후 version/locktime을 채우지만, 위 초기화로 동일 효과.
+  return txObject
+}
+
+/**
+ * v1 dcent.addBitcoinTransactionInput (src-v1/index.js#l873-893) 1:1 port.
+ *
+ * 이전 tx output 정보를 input 배열에 push (in-place mutation, v1 1:1).
+ * Max number of "input" is 50 (디바이스 제약 — wire 검증은 bridge sdk 책임).
+ *
+ * **snake_case keys (v1 wire format 1:1)**: `prev_tx` / `utxo_idx`. Drift 시 bridge sdk가
+ * 인식하지 못해 invalid signature.
+ *
+ * @param transaction `getBitcoinTransactionObject`가 반환한 객체
+ * @param prevTx 이전 transaction의 raw hex 데이터 (signing source)
+ * @param utxoIdx prev_tx 안의 output index
+ * @param type p2pkh / p2pk / p2sh
+ * @param key signing 용 BIP44 key path
+ * @returns 같은 transaction 객체 (mutation 후 반환 — chaining 가능)
+ */
+export function addBitcoinTransactionInput (
+  transaction: BitcoinTxObject,
+  prevTx: string,
+  utxoIdx: number,
+  type: string,
+  key: string,
+): BitcoinTxObject {
+  const parameter = transaction.request.body.parameter
+  parameter.input = parameter.input || []
+  parameter.input.push({
+    prev_tx: prevTx, // eslint-disable-line camelcase
+    utxo_idx: utxoIdx, // eslint-disable-line camelcase
+    type,
+    key,
+  })
+  return transaction
+}
+
+/**
+ * v1 dcent.addBitcoinTransactionOutput (src-v1/index.js#l904-921) 1:1 port.
+ *
+ * Spending 정보를 output 배열에 push (in-place mutation, v1 1:1).
+ * Max number of "output" is 10.
+ *
+ * @param transaction `getBitcoinTransactionObject`가 반환한 객체
+ * @param type p2pkh / p2pk / p2sh / change
+ * @param value 보낼 coin amount
+ * @param to 받는 사람 주소
+ * @returns 같은 transaction 객체
+ */
+export function addBitcoinTransactionOutput (
+  transaction: BitcoinTxObject,
+  type: string,
+  value: number | string,
+  to: string,
+): BitcoinTxObject {
+  const parameter = transaction.request.body.parameter
+  parameter.output = parameter.output || []
+  parameter.output.push({ type, value, to })
+  return transaction
+}

--- a/src/sign/coinGroupValidator.ts
+++ b/src/sign/coinGroupValidator.ts
@@ -1,0 +1,123 @@
+/**
+ * v1 coinGroup validators port (m08-01-02.5)
+ *
+ * v1 src-v1/index.js#l479-543 1:1 port.
+ *
+ * 함수:
+ *   - `isAvaliableCoinGroup` (l479-516) — 지원되는 coinGroup 화이트리스트
+ *   - `_contractNotStartWith0x` (l518-529, internal) — 0x prefix가 필요 없는 contract 그룹
+ *   - `isAvailableSyncAccountCoinName` (l531-543) — coin_group + coin_name 짝 검증
+ *
+ * 룰 준수:
+ *   - boundary-validation: falsy 가드 + switch default
+ *   - error-handling-consistency: boolean 반환 (throw는 caller — syncAccount)
+ *   - reuse-shared-utils: m08-01-01 enum + isTokenType (coinTypeValidators) 재사용
+ */
+
+import { coinGroup as dcentCoinGroup } from '../types/coinGroup'
+import { isTokenType } from './coinTypeValidators'
+
+/**
+ * v1 isAvaliableCoinGroup (src-v1/index.js#l479-516) 1:1 port.
+ *
+ * 지원되는 coinGroup이면 true. 모든 비교는 toLowerCase.
+ */
+export function isAvaliableCoinGroup (coinGroup: string): boolean {
+  if (!coinGroup) {
+    return false
+  }
+  switch (coinGroup.toLowerCase()) {
+    case dcentCoinGroup.BITCOIN.toLowerCase():
+    case dcentCoinGroup.BITCOIN_TESTNET.toLowerCase():
+    case dcentCoinGroup.MONACOIN.toLowerCase():
+    case dcentCoinGroup.MONACOIN_TESTNET.toLowerCase():
+    case dcentCoinGroup.ERC20.toLowerCase():
+    case dcentCoinGroup.ERC20_KOVAN.toLowerCase():
+    case dcentCoinGroup.ETHEREUM.toLowerCase():
+    case dcentCoinGroup.ETHEREUM_KOVAN.toLowerCase():
+    case dcentCoinGroup.RRC20.toLowerCase():
+    case dcentCoinGroup.RRC20_TESTNET.toLowerCase():
+    case dcentCoinGroup.RSK.toLowerCase():
+    case dcentCoinGroup.RSK_TESTNET.toLowerCase():
+    case dcentCoinGroup.KLAYTN.toLowerCase():
+    case dcentCoinGroup.KLAY_BAOBAB.toLowerCase():
+    case dcentCoinGroup.KLAYTN_KCT.toLowerCase():
+    case dcentCoinGroup.KCT_BAOBAB.toLowerCase():
+    case dcentCoinGroup.RIPPLE.toLowerCase():
+    case dcentCoinGroup.RIPPLE_TESTNET.toLowerCase():
+    case dcentCoinGroup.XDC.toLowerCase():
+    case dcentCoinGroup.XDC_APOTHEM.toLowerCase():
+    case dcentCoinGroup.XRC20.toLowerCase():
+    case dcentCoinGroup.XRC20_APOTHEM.toLowerCase():
+    case dcentCoinGroup.HEDERA.toLowerCase():
+    case dcentCoinGroup.HEDERA_HTS.toLowerCase():
+    case dcentCoinGroup.HEDERA_TESTNET.toLowerCase():
+    case dcentCoinGroup.HTS_TESTNET.toLowerCase():
+    case dcentCoinGroup.STELLAR.toLowerCase():
+    case dcentCoinGroup.TRON.toLowerCase():
+      return true
+    default:
+      return false
+  }
+}
+
+/**
+ * v1 _contractNotStartWith0x (src-v1/index.js#l518-529, internal) 1:1 port.
+ *
+ * 0x prefix가 필요 없는 contract group이면 true.
+ * (TRC token / XRC20 / HTS / Algorand asset/app / PARA XC20)
+ *
+ * 본 함수는 module-internal이며 export하지 않는다 (`isAvailableSyncAccountCoinName` 내부에서만 사용).
+ */
+function _contractNotStartWith0x (coinGroup: string): boolean {
+  if (
+    coinGroup === dcentCoinGroup.TRC_TOKEN.toLowerCase() ||
+    coinGroup === dcentCoinGroup.TRC_TESTNET.toLowerCase() ||
+    coinGroup === dcentCoinGroup.XRC20.toLowerCase() ||
+    coinGroup === dcentCoinGroup.XRC20_APOTHEM.toLowerCase() ||
+    coinGroup === dcentCoinGroup.HTS_TESTNET.toLowerCase() ||
+    coinGroup === dcentCoinGroup.HEDERA_HTS.toLowerCase() ||
+    coinGroup === dcentCoinGroup.ALGORAND_ASSET.toLowerCase() ||
+    coinGroup === dcentCoinGroup.ALGORAND_ASSET_TESTNET.toLowerCase() ||
+    coinGroup === dcentCoinGroup.ALGORAND_APP.toLowerCase() ||
+    coinGroup === dcentCoinGroup.ALGORAND_APP_TESTNET.toLowerCase() ||
+    coinGroup === dcentCoinGroup.PARA_XC20.toLowerCase() ||
+    coinGroup === dcentCoinGroup.PARA_XC20_TESTNET.toLowerCase()
+  ) {
+    return true
+  }
+  return false
+}
+
+/**
+ * v1 isAvailableSyncAccountCoinName (src-v1/index.js#l531-543) 1:1 port.
+ *
+ * Token 그룹이면 coin_name이 0x로 시작하거나 (`_contractNotStartWith0x`이 true인 그룹).
+ * Non-token 그룹이면 coin_name이 valid coinGroup이어야 함.
+ *
+ * NOTE: v1 함수명에 typo (`isAvailable` vs `isAvaliable`) 차이가 있음 — 이 함수는 `isAvailable` (정확).
+ * v2도 동일 이름 보존.
+ *
+ * @param account `{coin_group, coin_name}` 짝
+ */
+export function isAvailableSyncAccountCoinName (account: {
+  // eslint-disable-next-line camelcase
+  coin_group: string
+  // eslint-disable-next-line camelcase
+  coin_name: string
+}): boolean {
+  if (isTokenType(account.coin_group)) {
+    if (
+      !account.coin_name.startsWith('0x') &&
+      !account.coin_name.startsWith('0X') &&
+      _contractNotStartWith0x(account.coin_group.toLowerCase()) !== true
+    ) {
+      return false
+    }
+  } else {
+    if (!isAvaliableCoinGroup(account.coin_name)) {
+      return false
+    }
+  }
+  return true
+}

--- a/src/sign/coinTypeValidators.ts
+++ b/src/sign/coinTypeValidators.ts
@@ -1,0 +1,208 @@
+/**
+ * v1 coinType validators port (m08-01-02.5)
+ *
+ * v1 src-v1/index.js의 `isAvaliableCoinType` (l545-612), `isTokenType` (l614-643),
+ * `isBitcoinTxCoinType` (l645-655), `isCzoneCoinType` (l657-664),
+ * `isParachainCoinType` (l666-679), `getCzonePrifix` (l681-688)를 1:1 port한다.
+ *
+ * 무수정 호환 약속:
+ *   - 함수명 v1 typo `getCzonePrifix` 그대로 보존 (export 표면)
+ *   - 모든 case는 v1과 동일한 enum 값 비교 (`coinType.toLowerCase()` vs `dcentCoinType.X.toLowerCase()`)
+ *   - 빈 문자열/null/undefined 입력 처리도 v1과 동일 (`!coinType` 가드)
+ *
+ * v2 enum (`coinType` / `coinGroup`) 자체가 m08-01-01에서 v1 src-v1/type/dcent-web-type.js와
+ * 키·값 1:1 일치로 도입되었으므로 (drift 테스트로 보장), 본 모듈은 그 enum을 그대로 사용해도
+ * v1 동작과 동등하다.
+ *
+ * 룰 준수:
+ *   - boundary-validation: 모든 입력에 대해 falsy 가드 + switch default 처리
+ *   - error-handling-consistency: validator는 boolean 반환 (throw 안 함). throw는 caller (getAddress 등)
+ *   - reuse-shared-utils: m08-01-01의 v2 enum 재사용
+ */
+
+import { Buffer } from 'buffer'
+import { coinType as dcentCoinType } from '../types/coinType'
+import { coinGroup as dcentCoinGroup } from '../types/coinGroup'
+
+/**
+ * v1 isAvaliableCoinType (src-v1/index.js#l545-612) 1:1 port.
+ *
+ * 지원되는 coinType이면 true. enum 키 또는 값 어느 쪽 입력도 toLowerCase 비교로 매치.
+ */
+export function isAvaliableCoinType (coinType: string): boolean {
+  if (!coinType) {
+    return false
+  }
+  switch (coinType.toLowerCase()) {
+    case dcentCoinType.BITCOIN.toLowerCase():
+    case dcentCoinType.BITCOIN_TESTNET.toLowerCase():
+    case dcentCoinType.MONACOIN.toLowerCase():
+    case dcentCoinType.MONACOIN_TESTNET.toLowerCase():
+    case dcentCoinType.ETHEREUM.toLowerCase():
+    case dcentCoinType.ETHEREUM_KOVAN.toLowerCase():
+    case dcentCoinType.ERC20.toLowerCase():
+    case dcentCoinType.ERC20_KOVAN.toLowerCase():
+    case dcentCoinType.RRC20.toLowerCase():
+    case dcentCoinType.RRC20_TESTNET.toLowerCase():
+    case dcentCoinType.RSK.toLowerCase():
+    case dcentCoinType.RSK_TESTNET.toLowerCase():
+    case dcentCoinType.KLAYTN.toLowerCase():
+    case dcentCoinType.KLAY_BAOBAB.toLowerCase():
+    case dcentCoinType.KLAYTN_KCT.toLowerCase():
+    case dcentCoinType.KCT_BAOBAB.toLowerCase():
+    case dcentCoinType.RIPPLE.toLowerCase():
+    case dcentCoinType.RIPPLE_TESTNET.toLowerCase():
+    case dcentCoinType.XDC.toLowerCase():
+    case dcentCoinType.XDC_APOTHEM.toLowerCase():
+    case dcentCoinType.XRC20.toLowerCase():
+    case dcentCoinType.XRC20_APOTHEM.toLowerCase():
+    case dcentCoinType.HEDERA.toLowerCase():
+    case dcentCoinType.HEDERA_HTS.toLowerCase():
+    case dcentCoinType.HEDERA_TESTNET.toLowerCase():
+    case dcentCoinType.HTS_TESTNET.toLowerCase():
+    case dcentCoinType.STELLAR.toLowerCase():
+    case dcentCoinType.STELLAR_TESTNET.toLowerCase():
+    case dcentCoinType.TRON.toLowerCase():
+    case dcentCoinType.TRON_TESTNET.toLowerCase():
+    case dcentCoinType.TRON_TRC_TOKEN.toLowerCase():
+    case dcentCoinType.TRON_TRC_TESTNET.toLowerCase():
+    case dcentCoinType.TEZOS.toLowerCase():
+    case dcentCoinType.TEZOS_TESTNET.toLowerCase():
+    case dcentCoinType.XTZ_FA.toLowerCase():
+    case dcentCoinType.XTZ_FA_TESTNET.toLowerCase():
+    case dcentCoinType.VECHAIN.toLowerCase():
+    case dcentCoinType.VECHAIN_ERC20.toLowerCase():
+    case dcentCoinType.NEAR.toLowerCase():
+    case dcentCoinType.NEAR_TESTNET.toLowerCase():
+    case dcentCoinType.NEAR_TOKEN.toLowerCase():
+    case dcentCoinType.HAVAH.toLowerCase():
+    case dcentCoinType.HAVAH_TESTNET.toLowerCase():
+    case dcentCoinType.HAVAH_HSP20.toLowerCase():
+    case dcentCoinType.HAVAH_HSP20_TESTNET.toLowerCase():
+    case dcentCoinType.POLKADOT.toLowerCase():
+    case dcentCoinType.COSMOS.toLowerCase():
+    case dcentCoinType.COREUM.toLowerCase():
+    case dcentCoinType.ALGORAND.toLowerCase():
+    case dcentCoinType.ALGORAND_TESTNET.toLowerCase():
+    case dcentCoinType.ALGORAND_ASSET.toLowerCase():
+    case dcentCoinType.ALGORAND_ASSET_TESTNET.toLowerCase():
+    case dcentCoinType.ALGORAND_APP.toLowerCase():
+    case dcentCoinType.ALGORAND_APP_TESTNET.toLowerCase():
+    case dcentCoinType.PARA.toLowerCase():
+    case dcentCoinType.PARA_TESTNET.toLowerCase():
+    case dcentCoinType.PARA_XC20.toLowerCase():
+    case dcentCoinType.PARA_XC20_TESTNET.toLowerCase():
+      return true
+    default:
+      return false
+  }
+}
+
+/**
+ * v1 isTokenType (src-v1/index.js#l614-643) 1:1 port.
+ *
+ * 토큰(ERC20/RRC20/KCT/XRC20/XTZ_FA/...)이면 true.
+ * 입력은 coinGroup 또는 coinType 둘 중 무엇이든 가능 (v1이 mixed로 사용).
+ */
+export function isTokenType (coinGroup: string): boolean {
+  if (!coinGroup) {
+    return false
+  }
+  switch (coinGroup.toLowerCase()) {
+    case dcentCoinGroup.ERC20.toLowerCase():
+    case dcentCoinGroup.ERC20_KOVAN.toLowerCase():
+    case dcentCoinType.RRC20.toLowerCase():
+    case dcentCoinType.RRC20_TESTNET.toLowerCase():
+    case dcentCoinType.KLAYTN_KCT.toLowerCase():
+    case dcentCoinType.KCT_BAOBAB.toLowerCase():
+    case dcentCoinGroup.XRC20.toLowerCase():
+    case dcentCoinGroup.XRC20_APOTHEM.toLowerCase():
+    case dcentCoinGroup.XTZ_FA.toLowerCase():
+    case dcentCoinGroup.XTZ_FA_TESTNET.toLowerCase():
+    case dcentCoinGroup.VECHAIN_ERC20.toLowerCase():
+    case dcentCoinGroup.HAVAH_HSP20.toLowerCase():
+    case dcentCoinGroup.HAVAH_HSP20_TESTNET.toLowerCase():
+    case dcentCoinGroup.NEAR_TOKEN.toLowerCase():
+    case dcentCoinType.ALGORAND_ASSET.toLowerCase():
+    case dcentCoinType.ALGORAND_ASSET_TESTNET.toLowerCase():
+    case dcentCoinType.ALGORAND_APP.toLowerCase():
+    case dcentCoinType.ALGORAND_APP_TESTNET.toLowerCase():
+    case dcentCoinGroup.PARA_XC20.toLowerCase():
+    case dcentCoinGroup.PARA_XC20_TESTNET.toLowerCase():
+      return true
+    default:
+      return false
+  }
+}
+
+/**
+ * v1 isBitcoinTxCoinType (src-v1/index.js#l645-655) 1:1 port.
+ *
+ * BITCOIN/BITCOIN_TESTNET/MONACOIN/MONACOIN_TESTNET이면 true (Bitcoin tx 빌더 사용 가능).
+ *
+ * NOTE: v1과 동일하게 입력 falsy 가드 없음 — 빈 문자열 입력 시 toLowerCase()가 동작하므로
+ * default로 false를 반환하는 흐름이 자연스럽게 유지된다.
+ */
+export function isBitcoinTxCoinType (coinType: string): boolean {
+  switch (coinType.toLowerCase()) {
+    case dcentCoinType.BITCOIN.toLowerCase():
+    case dcentCoinType.BITCOIN_TESTNET.toLowerCase():
+    case dcentCoinType.MONACOIN.toLowerCase():
+    case dcentCoinType.MONACOIN_TESTNET.toLowerCase():
+      return true
+    default:
+      return false
+  }
+}
+
+/**
+ * v1 isCzoneCoinType (src-v1/index.js#l657-664) 1:1 port.
+ *
+ * COREUM이면 true (czone wallet 그룹).
+ */
+export function isCzoneCoinType (coinType: string): boolean {
+  switch (coinType.toLowerCase()) {
+    case dcentCoinType.COREUM.toLowerCase():
+      return true
+    default:
+      return false
+  }
+}
+
+/**
+ * v1 isParachainCoinType (src-v1/index.js#l666-679) 1:1 port.
+ *
+ * PARA / PARA_TESTNET / PARA_XC20 / PARA_XC20_TESTNET이면 true.
+ */
+export function isParachainCoinType (coinType: string): boolean {
+  if (!coinType) {
+    return false
+  }
+  switch (coinType.toLowerCase()) {
+    case dcentCoinType.PARA.toLowerCase():
+    case dcentCoinType.PARA_TESTNET.toLowerCase():
+    case dcentCoinType.PARA_XC20.toLowerCase():
+    case dcentCoinType.PARA_XC20_TESTNET.toLowerCase():
+      return true
+    default:
+      return false
+  }
+}
+
+/**
+ * v1 getCzonePrifix (src-v1/index.js#l681-688) 1:1 port.
+ *
+ * **v1 typo `getCzonePrifix` 그대로 보존** — dApp이 v1에서 import한 이름과 동일해야 함.
+ * 의미상으로는 `getCzonePrefix`가 맞으나 v2에서 오타 수정 시 dApp이 호출 표면 깨짐.
+ *
+ * COREUM → `Buffer.from('core', 'utf8').toString('hex')` ('636f7265' = "core" hex 인코딩).
+ * 그 외 → undefined.
+ */
+export function getCzonePrifix (coinType: string): string | undefined {
+  switch (coinType.toLowerCase()) {
+    case dcentCoinType.COREUM.toLowerCase():
+      return Buffer.from('core', 'utf8').toString('hex')
+    default:
+      return undefined
+  }
+}

--- a/src/sign/configure.ts
+++ b/src/sign/configure.ts
@@ -1,0 +1,86 @@
+/**
+ * v1 setLabel / syncAccount / selectAddress port (m08-01-02.5)
+ *
+ * v1 src-v1/index.js의 `dcent.setLabel` (l705-716), `dcent.syncAccount` (l724-745),
+ * `dcent.selectAddress` (l762-772)를 1:1 port.
+ *
+ * **v1 1:1 보존 디테일**:
+ *   - setLabel: `isAvaliableLabel` regex 검증 → throw `param_error` ('Invalid Label : ' + label)
+ *   - syncAccount: per-account 3종 검증 (early throw) — coinGroup → coinName → label 순서
+ *     - coin_group: `isAvaliableCoinGroup` fail → `coin_group_error`
+ *     - coin_name: `isAvailableSyncAccountCoinName` fail → `coin_name_error`
+ *     - label: `isAvaliableLabel` fail → `param_error` ('Invalid Label - ' + label)
+ *   - selectAddress: `Array.isArray` 검증만 → throw `param_error`
+ *
+ * 룰 준수:
+ *   - boundary-validation: 모든 인자 검증 후 _call
+ *   - error-handling-consistency: 모든 검증 실패는 dcentException throw (v1 1:1 메시지)
+ *   - reuse-shared-utils: validators는 sibling 모듈에서 import
+ */
+
+import { _call } from './call'
+import { isAvaliableLabel } from './labelValidator'
+import { isAvaliableCoinGroup, isAvailableSyncAccountCoinName } from './coinGroupValidator'
+import { dcentException } from '../v1/dcent-exception'
+import type { V1Response } from './types'
+
+/* eslint-disable camelcase */
+/** sync account info — v1 wire format에 맞춰 snake_case. */
+export interface SyncAccountInfo {
+  coin_group: string
+  coin_name: string
+  label: string
+}
+/* eslint-enable camelcase */
+
+/**
+ * v1 dcent.setLabel (src-v1/index.js#l705-716) 1:1 port.
+ *
+ * @param label D'CENT biometric Wallet에 설정할 label (regex `/^[a-zA-Z\d.!#$%&\+\-_]{2,14}$/`)
+ * @throws dcentException('param_error') label regex unmatch 시
+ */
+export function setLabel (label: string): Promise<V1Response> {
+  if (!isAvaliableLabel(label)) {
+    throw dcentException('param_error', 'Invalid Label : ' + label)
+  }
+  return _call({ method: 'setLabel', params: { label } })
+}
+
+/**
+ * v1 dcent.syncAccount (src-v1/index.js#l724-745) 1:1 port.
+ *
+ * Account 정보 동기화 — 추가 또는 갱신.
+ * Per-account 3종 검증 (coin_group / coin_name / label) — early throw on first failure.
+ *
+ * @param accountInfos 검증 후 디바이스에 sync할 account 배열
+ * @throws dcentException 첫 invalid account의 첫 invalid 필드에서 throw (v1 동일 순서)
+ */
+export function syncAccount (accountInfos: SyncAccountInfo[]): Promise<V1Response> {
+  for (let i = 0; i < accountInfos.length; i = i + 1) {
+    const account = accountInfos[i]
+
+    if (!isAvaliableCoinGroup(account.coin_group)) {
+      throw dcentException('coin_group_error', 'not supported coin group')
+    }
+    if (!isAvailableSyncAccountCoinName(account)) {
+      throw dcentException('coin_name_error', 'not supported coin name')
+    }
+    if (!isAvaliableLabel(account.label)) {
+      throw dcentException('param_error', 'Invalid Label - ' + account.label)
+    }
+  }
+  return _call({ method: 'syncAccount', params: { accountInfos } })
+}
+
+/**
+ * v1 dcent.selectAddress (src-v1/index.js#l762-772) 1:1 port.
+ *
+ * @param addresses 선택할 address 배열
+ * @throws dcentException('param_error') Array가 아닌 경우
+ */
+export function selectAddress (addresses: string[]): Promise<V1Response> {
+  if (!Array.isArray(addresses)) {
+    throw dcentException('param_error', 'addresses is not array')
+  }
+  return _call({ method: 'selectAddress', params: { addresses } })
+}

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -1,5 +1,5 @@
 /**
- * v2 sign — barrel export (m08-01-02)
+ * v2 sign — barrel export (m08-01-02 + m08-01-02.5)
  *
  * sign 디렉토리의 public surface를 한 곳에서 export.
  * src/index.ts (v2 facade entry)가 본 모듈을 import하여 dApp에 노출한다.
@@ -20,3 +20,30 @@ export { _sanitizeChain } from './sanitize'
 export { _assertV1Success } from './assert'
 export { providerErrorToV1 } from './error'
 export { chainToMethod, PREFIX_TO_METHOD } from './chainToMethod'
+
+// m08-01-02.5: read-only / configure / Bitcoin tx-builder + v1 validators
+export { info, getDeviceInfo, getAccountInfo } from './info'
+export { getAddress, getXPUB } from './address'
+export { setLabel, syncAccount, selectAddress } from './configure'
+export type { SyncAccountInfo } from './configure'
+export {
+  getBitcoinTransactionObject,
+  addBitcoinTransactionInput,
+  addBitcoinTransactionOutput,
+} from './bitcoinTxBuilder'
+export type { BitcoinTxObject, BitcoinTxParameter } from './bitcoinTxBuilder'
+
+// v1 validator helpers — sibling module(m08-01-03/04 wrapper)이 재사용. dApp 표면 1:1 보존.
+export {
+  isAvaliableCoinType,
+  isCzoneCoinType,
+  isParachainCoinType,
+  isBitcoinTxCoinType,
+  isTokenType,
+  getCzonePrifix, // v1 typo 보존
+} from './coinTypeValidators'
+export { isAvaliableLabel } from './labelValidator'
+export {
+  isAvaliableCoinGroup,
+  isAvailableSyncAccountCoinName,
+} from './coinGroupValidator'

--- a/src/sign/info.ts
+++ b/src/sign/info.ts
@@ -1,0 +1,36 @@
+/**
+ * v1 read-only info functions port (m08-01-02.5)
+ *
+ * v1 src-v1/index.js의 `dcent.info` (l439-443), `dcent.getDeviceInfo` (l464-468),
+ * `dcent.getAccountInfo` (l752-756)를 1:1 port.
+ *
+ * 모두 인자 없이 `_call({method})`만 호출하는 단순 wrapper.
+ *
+ * 룰 준수:
+ *   - error-handling-consistency: `_call`이 V1Response를 반환 (throw 없음, mutation 격리)
+ *   - reuse-shared-utils: m08-01-02-generic-sign-core의 `_call` 재사용
+ */
+
+import { _call } from './call'
+import type { V1Response } from './types'
+
+/**
+ * v1 dcent.info — Bridge (Tray Daemon) status 정보 조회.
+ */
+export function info (): Promise<V1Response> {
+  return _call({ method: 'info' })
+}
+
+/**
+ * v1 dcent.getDeviceInfo — D'CENT Biometric Wallet 디바이스 정보 조회.
+ */
+export function getDeviceInfo (): Promise<V1Response> {
+  return _call({ method: 'getDeviceInfo' })
+}
+
+/**
+ * v1 dcent.getAccountInfo — Wallet에 등록된 account 리스트 조회.
+ */
+export function getAccountInfo (): Promise<V1Response> {
+  return _call({ method: 'getAccountInfo' })
+}

--- a/src/sign/labelValidator.ts
+++ b/src/sign/labelValidator.ts
@@ -1,0 +1,32 @@
+/**
+ * v1 isAvaliableLabel port (m08-01-02.5)
+ *
+ * v1 src-v1/index.js#l470-477 1:1 port.
+ *
+ * regex: `/^[a-zA-Z\d.!#$%&\+\-_]{2,14}$/`
+ * - 영숫자 + 특수문자(`.!#$%&+-_`)만 허용
+ * - 길이 2~14자
+ * - 한글 / 공백 / 그 외 특수문자 reject
+ *
+ * 함수명에 typo (`isAvaliable` not `isAvailable`)가 있으나 v1과 1:1 호환을 위해 보존.
+ *
+ * 룰 준수:
+ *   - boundary-validation: falsy 가드 + regex 검증
+ *   - error-handling-consistency: boolean 반환 (throw는 caller — setLabel/syncAccount)
+ */
+
+// eslint-disable-next-line no-useless-escape
+const LABEL_REGEX = /^[a-zA-Z\d.!#$%&\+\-_]{2,14}$/
+
+/**
+ * v1 isAvaliableLabel (src-v1/index.js#l470-477) 1:1 port.
+ *
+ * @param label 검증할 label 문자열
+ * @returns regex match + truthy면 true, 그 외 false
+ */
+export function isAvaliableLabel (label: string): boolean {
+  if (!label || !LABEL_REGEX.test(label)) {
+    return false
+  }
+  return true
+}

--- a/src/v1/dcent-exception.ts
+++ b/src/v1/dcent-exception.ts
@@ -1,0 +1,59 @@
+/**
+ * v1 dcentException helper port (m08-01-02.5)
+ *
+ * v1 src-v1/index.js#L61-L76의 `dcent.dcentException`과 1:1 호환.
+ * `throw dcentException(code, message)`가 v1과 동일한 shape의 객체를 throw하도록 보장한다.
+ *
+ * v2 read-only / configure / tx-builder 함수들이 인자 검증 실패 시 본 헬퍼를 사용.
+ *
+ * 룰 준수:
+ *   - error-handling-consistency: v1 1:1 호환 — throw object 형태 그대로 보존
+ *   - mutation-isolation: 매 호출마다 새 객체 반환
+ */
+
+/* eslint-disable camelcase */
+/** v1 dcentException이 반환하는 throw object shape. v1 wire format에 맞춰 snake_case 사용. */
+export interface V1Exception {
+  header: {
+    version: '1.0'
+    request_from: 'dcent-web'
+    status: 'error'
+  }
+  body: {
+    error: {
+      code: string
+      message: string
+    }
+  }
+}
+/* eslint-enable camelcase */
+
+/**
+ * v1 호환 exception 객체를 생성한다 (caller가 throw).
+ *
+ * v1 src-v1/index.js#L61-L76:
+ *   ```js
+ *   dcent.dcentException = function (code, message) {
+ *     return { header: {...}, body: { error: { code, message } } }
+ *   }
+ *   ```
+ *
+ * @param code v1 error code 문자열 (`'param_error'` / `'coin_type_error'` / `'coin_group_error'` / `'coin_name_error'`)
+ * @param message 사용자에게 노출할 에러 메시지
+ * @returns 매 호출마다 새 V1Exception 객체 (mutation-isolation)
+ */
+export function dcentException (code: string, message: string): V1Exception {
+  return {
+    header: {
+      version: '1.0',
+      request_from: 'dcent-web',
+      status: 'error',
+    },
+    body: {
+      error: {
+        code,
+        message,
+      },
+    },
+  }
+}

--- a/tests/unit/v2/sign/address.test.ts
+++ b/tests/unit/v2/sign/address.test.ts
@@ -1,0 +1,156 @@
+/**
+ * getAddress / getXPUB 단위 테스트 (m08-01-02.5)
+ *
+ * T-U-ADDR-01: getAddress('ETHEREUM', path) → 평범한 coinType (czone/parachain 분기 안 탐)
+ * T-U-ADDR-02: getAddress('COREUM', path) → czone 변환 + optionParam
+ * T-U-ADDR-03: getAddress('PARA', path, '5') → parachain prefix → optionParam: 5
+ * T-U-ADDR-04: getAddress('PARA', path, NaN) → param_error reject
+ * T-U-ADDR-05: response header.response_from === 'czone' → coinType으로 복원
+ * T-U-ADDR-06: getAddress(invalidCoinType, ...) → coin_type_error reject
+ * T-U-XPUB-01: getXPUB(key, bip32name) → _call
+ *
+ * T-U-PARACHAIN-PREFIX-01..04: 0 / '' / NaN / null 모두 reject (v1 !Number(prefix) 1:1)
+ *
+ * NOTE: getAddress는 `async function`이므로 sync `throw`도 reject로 변환된다.
+ *       에러 검증은 `await expect(...).rejects.toEqual(...)` 패턴 사용.
+ */
+
+import { Buffer } from 'buffer'
+import { getAddress, getXPUB } from '../../../../src/sign/address'
+import { ensureSingleton, _resetForTesting } from '../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+const expectV1Error = (code: string, message?: string) =>
+  expect.objectContaining({
+    body: {
+      error: message !== undefined ? { code, message } : expect.objectContaining({ code }),
+    },
+  })
+
+describe('getAddress — m08-01-02.5', () => {
+  test('T-U-ADDR-01: 일반 coinType — params {coinType, path}만 (czone/parachain 분기 안 탐)', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: { address: '0xabc' },
+    })
+
+    const resp = await getAddress('ETHEREUM', "m/44'/60'/0'/0/0")
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getAddress')
+    expect(callArg.params).toEqual({
+      coinType: 'ETHEREUM',
+      path: "m/44'/60'/0'/0/0",
+    })
+    expect(callArg.params).not.toHaveProperty('optionParam')
+    expect(resp.header.status).toBe('success')
+  })
+
+  test('T-U-ADDR-02: COREUM (czone) — coinType="czone" + optionParam hex of "core"', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r2',
+      result: { address: 'core1abc...' },
+    })
+
+    await getAddress('COREUM', "m/44'/118'/0'/0/0")
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.params?.coinType).toBe('czone')
+    expect(callArg.params?.optionParam).toBe(Buffer.from('core', 'utf8').toString('hex'))
+  })
+
+  test('T-U-ADDR-03: PARA + prefix="5" — optionParam: 5 (number)', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r3',
+      result: { address: 'parachain-addr' },
+    })
+
+    await getAddress('PARA', "m/44'/354'/0'/0/0", '5')
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.params?.coinType).toBe('PARA')
+    expect(callArg.params?.optionParam).toBe(5)
+    expect(typeof callArg.params?.optionParam).toBe('number')
+  })
+
+  test('T-U-ADDR-04: PARA + prefix=NaN → param_error reject', async () => {
+    await expect(getAddress('PARA', 'path', NaN)).rejects.toEqual(
+      expectV1Error('param_error', 'Invaild Parameter'),
+    )
+  })
+
+  test('T-U-ADDR-05: response_from === czone → coinType으로 복원', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r5',
+      result: {
+        header: { version: '1.0', status: 'success', response_from: 'czone' },
+        body: { command: 'getAddress', parameter: { address: 'core1abc' } },
+      },
+    })
+
+    const resp = await getAddress('COREUM', "m/44'/118'/0'/0/0")
+    expect(resp.header.response_from).toBe('COREUM')
+  })
+
+  test('T-U-ADDR-06: invalid coinType → coin_type_error reject', async () => {
+    await expect(getAddress('UNKNOWN_COIN', 'path')).rejects.toEqual(
+      expectV1Error('coin_type_error', 'not supported coin type'),
+    )
+  })
+})
+
+describe('getXPUB — m08-01-02.5', () => {
+  test('T-U-XPUB-01: getXPUB(key, bip32name) → _call', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r-xpub',
+      result: { xpub: 'xpub6...' },
+    })
+
+    await getXPUB("m/44'/0'/0'", 'Bitcoin seed')
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getXPUB')
+    expect(callArg.params).toEqual({ key: "m/44'/0'/0'", bip32name: 'Bitcoin seed' })
+  })
+})
+
+describe('parachain prefix edge cases — v1 !Number(prefix) 1:1', () => {
+  // v1 `if (!Number(prefix)) throw` — 0/''/null/undefined/NaN/non-numeric string 모두 reject
+
+  test('T-U-PARACHAIN-PREFIX-01: prefix=0 → param_error (!Number(0) = true)', async () => {
+    await expect(getAddress('PARA', 'path', 0)).rejects.toEqual(
+      expectV1Error('param_error', 'Invaild Parameter'),
+    )
+  })
+
+  test('T-U-PARACHAIN-PREFIX-02: prefix="" → param_error (Number("") = 0)', async () => {
+    await expect(getAddress('PARA', 'path', '')).rejects.toEqual(
+      expectV1Error('param_error', 'Invaild Parameter'),
+    )
+  })
+
+  test('T-U-PARACHAIN-PREFIX-03: prefix=NaN → param_error', async () => {
+    await expect(getAddress('PARA', 'path', NaN)).rejects.toEqual(
+      expectV1Error('param_error'),
+    )
+  })
+
+  test('T-U-PARACHAIN-PREFIX-04: prefix=null → param_error (Number(null) = 0)', async () => {
+    await expect(getAddress('PARA', 'path', null)).rejects.toEqual(
+      expectV1Error('param_error'),
+    )
+  })
+})

--- a/tests/unit/v2/sign/bitcoinTxBuilder.test.ts
+++ b/tests/unit/v2/sign/bitcoinTxBuilder.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Bitcoin transaction builder 단위 테스트 (m08-01-02.5)
+ *
+ * T-U-TXBLD-01..04: 정상 tx object / invalid coinType / input/output shape (snake_case keys)
+ * T-U-TXBLD-NESTED-01: 전체 envelope 검증 (v1 byte-wise 동등)
+ * T-U-TXBLD-NESTED-02: 다중 push
+ * T-MUT-TX-01/02: mutation 격리 (호출별 독립 객체)
+ */
+
+import {
+  getBitcoinTransactionObject,
+  addBitcoinTransactionInput,
+  addBitcoinTransactionOutput,
+} from '../../../../src/sign/bitcoinTxBuilder'
+
+describe('getBitcoinTransactionObject — m08-01-02.5', () => {
+  test('T-U-TXBLD-01: BITCOIN — 정상 tx object 생성, request_to === "BITCOIN"', () => {
+    const tx = getBitcoinTransactionObject('BITCOIN')
+    expect(tx.request.header.request_to).toBe('BITCOIN')
+    expect(tx.request.body.command).toBe('transaction')
+  })
+
+  test('T-U-TXBLD-02: invalid coinType → coin_type_error throw', () => {
+    expect(() => getBitcoinTransactionObject('ETHEREUM')).toThrow(
+      expect.objectContaining({
+        body: { error: { code: 'coin_type_error', message: 'not supported coin type' } },
+      }),
+    )
+  })
+
+  test('T-U-TXBLD-NESTED-01: 전체 envelope shape v1 1:1', () => {
+    const tx = getBitcoinTransactionObject('BITCOIN')
+    expect(tx.request.header.version).toBe('1.0')
+    expect(tx.request.header.request_to).toBe('BITCOIN')
+    expect(tx.request.body.command).toBe('transaction')
+    expect(tx.request.body.parameter.version).toBe(1)
+    expect(tx.request.body.parameter.locktime).toBe(0)
+    // input/output은 초기에는 없음 (push 시 lazy 생성)
+    expect(tx.request.body.parameter.input).toBeUndefined()
+    expect(tx.request.body.parameter.output).toBeUndefined()
+  })
+})
+
+describe('addBitcoinTransactionInput — m08-01-02.5', () => {
+  test('T-U-TXBLD-03: input shape — snake_case keys (prev_tx / utxo_idx)', () => {
+    const tx = getBitcoinTransactionObject('BITCOIN')
+    addBitcoinTransactionInput(tx, 'deadbeefRawHex', 1, 'p2pkh', "m/44'/0'/0'/0/0")
+
+    const inp = tx.request.body.parameter.input
+    expect(inp).toBeDefined()
+    expect(inp).toHaveLength(1)
+    expect(inp![0]).toEqual({
+      prev_tx: 'deadbeefRawHex',
+      utxo_idx: 1,
+      type: 'p2pkh',
+      key: "m/44'/0'/0'/0/0",
+    })
+    // Drift 방어: camelCase로 변환되지 않았는지
+    expect(inp![0]).not.toHaveProperty('prevTx')
+    expect(inp![0]).not.toHaveProperty('utxoIdx')
+  })
+
+  test('T-U-TXBLD-NESTED-02a: 다중 input push — length === N', () => {
+    const tx = getBitcoinTransactionObject('BITCOIN')
+    addBitcoinTransactionInput(tx, 'tx1', 0, 'p2pkh', 'k1')
+    addBitcoinTransactionInput(tx, 'tx2', 1, 'p2sh', 'k2')
+    addBitcoinTransactionInput(tx, 'tx3', 2, 'p2pk', 'k3')
+
+    expect(tx.request.body.parameter.input).toHaveLength(3)
+    expect(tx.request.body.parameter.input![0].prev_tx).toBe('tx1')
+    expect(tx.request.body.parameter.input![2].utxo_idx).toBe(2)
+  })
+})
+
+describe('addBitcoinTransactionOutput — m08-01-02.5', () => {
+  test('T-U-TXBLD-04: output shape {type, value, to}', () => {
+    const tx = getBitcoinTransactionObject('BITCOIN')
+    addBitcoinTransactionOutput(tx, 'p2pkh', '100000', '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa')
+
+    const out = tx.request.body.parameter.output
+    expect(out).toBeDefined()
+    expect(out).toHaveLength(1)
+    expect(out![0]).toEqual({
+      type: 'p2pkh',
+      value: '100000',
+      to: '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
+    })
+  })
+
+  test('T-U-TXBLD-NESTED-02b: 다중 output push — length === M', () => {
+    const tx = getBitcoinTransactionObject('BITCOIN')
+    addBitcoinTransactionOutput(tx, 'p2pkh', '100', 'addr1')
+    addBitcoinTransactionOutput(tx, 'change', '50', 'addr2')
+
+    expect(tx.request.body.parameter.output).toHaveLength(2)
+    expect(tx.request.body.parameter.output![1].type).toBe('change')
+  })
+})
+
+describe('Mutation isolation — m08-01-02.5', () => {
+  test('T-MUT-TX-01: 두 번 호출 → 서로 다른 객체 + 분리된 input/output 배열', () => {
+    const tx1 = getBitcoinTransactionObject('BITCOIN')
+    const tx2 = getBitcoinTransactionObject('BITCOIN')
+
+    expect(tx1).not.toBe(tx2)
+    expect(tx1.request).not.toBe(tx2.request)
+    expect(tx1.request.body).not.toBe(tx2.request.body)
+    expect(tx1.request.body.parameter).not.toBe(tx2.request.body.parameter)
+  })
+
+  test('T-MUT-TX-02: tx1.input.push가 tx2.input에 영향 없음', () => {
+    const tx1 = getBitcoinTransactionObject('BITCOIN')
+    const tx2 = getBitcoinTransactionObject('BITCOIN')
+
+    addBitcoinTransactionInput(tx1, 'leaky-tx', 0, 'p2pkh', 'k')
+
+    expect(tx1.request.body.parameter.input).toHaveLength(1)
+    expect(tx2.request.body.parameter.input).toBeUndefined()
+  })
+})

--- a/tests/unit/v2/sign/coinGroupValidator-drift.test.ts
+++ b/tests/unit/v2/sign/coinGroupValidator-drift.test.ts
@@ -1,0 +1,121 @@
+/**
+ * coinGroupValidator drift 방어 테스트 (m08-01-02.5)
+ *
+ * v1 isAvaliableCoinGroup (l479-516) + isAvailableSyncAccountCoinName (l531-543) 1:1.
+ *
+ * T-DRIFT-SYNCACC-01: 정상/invalid 짝 검증 + token group + non-token group 분기
+ */
+
+import {
+  isAvaliableCoinGroup,
+  isAvailableSyncAccountCoinName,
+} from '../../../../src/sign/coinGroupValidator'
+
+describe('isAvaliableCoinGroup — m08-01-02.5 (v1 enum 1:1)', () => {
+  test.each([
+    'BITCOIN', 'BTC-TESTNET',
+    'MONACOIN', 'MONA-TESTNET',
+    'ERC20', 'ERC20_KOVAN',
+    'ETHEREUM', 'ETH-KOVAN',
+    'RRC20', 'RRC20-TESTNET',
+    'RSK', 'RSK-TESTNET',
+    'KLAYTN', 'KLAYTN-TESTNET', 'KLAYTN-ERC20', 'KRC20-TESTNET',
+    'RIPPLE', 'XRP-TESTNET',
+    'XINFIN', 'XDC-APOTHEM', 'XRC20', 'XRC20-APOTHEM',
+    'HEDERA', 'HEDERA-HTS', 'HEDERA-TESTNET', 'HTS-TESTNET',
+    'STELLAR', 'TRON',
+  ])('valid coinGroup "%s" → true', (input) => {
+    expect(isAvaliableCoinGroup(input)).toBe(true)
+  })
+
+  test.each(['', 'random_unknown', 'foo-bar', 'COREUM', 'POLKADOT', 'ALGORAND'])(
+    'invalid coinGroup "%s" → false',
+    (input) => {
+      expect(isAvaliableCoinGroup(input)).toBe(false)
+    },
+  )
+
+  test('null → false (falsy guard)', () => {
+    expect(isAvaliableCoinGroup(null as unknown as string)).toBe(false)
+  })
+})
+
+describe('isAvailableSyncAccountCoinName — m08-01-02.5', () => {
+  describe('T-DRIFT-SYNCACC-01: non-token group → coin_name이 valid coinGroup이어야', () => {
+    test('BITCOIN + BITCOIN → true', () => {
+      expect(
+        isAvailableSyncAccountCoinName({ coin_group: 'BITCOIN', coin_name: 'BITCOIN' }),
+      ).toBe(true)
+    })
+
+    test('ETHEREUM + ETHEREUM → true', () => {
+      expect(
+        isAvailableSyncAccountCoinName({ coin_group: 'ETHEREUM', coin_name: 'ETHEREUM' }),
+      ).toBe(true)
+    })
+
+    test('BITCOIN + invalid coin_name → false', () => {
+      expect(
+        isAvailableSyncAccountCoinName({ coin_group: 'BITCOIN', coin_name: 'invalid_name' }),
+      ).toBe(false)
+    })
+  })
+
+  describe('T-DRIFT-SYNCACC-01b: token group (ERC20) → coin_name 0x prefix 필수', () => {
+    test('ERC20 + 0xabc → true', () => {
+      expect(
+        isAvailableSyncAccountCoinName({ coin_group: 'ERC20', coin_name: '0xabc123' }),
+      ).toBe(true)
+    })
+
+    test('ERC20 + 0XABC (uppercase 0X) → true', () => {
+      expect(
+        isAvailableSyncAccountCoinName({ coin_group: 'ERC20', coin_name: '0XABC123' }),
+      ).toBe(true)
+    })
+
+    test('ERC20 + no prefix → false', () => {
+      expect(
+        isAvailableSyncAccountCoinName({ coin_group: 'ERC20', coin_name: 'noprefix' }),
+      ).toBe(false)
+    })
+  })
+
+  describe('T-DRIFT-SYNCACC-01c: contract group exemption — token-typed only', () => {
+    /**
+     * v1 동작:
+     *   - isTokenType(coin_group)=true이면 token 분기로 진입하여 coin_name 0x prefix 또는
+     *     `_contractNotStartWith0x(coin_group)` 둘 중 하나라도 true면 valid.
+     *   - isTokenType=false이면 non-token 분기로 가서 coin_name이 valid coinGroup이어야.
+     *
+     * `_contractNotStartWith0x`는 token이 아닌 coin_group(TRC-TOKEN, HTS-TESTNET 등)도 포함하지만,
+     * 그 그룹들은 isTokenType=false이므로 token 분기에 도달하지 못함. 따라서 _contractNotStartWith0x
+     * exemption이 실제 효과를 주는 case는 isTokenType=true이면서 _contractNotStartWith0x도 true인
+     * coin_group뿐이다 — 즉 XRC20 / XRC20-APOTHEM / ALGO-ASSET / ALGO-APP / XC20 등.
+     */
+
+    test('XRC20 + non-0x coin_name → true (token + _contractNotStartWith0x exemption)', () => {
+      expect(
+        isAvailableSyncAccountCoinName({ coin_group: 'XRC20', coin_name: 'token-id' }),
+      ).toBe(true)
+    })
+
+    test('XRC20-APOTHEM + non-0x coin_name → true', () => {
+      expect(
+        isAvailableSyncAccountCoinName({ coin_group: 'XRC20-APOTHEM', coin_name: 'token-id' }),
+      ).toBe(true)
+    })
+
+    test('XC20 + non-0x coin_name → true (PARA_XC20)', () => {
+      expect(
+        isAvailableSyncAccountCoinName({ coin_group: 'XC20', coin_name: 'xc20-id' }),
+      ).toBe(true)
+    })
+
+    test('ALGO-ASSET + non-0x coin_name → true', () => {
+      expect(
+        isAvailableSyncAccountCoinName({ coin_group: 'ALGO-ASSET', coin_name: 'asset-id' }),
+      ).toBe(true)
+    })
+  })
+})

--- a/tests/unit/v2/sign/coinTypeValidators-drift.test.ts
+++ b/tests/unit/v2/sign/coinTypeValidators-drift.test.ts
@@ -1,0 +1,209 @@
+/**
+ * coinTypeValidators drift 방어 테스트 (m08-01-02.5)
+ *
+ * v2 helper들이 v1 src-v1/index.js의 동작과 1:1 일치하는지 검증.
+ *
+ * v1 helper들은 private(module-internal)이므로 require로 직접 비교 불가.
+ * 대신 v1 source의 case enum을 hardcoded fixture로 추출하여 v2 결과와 대조.
+ *
+ * Fixture 출처: src-v1/index.js#l470-688의 각 switch case + dcentCoinType / dcentCoinGroup enum.
+ *
+ * T-DRIFT-VALIDATOR-01: isAvaliableCoinType — 모든 enum 값 + invalid
+ * T-DRIFT-VALIDATOR-02: isCzoneCoinType
+ * T-DRIFT-VALIDATOR-03: isParachainCoinType
+ * T-DRIFT-VALIDATOR-04: isBitcoinTxCoinType
+ * T-DRIFT-VALIDATOR-05: isTokenType
+ * T-DRIFT-VALIDATOR-06: getCzonePrifix (v1 typo 보존)
+ */
+
+import { Buffer } from 'buffer'
+import {
+  isAvaliableCoinType,
+  isCzoneCoinType,
+  isParachainCoinType,
+  isBitcoinTxCoinType,
+  isTokenType,
+  getCzonePrifix,
+} from '../../../../src/sign/coinTypeValidators'
+import { coinType as dcentCoinType } from '../../../../src/types/coinType'
+import { coinGroup as dcentCoinGroup } from '../../../../src/types/coinGroup'
+
+// ────────────────────────────────────────────────────────────────────────────
+// Fixtures (v1 src-v1/index.js의 case enum을 그대로 옮김)
+// v2 enum은 m08-01-01에서 v1과 1:1 보장되므로 enum value를 그대로 사용.
+// ────────────────────────────────────────────────────────────────────────────
+
+/** v1 isAvaliableCoinType (l545-612)이 true 반환하는 모든 case. */
+const V1_AVAILABLE_COIN_TYPE_KEYS = [
+  'BITCOIN', 'BITCOIN_TESTNET', 'MONACOIN', 'MONACOIN_TESTNET',
+  'ETHEREUM', 'ETHEREUM_KOVAN', 'ERC20', 'ERC20_KOVAN',
+  'RRC20', 'RRC20_TESTNET', 'RSK', 'RSK_TESTNET',
+  'KLAYTN', 'KLAY_BAOBAB', 'KLAYTN_KCT', 'KCT_BAOBAB',
+  'RIPPLE', 'RIPPLE_TESTNET',
+  'XDC', 'XDC_APOTHEM', 'XRC20', 'XRC20_APOTHEM',
+  'HEDERA', 'HEDERA_HTS', 'HEDERA_TESTNET', 'HTS_TESTNET',
+  'STELLAR', 'STELLAR_TESTNET',
+  'TRON', 'TRON_TESTNET', 'TRON_TRC_TOKEN', 'TRON_TRC_TESTNET',
+  'TEZOS', 'TEZOS_TESTNET', 'XTZ_FA', 'XTZ_FA_TESTNET',
+  'VECHAIN', 'VECHAIN_ERC20',
+  'NEAR', 'NEAR_TESTNET', 'NEAR_TOKEN',
+  'HAVAH', 'HAVAH_TESTNET', 'HAVAH_HSP20', 'HAVAH_HSP20_TESTNET',
+  'POLKADOT', 'COSMOS', 'COREUM',
+  'ALGORAND', 'ALGORAND_TESTNET',
+  'ALGORAND_ASSET', 'ALGORAND_ASSET_TESTNET',
+  'ALGORAND_APP', 'ALGORAND_APP_TESTNET',
+  'PARA', 'PARA_TESTNET', 'PARA_XC20', 'PARA_XC20_TESTNET',
+] as const
+
+const INVALID_COIN_TYPES = ['', 'UNKNOWN_COIN', 'foo-bar', 'random123', '123']
+
+describe('coinTypeValidators drift — m08-01-02.5', () => {
+  describe('T-DRIFT-VALIDATOR-01: isAvaliableCoinType', () => {
+    // v1 동작: 입력은 enum **value**(혹은 case-insensitive 변형)이어야 매치.
+    // enum **key**는 일부만 매치(키와 값이 동일한 경우, 예: BITCOIN/ETHEREUM).
+    // 따라서 모든 v1 enum value를 fixture로 사용 + key 케이스는 별도로 매치 가능한 것만 검증.
+    test.each(V1_AVAILABLE_COIN_TYPE_KEYS)(
+      'enum value for %s → true (input as enum value)',
+      (key) => {
+        const value = (dcentCoinType as Record<string, string>)[key]
+        // v1 RIPPLE_TESTNET value는 빈 문자열 → falsy 가드로 false 반환 (v1 동작과 일치)
+        if (value === '') {
+          expect(isAvaliableCoinType(value)).toBe(false)
+        } else {
+          expect(isAvaliableCoinType(value)).toBe(true)
+        }
+      },
+    )
+
+    // 키 자체가 매치되는 케이스 — value === key.toLowerCase() 인 경우만 (case-insensitive)
+    test.each([
+      'BITCOIN', 'ETHEREUM', 'KLAYTN', 'RIPPLE',
+      'HEDERA', 'STELLAR', 'TRON', 'TEZOS', 'VECHAIN', 'NEAR',
+      'HAVAH', 'POLKADOT', 'COSMOS', 'COREUM', 'ALGORAND', 'PARA',
+    ])(
+      'enum key %s → true (key matches value lowercase)',
+      (key) => {
+        expect(isAvaliableCoinType(key)).toBe(true)
+      },
+    )
+
+    test.each(INVALID_COIN_TYPES)('invalid "%s" → false', (input) => {
+      expect(isAvaliableCoinType(input)).toBe(false)
+    })
+
+    // null/undefined도 falsy 가드로 false (TypeScript 타입을 우회한 런타임 검증)
+    test('null → false (falsy guard)', () => {
+      expect(isAvaliableCoinType(null as unknown as string)).toBe(false)
+    })
+    test('undefined → false (falsy guard)', () => {
+      expect(isAvaliableCoinType(undefined as unknown as string)).toBe(false)
+    })
+  })
+
+  describe('T-DRIFT-VALIDATOR-02: isCzoneCoinType', () => {
+    test('COREUM → true', () => {
+      expect(isCzoneCoinType('COREUM')).toBe(true)
+    })
+    test('coreum (lowercase value) → true', () => {
+      expect(isCzoneCoinType(dcentCoinType.COREUM)).toBe(true)
+    })
+    test.each(['BITCOIN', 'ETHEREUM', 'PARA', 'COSMOS'])(
+      'non-czone %s → false',
+      (input) => {
+        expect(isCzoneCoinType(input)).toBe(false)
+      },
+    )
+  })
+
+  describe('T-DRIFT-VALIDATOR-03: isParachainCoinType', () => {
+    // v1과 동일: enum value 또는 enum value의 대문자 변형 모두 허용 (toLowerCase 비교).
+    // enum 키 자체는 값과 다를 수 있어 사용 안 함 (e.g. PARA_TESTNET key vs 'para-testnet' value).
+    test.each([
+      dcentCoinType.PARA,             // 'para'
+      dcentCoinType.PARA_TESTNET,     // 'para-testnet'
+      dcentCoinType.PARA_XC20,        // 'para-xc20'
+      dcentCoinType.PARA_XC20_TESTNET, // 'para-xc20-testnet'
+      'PARA',                          // PARA key == value 'para' (toLowerCase 매치)
+    ])('parachain "%s" → true', (input) => {
+      expect(isParachainCoinType(input)).toBe(true)
+    })
+    test.each([
+      dcentCoinType.BITCOIN, dcentCoinType.ETHEREUM,
+      dcentCoinType.COSMOS, dcentCoinType.COREUM,
+    ])('non-parachain "%s" → false', (input) => {
+      expect(isParachainCoinType(input)).toBe(false)
+    })
+    test('null → false (falsy guard)', () => {
+      expect(isParachainCoinType(null as unknown as string)).toBe(false)
+    })
+  })
+
+  describe('T-DRIFT-VALIDATOR-04: isBitcoinTxCoinType', () => {
+    test.each([
+      dcentCoinType.BITCOIN,
+      dcentCoinType.BITCOIN_TESTNET,
+      dcentCoinType.MONACOIN,
+      dcentCoinType.MONACOIN_TESTNET,
+      'BITCOIN', // key == value 'bitcoin' 매치
+    ])('bitcoin tx "%s" → true', (input) => {
+      expect(isBitcoinTxCoinType(input)).toBe(true)
+    })
+    test.each([
+      dcentCoinType.ETHEREUM, dcentCoinType.COREUM,
+      dcentCoinType.PARA, 'foo',
+    ])('non-bitcoin "%s" → false', (input) => {
+      expect(isBitcoinTxCoinType(input)).toBe(false)
+    })
+  })
+
+  describe('T-DRIFT-VALIDATOR-05: isTokenType', () => {
+    // v1 src-v1/index.js#l614-643의 case 그대로
+    const tokenInputs = [
+      // coinGroup keys
+      dcentCoinGroup.ERC20, dcentCoinGroup.ERC20_KOVAN,
+      dcentCoinType.RRC20, dcentCoinType.RRC20_TESTNET,
+      dcentCoinType.KLAYTN_KCT, dcentCoinType.KCT_BAOBAB,
+      dcentCoinGroup.XRC20, dcentCoinGroup.XRC20_APOTHEM,
+      dcentCoinGroup.VECHAIN_ERC20,
+      dcentCoinGroup.HAVAH_HSP20, dcentCoinGroup.HAVAH_HSP20_TESTNET,
+      dcentCoinGroup.NEAR_TOKEN,
+      dcentCoinType.ALGORAND_ASSET, dcentCoinType.ALGORAND_ASSET_TESTNET,
+      dcentCoinType.ALGORAND_APP, dcentCoinType.ALGORAND_APP_TESTNET,
+      dcentCoinGroup.PARA_XC20, dcentCoinGroup.PARA_XC20_TESTNET,
+    ]
+
+    test.each(tokenInputs)('token group/type "%s" → true', (input) => {
+      expect(isTokenType(input)).toBe(true)
+    })
+
+    test.each(['BITCOIN', 'ETHEREUM', 'COREUM', 'PARA'])(
+      'non-token %s → false',
+      (input) => {
+        expect(isTokenType(input)).toBe(false)
+      },
+    )
+
+    test('null → false (falsy guard)', () => {
+      expect(isTokenType(null as unknown as string)).toBe(false)
+    })
+  })
+
+  describe('T-DRIFT-VALIDATOR-06: getCzonePrifix (v1 typo 보존)', () => {
+    test('COREUM → Buffer.from("core").toString("hex")', () => {
+      const expected = Buffer.from('core', 'utf8').toString('hex')
+      expect(getCzonePrifix('COREUM')).toBe(expected)
+    })
+
+    test('coreum (lowercase value) → 동일 hex', () => {
+      const expected = Buffer.from('core', 'utf8').toString('hex')
+      expect(getCzonePrifix(dcentCoinType.COREUM)).toBe(expected)
+    })
+
+    test.each(['BITCOIN', 'ETHEREUM', 'PARA'])(
+      'non-czone %s → undefined',
+      (input) => {
+        expect(getCzonePrifix(input)).toBeUndefined()
+      },
+    )
+  })
+})

--- a/tests/unit/v2/sign/configure.test.ts
+++ b/tests/unit/v2/sign/configure.test.ts
@@ -1,0 +1,159 @@
+/**
+ * setLabel / syncAccount / selectAddress 단위 테스트 (m08-01-02.5)
+ *
+ * T-U-LABEL-01/02: setLabel valid + invalid 4종
+ * T-U-SYNC-01..05: syncAccount 3종 검증 + 다중 account
+ * T-U-SEL-01/02: selectAddress array + non-array
+ */
+
+import { setLabel, syncAccount, selectAddress } from '../../../../src/sign/configure'
+import { ensureSingleton, _resetForTesting } from '../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+describe('setLabel — m08-01-02.5', () => {
+  test('T-U-LABEL-01: valid label "valid_label-2" → _call', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: { ok: true },
+    })
+
+    await setLabel('valid_label-2')
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    expect(sendSpy.mock.calls[0][0].method).toBe('setLabel')
+    expect(sendSpy.mock.calls[0][0].params).toEqual({ label: 'valid_label-2' })
+  })
+
+  test('T-U-LABEL-02a: too short ("a") → param_error throw', () => {
+    expect(() => setLabel('a')).toThrow(
+      expect.objectContaining({
+        body: { error: { code: 'param_error', message: 'Invalid Label : a' } },
+      }),
+    )
+  })
+
+  test('T-U-LABEL-02b: too long (15 chars) → param_error throw', () => {
+    const long15 = 'A'.repeat(15)
+    expect(() => setLabel(long15)).toThrow(
+      expect.objectContaining({ body: { error: { code: 'param_error', message: `Invalid Label : ${long15}` } } }),
+    )
+  })
+
+  test('T-U-LABEL-02c: 한글 → param_error throw', () => {
+    expect(() => setLabel('한글라벨')).toThrow(
+      expect.objectContaining({
+        body: { error: { code: 'param_error', message: 'Invalid Label : 한글라벨' } },
+      }),
+    )
+  })
+
+  test('T-U-LABEL-02d: 공백 포함 → param_error throw', () => {
+    expect(() => setLabel('has space')).toThrow(
+      expect.objectContaining({
+        body: { error: { code: 'param_error', message: 'Invalid Label : has space' } },
+      }),
+    )
+  })
+})
+
+describe('syncAccount — m08-01-02.5', () => {
+  test('T-U-SYNC-01: valid account → 3종 검증 통과 + _call', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 's1',
+      result: { ok: true },
+    })
+
+    const validAccount = {
+      coin_group: 'BITCOIN',
+      coin_name: 'BITCOIN',
+      label: 'main',
+    }
+    await syncAccount([validAccount])
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    expect(sendSpy.mock.calls[0][0].method).toBe('syncAccount')
+    expect(sendSpy.mock.calls[0][0].params).toEqual({ accountInfos: [validAccount] })
+  })
+
+  test('T-U-SYNC-02: invalid coin_group ("random") → coin_group_error throw', () => {
+    expect(() =>
+      syncAccount([{ coin_group: 'random_unknown', coin_name: 'BITCOIN', label: 'main' }]),
+    ).toThrow(
+      expect.objectContaining({
+        body: { error: { code: 'coin_group_error', message: 'not supported coin group' } },
+      }),
+    )
+  })
+
+  test('T-U-SYNC-03: ERC20 + coin_name without 0x prefix → coin_name_error throw', () => {
+    expect(() =>
+      syncAccount([{ coin_group: 'ERC20', coin_name: 'noprefix', label: 'main' }]),
+    ).toThrow(
+      expect.objectContaining({
+        body: { error: { code: 'coin_name_error', message: 'not supported coin name' } },
+      }),
+    )
+  })
+
+  test('T-U-SYNC-04: valid group/name + invalid label ("a") → param_error throw', () => {
+    expect(() =>
+      syncAccount([{ coin_group: 'BITCOIN', coin_name: 'BITCOIN', label: 'a' }]),
+    ).toThrow(
+      expect.objectContaining({
+        body: { error: { code: 'param_error', message: 'Invalid Label - a' } },
+      }),
+    )
+  })
+
+  test('T-U-SYNC-05: 다중 account 중 두 번째가 invalid → throw + _call 미호출 (early throw)', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 's5',
+      result: { ok: true },
+    })
+
+    const validAccount = { coin_group: 'BITCOIN', coin_name: 'BITCOIN', label: 'main' }
+    const invalidAccount = { coin_group: 'random_unknown', coin_name: 'X', label: 'sub' }
+
+    expect(() => syncAccount([validAccount, invalidAccount])).toThrow(
+      expect.objectContaining({
+        body: { error: { code: 'coin_group_error', message: 'not supported coin group' } },
+      }),
+    )
+
+    expect(sendSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('selectAddress — m08-01-02.5', () => {
+  test('T-U-SEL-01: array → _call', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'sa1',
+      result: { ok: true },
+    })
+
+    await selectAddress(['addr1', 'addr2'])
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    expect(sendSpy.mock.calls[0][0].method).toBe('selectAddress')
+    expect(sendSpy.mock.calls[0][0].params).toEqual({ addresses: ['addr1', 'addr2'] })
+  })
+
+  test('T-U-SEL-02: non-array → param_error throw', () => {
+    expect(() => selectAddress('notarray' as unknown as string[])).toThrow(
+      expect.objectContaining({
+        body: { error: { code: 'param_error', message: 'addresses is not array' } },
+      }),
+    )
+  })
+})

--- a/tests/unit/v2/sign/info.test.ts
+++ b/tests/unit/v2/sign/info.test.ts
@@ -1,0 +1,69 @@
+/**
+ * info / getDeviceInfo / getAccountInfo 단위 테스트 (m08-01-02.5)
+ *
+ * T-U-INFO-01: info() — _call({method: 'info'}) 호출
+ * T-U-DEVINFO-01: getDeviceInfo() — _call({method: 'getDeviceInfo'})
+ * T-U-ACC-01: getAccountInfo() — _call({method: 'getAccountInfo'})
+ *
+ * 모두 인자 없이 _call로 method를 그대로 위임하는 wrapper.
+ */
+
+import { info, getDeviceInfo, getAccountInfo } from '../../../../src/sign/info'
+import { ensureSingleton, _resetForTesting } from '../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+describe('read-only info functions — m08-01-02.5', () => {
+  test('T-U-INFO-01: info() → _call({method: "info"})', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'req-info',
+      result: { build: '1.2.3', running: true },
+    })
+
+    const resp = await info()
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    expect(sendSpy.mock.calls[0][0]).toMatchObject({ method: 'info' })
+    expect(sendSpy.mock.calls[0][0].params).toBeUndefined()
+    expect(resp.header.status).toBe('success')
+    expect(resp.body.command).toBe('info')
+    expect(resp.body.parameter).toEqual({ build: '1.2.3', running: true })
+  })
+
+  test('T-U-DEVINFO-01: getDeviceInfo() → _call({method: "getDeviceInfo"})', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'req-dev',
+      result: { device_id: 'D-XYZ', label: 'mywallet' },
+    })
+
+    const resp = await getDeviceInfo()
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    expect(sendSpy.mock.calls[0][0].method).toBe('getDeviceInfo')
+    expect(sendSpy.mock.calls[0][0].params).toBeUndefined()
+    expect(resp.body.parameter?.device_id).toBe('D-XYZ')
+  })
+
+  test('T-U-ACC-01: getAccountInfo() → _call({method: "getAccountInfo"})', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'req-acc',
+      result: { accounts: [{ coin_group: 'BITCOIN', coin_name: 'BITCOIN', label: 'main' }] },
+    })
+
+    const resp = await getAccountInfo()
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    expect(sendSpy.mock.calls[0][0].method).toBe('getAccountInfo')
+    expect(resp.header.status).toBe('success')
+    expect(Array.isArray(resp.body.parameter?.accounts)).toBe(true)
+  })
+})

--- a/tests/unit/v2/sign/labelValidator-drift.test.ts
+++ b/tests/unit/v2/sign/labelValidator-drift.test.ts
@@ -1,0 +1,51 @@
+/**
+ * labelValidator drift 방어 테스트 (m08-01-02.5)
+ *
+ * v1 isAvaliableLabel (src-v1/index.js#l470-477) regex `/^[a-zA-Z\d.!#$%&\+\-_]{2,14}$/` 1:1.
+ *
+ * T-DRIFT-LABEL-01: valid 4종 + reject 5종 + 경계값
+ */
+
+import { isAvaliableLabel } from '../../../../src/sign/labelValidator'
+
+describe('labelValidator drift — m08-01-02.5 (v1 regex 1:1)', () => {
+  // 정상 케이스 — v1 regex가 허용하는 문자 집합 + 길이 2~14
+  describe('T-DRIFT-LABEL-01: valid labels', () => {
+    test.each([
+      'ab', // 길이 2 (최소)
+      'a-z_AZ09', // 영숫자 + - _
+      'AAAAAAAAAAAAAA', // 길이 14 (최대)
+      '.!#$%&+_-', // 모든 허용 특수문자
+      'mywallet',
+      'D-CENT_001',
+    ])('valid "%s" → true', (label) => {
+      expect(isAvaliableLabel(label)).toBe(true)
+    })
+  })
+
+  // 거부 케이스 — regex unmatch
+  describe('T-DRIFT-LABEL-01b: invalid labels', () => {
+    test.each([
+      '', // 빈 문자열 (falsy 가드)
+      'a', // 길이 1 (< 2)
+      'A'.repeat(15), // 길이 15 (> 14)
+      '한글', // 비ASCII
+      '한글라벨',
+      'has space', // 공백 (regex 미허용)
+      'has@email', // @ 미허용
+      'with(paren)', // ( ) 미허용
+      'with[bracket]', // [ ] 미허용
+      'with/slash', // / 미허용
+    ])('invalid "%s" → false', (label) => {
+      expect(isAvaliableLabel(label)).toBe(false)
+    })
+  })
+
+  // null/undefined도 falsy 가드로 false (런타임 검증)
+  test('null → false', () => {
+    expect(isAvaliableLabel(null as unknown as string)).toBe(false)
+  })
+  test('undefined → false', () => {
+    expect(isAvaliableLabel(undefined as unknown as string)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

m08-01 connector v2 dApp facade epic (DC-1998)의 3번째 child. m08-01-02 generic sign core(`_call`) 머지 후, dApp이 직접 호출하는 v1 호환 표면을 추가한다.

- **8 read-only / configure 함수**: `info` / `getDeviceInfo` / `getAccountInfo` / `getAddress` (czone+parachain 분기) / `getXPUB` / `setLabel` / `syncAccount` / `selectAddress`
- **3 Bitcoin tx 빌더**: `getBitcoinTransactionObject` / `addBitcoinTransactionInput` / `addBitcoinTransactionOutput`
- **v1 검증 helper port**: `coinTypeValidators` / `labelValidator` / `coinGroupValidator`
- **`src/v1/dcent-exception.ts` 신설** — v1 throw object 형태 1:1 helper

### v1 호환 약속 (drift 시 wire format 깨짐)

- BitcoinTxObject **nested envelope** 보존: `{request: {header: {version, request_to}, body: {command, parameter}}}`
- snake_case keys 보존: `prev_tx`, `utxo_idx`, `coin_group`, `coin_name`
- v1 typo `getCzonePrifix` 그대로 export (수정 시 dApp 표면 깨짐)
- `isAvaliableLabel` regex `/^[a-zA-Z\d.!#$%&\+\-_]{2,14}$/` 1:1
- parachain prefix `!Number(prefix)` 검증 (0/''/NaN/null 모두 reject)
- `syncAccount` 3종 검증: `isAvaliableCoinGroup` → `isAvailableSyncAccountCoinName` → `isAvaliableLabel`

### 의존

- depends-on: m08-01-02-generic-sign-core (PR #136, MERGED_TO_EPIC) — `_call` / `V1Response` import
- epic: m08-01 (DC-1998)
- base: `epic/DC-1998_m08-01-connector-v2-dapp-facade`

## Rationale

**v1 1:1 호환**이 비스코프 첫 항목으로 명시된 핵심 제약: bridge sdk(dcent-web-sdk)가 m06-01 시점 그대로이므로 wire format(envelope shape, snake_case keys, validator regex)이 어떤 형태로든 변경되면 silent fail 또는 invalid signature. 따라서:

- BitcoinTxObject schema는 v1 nested envelope 그대로 보존 (flat camelCase 검토는 후속 m08-02)
- v1 typo `getCzonePrifix` 수정하지 않음 (dApp이 import하는 표면)
- 검증 함수의 case enum / regex는 v1 src-v1/index.js#l470-688 라인별 그대로 port

drift 테스트 3종(`coinTypeValidators-drift` / `labelValidator-drift` / `coinGroupValidator-drift`)으로 v1 enum membership / regex / 짝 검증 등치를 자동 회귀 보장.

## Tested

422 v2 unit tests PASS — 27 test suites:

- **Main test suites (m08-01-02.5)**: `info.test.ts` / `address.test.ts` / `configure.test.ts` / `bitcoinTxBuilder.test.ts`
  - T-U-INFO-01, T-U-DEVINFO-01, T-U-ACC-01
  - T-U-ADDR-01..06 (czone / parachain / 응답 복원 / invalid coinType)
  - T-U-XPUB-01
  - T-U-LABEL-01, T-U-LABEL-02a..d (4종 invalid: too short / too long / 한글 / 공백)
  - T-U-SYNC-01..05 (3종 검증 + 다중 account early throw)
  - T-U-SEL-01, T-U-SEL-02
  - T-U-TXBLD-01..04, T-U-TXBLD-NESTED-01..02 (envelope 전체 검증 + 다중 push)
  - T-U-PARACHAIN-PREFIX-01..04 (0 / '' / NaN / null 모두 reject)
  - T-MUT-TX-01, T-MUT-TX-02 (mutation 격리: 호출별 독립 객체)

- **Drift 방어 (3 suites)**:
  - T-DRIFT-VALIDATOR-01..06 (`coinTypeValidators` 모든 enum value + edge case)
  - T-DRIFT-LABEL-01 (정상 6종 + 거부 10종)
  - T-DRIFT-SYNCACC-01a..c (token / non-token / contract group exemption 분기)

- **Build / Type / Lint**:
  - `npx tsc --noEmit` ✅ (baseline 0 errors 유지)
  - `npx eslint --ext .ts src` ✅
  - `npm run lint` (legacy .js) ✅
  - `npm run build` (webpack UMD) ✅
  - `npx tsc --emitDeclarationOnly` ✅ — `dist/v2/index.d.ts`에 11개 함수 + 9개 validator 모두 시그니처 export
  - `node -e \"require('./dist/v2/dcent-web-connector.min.js').default\"` — `getDeviceInfo` / `getAddress` / `getBitcoinTransactionObject` / `getCzonePrifix` 모두 `function` ✅

## Constraints

- **PR diff ~889 LOC** (DoD 권장 600 LOC 초과). 사유:
  - `coinTypeValidators.ts` (208 LOC) — v1 `isAvaliableCoinType`의 60+ enum case 1:1 보존 + JSDoc
  - `bitcoinTxBuilder.ts` (151 LOC) — JSDoc 주석 다수
  - `coinGroupValidator.ts` (123 LOC) — v1 검증 로직 + JSDoc
  - 모두 v1 src-v1/index.js의 line 단위 1:1 port + 주석으로 lined number 추적
  - **`pr-size-exception: \"v1-port-migration: v1 src-v1/index.js#l470-688 + l781-921의 라인 단위 1:1 port + JSDoc/주석 보존. 새 비즈니스 로직 0%, format-preserving migration\"`**
- **CI**: epic-base PR이라 GitHub Actions 트리거가 제한적. 로컬 검증으로 보강.
- **Reviewers**: epic 자동화 chain 모드 (사용자 정책: NO REVIEWERS — chain orchestrator가 즉시 머지)
- **Merge**: 사용자 정책에 따라 chain orchestrator(main)가 ready 시점에 즉시 머지

## Out of scope (이 PR 비포함)

- v1 호환 sign wrapper (`getEthereumSignedTransaction` 등) — m08-01-03/04 후속 child
- BitcoinTxObject schema flat camelCase 변경 — 후속 m08-02
- v1 typo `getCzonePrifix` 수정 (dApp 표면 보존)
- `package.json` `version` 변경 (`no-version-bump` 룰 준수)

## Related

- Epic: m08-01 (DC-1998), epic branch `epic/DC-1998_m08-01-connector-v2-dapp-facade`
- depends-on: m08-01-02-generic-sign-core (PR #136 머지됨)
- next: m08-01-03 (v1 호환 sign wrapper, 일부)