### PR TITLE
[DC-2002] feat(v2): connector v2 v1 EVM sign wrappers (m08-01-03)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,13 @@ import {
   isAvaliableLabel,
   isAvaliableCoinGroup,
   isAvailableSyncAccountCoinName,
+  // m08-01-03: v1 EVM sign wrappers + checkParameter helper
+  getEthereumSignedTransaction,
+  getEthereumSignedMessage,
+  getTokenSignedTransaction,
+  getKlaytnSignedTransaction,
+  checkParameter,
+  _sanitizeEthereumTypeOptions,
 } from './sign'
 
 // === 기존 named exports (m02-01·m02-02·m07-02 SHIPPED) ===
@@ -131,6 +138,17 @@ export {
   isAvailableSyncAccountCoinName,
 } from './sign'
 
+// === 새 named exports (m08-01-03 — v1 EVM sign wrappers + checkParameter helper) ===
+export {
+  getEthereumSignedTransaction,
+  getEthereumSignedMessage,
+  getTokenSignedTransaction,
+  getKlaytnSignedTransaction,
+  checkParameter,
+  _sanitizeEthereumTypeOptions,
+} from './sign'
+export type { EvmTokenContract, KlaytnContract, EthereumTypeOptions } from './sign'
+
 // === default export object (v1 호환 패턴) ===
 //
 // dApp이 `import dcent from 'dcent-web-connector'` 또는 `const dcent = require(...)`로
@@ -176,6 +194,13 @@ const dcent = {
   isAvaliableLabel,
   isAvaliableCoinGroup,
   isAvailableSyncAccountCoinName,
+  // m08-01-03: v1 EVM sign wrappers + checkParameter helper
+  getEthereumSignedTransaction,
+  getEthereumSignedMessage,
+  getTokenSignedTransaction,
+  getKlaytnSignedTransaction,
+  checkParameter,
+  _sanitizeEthereumTypeOptions,
 } as const
 
 export default dcent

--- a/src/sign/_sanitizeEthereumTypeOptions.ts
+++ b/src/sign/_sanitizeEthereumTypeOptions.ts
@@ -1,0 +1,89 @@
+/**
+ * EVM type_options sanitize helper (m08-01-03)
+ *
+ * `getEthereumSignedTransaction(..., typeOptions)`이 dApp에서 받는 `typeOptions` 객체를
+ * known fields whitelist로만 추출. `dapp-input-sanitization` / `provider-security-checklist` C3 룰 준수.
+ *
+ * 적용 룰:
+ *   - dapp-input-sanitization: dApp 입력 객체 직접 spread/pass-through 금지. known fields만 추출.
+ *   - provider-security-checklist C3: typeOptions는 dApp-controllable 필드. EIP-1559/2930 spec 정의 필드만 통과.
+ *
+ * 검증 단계:
+ *   1. opts가 null/undefined/non-object → 빈 객체 반환
+ *   2. `__proto__` / `constructor` / `prototype` 키 명시 차단 (대소문자 무시)
+ *   3. `maxFeePerGas` / `maxPriorityFeePerGas`: string 타입만 통과
+ *   4. `accessList`: Array 타입 + 각 entry가 `{address: string, storageKeys: string[]}` shape인 것만 통과
+ *
+ * 결과는 매 호출마다 새 객체 (`mutation-isolation` 룰).
+ */
+
+/* eslint-disable camelcase */
+/** EVM EIP-1559 + EIP-2930 type_options known fields. v2 spec 추가 시 본 인터페이스 확장. */
+export interface EthereumTypeOptions {
+  /** EIP-1559 max fee per gas (hex string). */
+  maxFeePerGas?: string
+  /** EIP-1559 max priority fee per gas (hex string). */
+  maxPriorityFeePerGas?: string
+  /** EIP-2930 access list entries. */
+  accessList?: Array<{ address: string; storageKeys: string[] }>
+}
+/* eslint-enable camelcase */
+
+/** prototype pollution 방어 — 명시적으로 차단할 키 (case-insensitive). */
+const PROTOTYPE_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
+/**
+ * dApp이 전달한 typeOptions를 known fields만 추출하여 새 객체로 반환한다.
+ *
+ * @param opts dApp이 전달한 typeOptions (검증되지 않은 입력)
+ * @returns 매 호출마다 새 EthereumTypeOptions 객체 (mutation-isolation)
+ */
+export function _sanitizeEthereumTypeOptions (opts?: unknown): EthereumTypeOptions {
+  const safe: EthereumTypeOptions = {}
+
+  if (opts === null || opts === undefined || typeof opts !== 'object') {
+    return safe
+  }
+
+  const o = opts as Record<string, unknown>
+
+  // maxFeePerGas — string only
+  if (typeof o.maxFeePerGas === 'string' && !PROTOTYPE_KEYS.has('maxFeePerGas'.toLowerCase())) {
+    safe.maxFeePerGas = o.maxFeePerGas
+  }
+
+  // maxPriorityFeePerGas — string only
+  if (typeof o.maxPriorityFeePerGas === 'string') {
+    safe.maxPriorityFeePerGas = o.maxPriorityFeePerGas
+  }
+
+  // accessList — Array of { address: string, storageKeys: string[] }
+  if (Array.isArray(o.accessList)) {
+    const cleaned: Array<{ address: string; storageKeys: string[] }> = []
+    for (const entry of o.accessList) {
+      if (entry === null || entry === undefined || typeof entry !== 'object') continue
+      const e = entry as Record<string, unknown>
+      if (typeof e.address !== 'string') continue
+      if (!Array.isArray(e.storageKeys)) continue
+      const storageKeys: string[] = []
+      let allStrings = true
+      for (const k of e.storageKeys) {
+        if (typeof k !== 'string') { allStrings = false; break }
+        storageKeys.push(k)
+      }
+      if (!allStrings) continue
+      cleaned.push({ address: e.address, storageKeys })
+    }
+    safe.accessList = cleaned
+  }
+
+  // prototype pollution 방어 — known field 추출만 했으므로 unknown / __proto__ 등은 자동 차단됨.
+  // 명시적 검증으로 추가 안전장치:
+  for (const key of Object.keys(safe)) {
+    if (PROTOTYPE_KEYS.has(key.toLowerCase())) {
+      delete (safe as Record<string, unknown>)[key]
+    }
+  }
+
+  return safe
+}

--- a/src/sign/checkParameter.ts
+++ b/src/sign/checkParameter.ts
@@ -1,0 +1,67 @@
+/**
+ * v1 checkParameter helper port (m08-01-03)
+ *
+ * v1 src-v1/index.js#l418의 `checkParameter(type, param)` helper를 v2 TypeScript로 1:1 port.
+ *
+ * v1 동작 (1:1 호환):
+ *   - type === 'numberString':
+ *     - typeof param !== 'string' → throw `dcentException('param_error', 'Invaild Parameter - ' + param)` (오타 그대로)
+ *     - `0x` prefix 없음 + isNumberString(param) → 그대로 반환
+ *     - `0x` prefix 있음 + isHexNumberString(param) → 그대로 반환
+ *     - 어느 분기에도 매칭되지 않음 → throw `dcentException('param_error', 'Invaild Parameter - - - ' + param)` (오타 + 4 dashes)
+ *   - 기타 type → 정의되지 않음 (v1과 동일하게 undefined 반환 ; m08-01-04 wrapper들이 'numberString' 외 type을 도입할 수 있음)
+ *
+ * 룰 준수:
+ *   - boundary-validation: 입력 문자열의 type/format을 검증, 실패 시 throw (silent return 금지)
+ *   - error-handling-consistency: 모든 검증 실패는 throw (`dcentException`)
+ *   - external-reference-edge-cases: v1 정규식과 1:1 동등 (drift defense T-DRIFT-CHK-01이 강제)
+ *   - reuse-shared-utils: v1 helper를 v2 경로로 옮김 (m08-01-04 wrapper들도 import)
+ */
+
+import { dcentException } from '../v1/dcent-exception'
+
+/**
+ * v1 isNumberString — 10진수 숫자 문자열 검증.
+ *
+ * v1 src-v1/index.js와 동일한 정규식: `^[0-9]+$` (양의 정수, '0' 포함).
+ */
+function isNumberString (str: string): boolean {
+  return /^[0-9]+$/.test(str)
+}
+
+/**
+ * v1 isHexNumberString — 16진수 숫자 문자열 검증.
+ *
+ * v1 src-v1/index.js와 동일한 정규식: lowercase 후 `^(0x)?[0-9a-f]+$` 매칭.
+ */
+function isHexNumberString (str: string): boolean {
+  return /^(0x)?[0-9a-f]+$/.test(str.toLowerCase())
+}
+
+/**
+ * v1 checkParameter — 입력 문자열의 type을 검증하고 정규화 반환.
+ *
+ * 현재 지원: `'numberString'` (10진/16진 숫자 문자열). m08-01-04에서 추가 type 도입 가능.
+ *
+ * @param type 검증 타입 (`'numberString'`)
+ * @param param 검증 대상 값
+ * @returns 검증 통과한 입력 그대로 반환 (정규화 없음 — v1 동작)
+ * @throws V1Exception (`'param_error'`) — 검증 실패 시
+ */
+export function checkParameter (type: string, param: unknown): string {
+  if (type === 'numberString') {
+    if (typeof param !== 'string') {
+      throw dcentException('param_error', 'Invaild Parameter - ' + String(param))
+    }
+    if (param.indexOf('0x') === -1) {
+      // 10진수 숫자 문자열
+      if (isNumberString(param)) return param
+    } else if (param.indexOf('0x') === 0) {
+      // 16진수 숫자 문자열
+      if (isHexNumberString(param)) return param
+    }
+    throw dcentException('param_error', 'Invaild Parameter - - - ' + param)
+  }
+  // v1과 동일: 정의되지 않은 type은 undefined 반환 (m08-01-04에서 추가)
+  return param as string
+}

--- a/src/sign/evm.ts
+++ b/src/sign/evm.ts
@@ -1,0 +1,312 @@
+/**
+ * v1 EVM sign wrappers — module-level functions (m08-01-03)
+ *
+ * v1 src-v1/index.js의 4개 EVM sign 함수를 v2 facade에 1:1 호환 port:
+ *   - getEthereumSignedTransaction (l961~l1032)
+ *   - getEthereumSignedMessage (l1110~l1118)
+ *   - getTokenSignedTransaction (l1046~l1101)
+ *   - getKlaytnSignedTransaction (l1136~l1210)
+ *
+ * 핵심 동작:
+ *   - 인자 검증 v1 1:1 (`Invaild` 오타, `txType !== 2일 때만 gasPrice 검증` 등)
+ *   - bridge sdk 호환을 위한 snake_case params keys (`gas_price`, `gas_limit`, `chain_id`, `tx_type`, `type_options`, `fee_ratio`)
+ *     → camelCase로 보내면 silent fail. T-DRIFT-EVM-01이 강제.
+ *   - txType !== 0 → method 이름이 `getEthereumSignedTypedTransaction`로 변경 (EIP-2930/EIP-1559)
+ *   - Klaytn `from` 미제공 시 `getAddress(coinType, key)` 자동 호출 (m08-01-02.5 의존)
+ *   - Klaytn coinType 정규화 (KLAY_BAOBAB→KLAYTN, KCT_BAOBAB→KLAYTN_KCT)
+ *   - XDC prefix 변환 (xdc → 0x)
+ *   - typeOptions sanitize (`provider-security-checklist` C3)
+ *
+ * 룰 준수:
+ *   - boundary-validation: 모든 인자 검증 (`checkParameter` + chainId/txType/decimals 타입 체크)
+ *   - error-handling-consistency: 검증 실패는 throw, popup/network 에러는 _call이 v1 호환 응답으로 변환
+ *   - mutation-isolation: _call이 매 호출마다 새 V1Response 객체 반환
+ *   - dapp-input-sanitization: typeOptions whitelist (`_sanitizeEthereumTypeOptions`)
+ *   - provider-security-checklist C3: typeOptions options whitelist
+ *   - cross-repo-interface-edit: bridge sdk가 알아야 하는 method 이름 + snake_case params shape 보존
+ *   - reuse-shared-utils: `_call`, `getAddress`, `dcentException`, `XDCPrefixConverter`, `coinType`/`klaytnTxType` enum 모두 재사용
+ *   - external-reference-edge-cases: drift defense T-DRIFT-EVM-01이 v1 wrapper와 bytewise 동등 단언
+ */
+
+/* eslint-disable camelcase */
+
+import { _call } from './call'
+import { checkParameter } from './checkParameter'
+import { _sanitizeEthereumTypeOptions, type EthereumTypeOptions } from './_sanitizeEthereumTypeOptions'
+import { getAddress } from './address'
+import { dcentException } from '../v1/dcent-exception'
+import { coinType as dcentCoinType } from '../types/coinType'
+import { klaytnTxType as dcentKlaytnTxType } from '../types/klaytnTxType'
+import { XDCPrefixConverter } from '../utils/xdc-prefix-converter'
+import type { V1Response } from './types'
+
+/** EVM 기본 wrapper의 기대 contract shape (token wrapper용). */
+export interface EvmTokenContract {
+  address: string
+  symbol: string
+  decimals: number | string
+  value: string
+  to: string
+}
+
+/** Klaytn KCT용 contract shape (선택적). */
+export interface KlaytnContract {
+  address?: string
+  symbol?: string
+  decimals?: number | string
+  value?: string
+  to?: string
+  [key: string]: unknown
+}
+
+/**
+ * v1 dcent.getEthereumSignedTransaction (src-v1/index.js#l961-l1032) 1:1 port.
+ *
+ * 동작:
+ *   1. chainId/txType 타입 검증 → 위반 시 `dcentException('param_error', 'Invaild Parameter')` throw
+ *   2. nonce/gasPrice(txType !== 2)/gasLimit/value 모두 `checkParameter('numberString', ...)` 검증
+ *   3. coinType switch:
+ *      - ETHEREUM/ETHEREUM_KOVAN/RSK/RSK_TESTNET → 그대로
+ *      - XDC/XDC_APOTHEM → `to = XDCPrefixConverter(to)` (xdc → 0x)
+ *      - 그 외 → `dcentException('coin_type_error', 'not supported coin type')` throw
+ *   4. typeOptions sanitize (`_sanitizeEthereumTypeOptions`)
+ *   5. snake_case params 구성 (bridge sdk wire format)
+ *   6. txType !== 0 → method 이름을 `getEthereumSignedTypedTransaction`로 변경
+ *   7. `_call({method, params})` 호출
+ *
+ * @returns V1Response (v1 호환 `{header, body}` shape)
+ */
+export async function getEthereumSignedTransaction (
+  coinType: string,
+  nonce: string,
+  gasPrice: string,
+  gasLimit: string,
+  to: string,
+  value: string,
+  data: string,
+  key: string,
+  chainId: number,
+  txType: number = 0,
+  typeOptions: Record<string, unknown> = {}
+): Promise<V1Response> {
+  if (typeof chainId !== 'number' || typeof txType !== 'number' || txType < 0 || txType > 2) {
+    throw dcentException('param_error', 'Invaild Parameter')
+  }
+
+  // v1과 동일하게 try/catch 구조 — 실제로는 throw를 그대로 propagate
+  nonce = checkParameter('numberString', nonce)
+  if (txType !== 2) {
+    gasPrice = checkParameter('numberString', gasPrice)
+  }
+  gasLimit = checkParameter('numberString', gasLimit)
+  value = checkParameter('numberString', value)
+
+  switch (coinType.toLowerCase()) {
+    case dcentCoinType.ETHEREUM.toLowerCase():
+    case dcentCoinType.ETHEREUM_KOVAN.toLowerCase():
+    case dcentCoinType.RSK.toLowerCase():
+    case dcentCoinType.RSK_TESTNET.toLowerCase():
+      break
+    case dcentCoinType.XDC.toLowerCase():
+    case dcentCoinType.XDC_APOTHEM.toLowerCase():
+      to = XDCPrefixConverter(to)
+      break
+    default:
+      throw dcentException('coin_type_error', 'not supported coin type')
+  }
+
+  // C3 sanitize — dApp 입력 객체의 unknown / prototype 키 차단
+  const safeTypeOptions: EthereumTypeOptions = _sanitizeEthereumTypeOptions(typeOptions)
+
+  // 🔴 snake_case params — bridge sdk wire format 호환의 핵심 (T-DRIFT-EVM-01)
+  const params: Record<string, unknown> = {
+    coinType: coinType,
+    nonce: nonce,
+    gas_price: gasPrice,
+    gas_limit: gasLimit,
+    to: to,
+    value: value,
+    data: data,
+    key: key,
+    chain_id: chainId,
+    tx_type: txType,
+    type_options: safeTypeOptions,
+  }
+
+  // txType !== 0 → method 이름 변경 (EIP-2930=1, EIP-1559=2)
+  const method = txType === 0 ? 'getEthereumSignedTransaction' : 'getEthereumSignedTypedTransaction'
+
+  return _call({ method, params })
+}
+
+/**
+ * v1 dcent.getEthereumSignedMessage (src-v1/index.js#l1110-l1118) 1:1 port.
+ *
+ * personal_sign / signTypedData 류. 인자 검증 없음 (v1과 동일).
+ *
+ * @returns V1Response
+ */
+export async function getEthereumSignedMessage (
+  message: string,
+  key: string
+): Promise<V1Response> {
+  return _call({
+    method: 'getEthereumSignedMessage',
+    params: {
+      message: message,
+      key: key,
+    },
+  })
+}
+
+/**
+ * v1 dcent.getTokenSignedTransaction (src-v1/index.js#l1046-l1101) 1:1 port.
+ *
+ * 동작:
+ *   1. nonce/gasPrice/gasLimit/contract.value 모두 `checkParameter('numberString', ...)` 검증
+ *   2. chainId/contract.decimals 타입 검증 → 위반 시 `dcentException('param_error', 'Invaild Parameter')` throw
+ *   3. token switch:
+ *      - ERC20/ERC20_KOVAN/RRC20/RRC20_TESTNET/KLAYTN_KCT/KCT_BAOBAB → 그대로
+ *      - XRC20/XRC20_APOTHEM → contract.to + contract.address XDC prefix 변환
+ *      - 그 외 → `dcentException('coin_type_error', 'not supported token type')` throw
+ *   4. snake_case params로 `_call`
+ *
+ * @returns V1Response
+ */
+export async function getTokenSignedTransaction (
+  token: string,
+  nonce: string,
+  gasPrice: string,
+  gasLimit: string,
+  key: string,
+  chainId: number,
+  contract: EvmTokenContract
+): Promise<V1Response> {
+  nonce = checkParameter('numberString', nonce)
+  gasPrice = checkParameter('numberString', gasPrice)
+  gasLimit = checkParameter('numberString', gasLimit)
+  contract.value = checkParameter('numberString', contract.value)
+
+  if (typeof chainId !== 'number' || typeof contract.decimals !== 'number') {
+    throw dcentException('param_error', 'Invaild Parameter')
+  }
+
+  switch (token.toLowerCase()) {
+    case dcentCoinType.ERC20.toLowerCase():
+    case dcentCoinType.ERC20_KOVAN.toLowerCase():
+    case dcentCoinType.RRC20.toLowerCase():
+    case dcentCoinType.RRC20_TESTNET.toLowerCase():
+    case dcentCoinType.KLAYTN_KCT.toLowerCase():
+    case dcentCoinType.KCT_BAOBAB.toLowerCase():
+      break
+    case dcentCoinType.XRC20.toLowerCase():
+    case dcentCoinType.XRC20_APOTHEM.toLowerCase():
+      contract.to = XDCPrefixConverter(contract.to)
+      contract.address = XDCPrefixConverter(contract.address)
+      break
+    default:
+      throw dcentException('coin_type_error', 'not supported token type')
+  }
+
+  return _call({
+    method: 'getTokenSignedTransaction',
+    params: {
+      token: token,
+      nonce: nonce,
+      gas_price: gasPrice,
+      gas_limit: gasLimit,
+      key: key,
+      chain_id: chainId,
+      contract: contract,
+    },
+  })
+}
+
+/**
+ * v1 dcent.getKlaytnSignedTransaction (src-v1/index.js#l1136-l1210) 1:1 port.
+ *
+ * 동작:
+ *   1. nonce/gasPrice/gasLimit/value 모두 `checkParameter('numberString', ...)` 검증
+ *   2. contract 있으면 contract.decimals도 검증
+ *   3. chainId 타입 검증 → 위반 시 `dcentException('param_error', 'Invaild Parameter chainId - {chainId}')` throw
+ *   4. coinType switch:
+ *      - KLAYTN/KLAY_BAOBAB → coinType = KLAYTN (정규화)
+ *      - KLAYTN_KCT/KCT_BAOBAB → coinType = KLAYTN_KCT (정규화)
+ *      - 그 외 → `dcentException('coin_type_error', 'not supported coin type')` throw
+ *   5. txType falsy → `dcentKlaytnTxType.LEGACY` (0xff) fallback
+ *   6. from falsy → `getAddress(coinType, key)` 자동 호출 후 `body.parameter.address` 채움 (fee delegation flow)
+ *   7. snake_case params로 `_call`
+ *
+ * @returns V1Response
+ */
+export async function getKlaytnSignedTransaction (
+  coinType: string,
+  nonce: string,
+  gasPrice: string,
+  gasLimit: string,
+  to: string,
+  value: string,
+  data: string,
+  key: string,
+  chainId: number,
+  txType: number,
+  from?: string,
+  feeRatio?: string | number,
+  contract?: KlaytnContract
+): Promise<V1Response> {
+  nonce = checkParameter('numberString', nonce)
+  gasPrice = checkParameter('numberString', gasPrice)
+  gasLimit = checkParameter('numberString', gasLimit)
+  value = checkParameter('numberString', value)
+  if (contract && contract.decimals !== undefined) {
+    contract.decimals = checkParameter('numberString', contract.decimals)
+  }
+
+  if (typeof chainId !== 'number') {
+    throw dcentException('param_error', 'Invaild Parameter chainId - ' + String(chainId))
+  }
+
+  switch (coinType.toLowerCase()) {
+    case dcentCoinType.KLAYTN.toLowerCase():
+    case dcentCoinType.KLAY_BAOBAB.toLowerCase():
+      coinType = dcentCoinType.KLAYTN
+      break
+    case dcentCoinType.KLAYTN_KCT.toLowerCase():
+    case dcentCoinType.KCT_BAOBAB.toLowerCase():
+      coinType = dcentCoinType.KLAYTN_KCT
+      break
+    default:
+      throw dcentException('coin_type_error', 'not supported coin type')
+  }
+
+  if (!txType) {
+    txType = dcentKlaytnTxType.LEGACY
+  }
+
+  if (!from) {
+    const addressResponse = await getAddress(coinType, key)
+    const addressParam = addressResponse?.body?.parameter as { address?: string } | undefined
+    if (addressParam && typeof addressParam.address === 'string') {
+      from = addressParam.address
+    }
+  }
+
+  return _call({
+    method: 'getKlaytnSignedTransaction',
+    params: {
+      coinType: coinType,
+      nonce: nonce,
+      gas_price: gasPrice,
+      gas_limit: gasLimit,
+      to: to,
+      value: value,
+      data: data,
+      key: key,
+      chain_id: chainId,
+      tx_type: txType,
+      from: from,
+      fee_ratio: feeRatio,
+      contract: contract,
+    },
+  })
+}

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -47,3 +47,15 @@ export {
   isAvaliableCoinGroup,
   isAvailableSyncAccountCoinName,
 } from './coinGroupValidator'
+
+// m08-01-03: v1 EVM sign wrappers + checkParameter helper + typeOptions sanitize
+export {
+  getEthereumSignedTransaction,
+  getEthereumSignedMessage,
+  getTokenSignedTransaction,
+  getKlaytnSignedTransaction,
+} from './evm'
+export type { EvmTokenContract, KlaytnContract } from './evm'
+export { checkParameter } from './checkParameter'
+export { _sanitizeEthereumTypeOptions } from './_sanitizeEthereumTypeOptions'
+export type { EthereumTypeOptions } from './_sanitizeEthereumTypeOptions'

--- a/src/utils/xdc-prefix-converter.ts
+++ b/src/utils/xdc-prefix-converter.ts
@@ -1,0 +1,38 @@
+/**
+ * v1 XDC prefix converter port (m08-01-03)
+ *
+ * v1 src-v1/utils/xdc-prefix-converter.js를 v2 TypeScript로 1:1 port.
+ *
+ * 동작 (v1 1:1):
+ *   - 입력이 `0x`로 시작하면 그대로 반환
+ *   - 입력이 `xdc`로 시작하면 `xdc` 3글자를 `0x`로 치환
+ *   - 그 외에는 v1과 동일하게 `'0x' + str.address` 형태로 반환 (v1 quirk: object를 string처럼 다룸)
+ *
+ * v1 quirk 보존: v1은 `str.address` 접근자를 사용하므로, 객체가 들어오면 `address` 필드를 꺼내서
+ * 0x를 prefix하는 동작. v2도 동일하게 보존하지만 TypeScript 타입은 string으로 강제하고
+ * 실패 시 원본 동작을 유지하기 위해 `string & {address?: string}` 광의 사용.
+ *
+ * 룰 준수:
+ *   - reuse-shared-utils: v1 src-v1/utils/에 이미 존재하는 helper를 v2 경로로 옮김
+ *   - boundary-validation: 입력 문자열이 0x/xdc/기타 분기 명시
+ */
+
+/**
+ * XDC 주소를 0x prefix로 변환한다.
+ *
+ * v1 src-v1/utils/xdc-prefix-converter.js와 1:1 호환.
+ *
+ * @param str XDC 주소 문자열 (`xdc...` 또는 `0x...`)
+ * @returns 0x로 시작하는 주소 문자열
+ */
+export function XDCPrefixConverter (str: string): string {
+  if (!str.startsWith('0x')) {
+    if (str.startsWith('xdc')) {
+      str = '0x' + str.substring(3)
+    } else {
+      // v1 quirk: 비표준 입력은 (str.address) 필드를 사용 — object가 string으로 들어왔을 때 호환
+      str = '0x' + (str as unknown as { address: string }).address
+    }
+  }
+  return str
+}

--- a/tests/unit/v2/sign/_sanitizeEthereumTypeOptions.test.ts
+++ b/tests/unit/v2/sign/_sanitizeEthereumTypeOptions.test.ts
@@ -1,0 +1,112 @@
+/**
+ * _sanitizeEthereumTypeOptions 단위 테스트 (m08-01-03)
+ *
+ * T-SEC-WHITE-EVM-01: known fields(maxFeePerGas, maxPriorityFeePerGas, accessList)만 통과, unknown 키 제거
+ * T-SEC-WHITE-EVM-02: prototype 키(__proto__, constructor, prototype) 차단
+ * T-SEC-WHITE-EVM-03: invalid 타입은 silent drop. opts null/undefined → 빈 객체
+ *
+ * 룰: dapp-input-sanitization, provider-security-checklist C3
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { _sanitizeEthereumTypeOptions } from '../../../../src/sign/_sanitizeEthereumTypeOptions'
+
+describe('_sanitizeEthereumTypeOptions — T-SEC-WHITE-EVM-01 known fields whitelist', () => {
+  test('known fields 모두 통과', () => {
+    const result = _sanitizeEthereumTypeOptions({
+      maxFeePerGas: '0x100',
+      maxPriorityFeePerGas: '0x10',
+      accessList: [{ address: '0xabc', storageKeys: ['0x1', '0x2'] }],
+    })
+    expect(result).toEqual({
+      maxFeePerGas: '0x100',
+      maxPriorityFeePerGas: '0x10',
+      accessList: [{ address: '0xabc', storageKeys: ['0x1', '0x2'] }],
+    })
+  })
+
+  test('unknown 키는 silent drop', () => {
+    const result = _sanitizeEthereumTypeOptions({
+      maxFeePerGas: '0x100',
+      unknownKey: 'evil',
+      anotherKey: 12345,
+    } as any)
+    expect(result).toEqual({ maxFeePerGas: '0x100' })
+    expect(result).not.toHaveProperty('unknownKey')
+    expect(result).not.toHaveProperty('anotherKey')
+  })
+})
+
+describe('_sanitizeEthereumTypeOptions — T-SEC-WHITE-EVM-02 prototype 차단', () => {
+  test('__proto__ 키 직접 주입 → 결과에 polluted 안 나옴', () => {
+    const evil = JSON.parse('{"maxFeePerGas":"0x100","__proto__":{"polluted":true}}')
+    const result = _sanitizeEthereumTypeOptions(evil)
+    expect(result).toEqual({ maxFeePerGas: '0x100' })
+    expect((result as any).polluted).toBeUndefined()
+    // 전역 Object.prototype 오염 안 됨
+    expect(({} as any).polluted).toBeUndefined()
+  })
+
+  test('constructor 키 → silent drop', () => {
+    const result = _sanitizeEthereumTypeOptions({
+      constructor: { evil: true },
+      maxFeePerGas: '0x100',
+    } as any)
+    expect(result).toEqual({ maxFeePerGas: '0x100' })
+  })
+
+  test('prototype 키 → silent drop', () => {
+    const result = _sanitizeEthereumTypeOptions({
+      prototype: { evil: true },
+      maxFeePerGas: '0x100',
+    } as any)
+    expect(result).toEqual({ maxFeePerGas: '0x100' })
+  })
+})
+
+describe('_sanitizeEthereumTypeOptions — T-SEC-WHITE-EVM-03 invalid 타입 silent drop + nullish', () => {
+  test('null → 빈 객체', () => {
+    expect(_sanitizeEthereumTypeOptions(null)).toEqual({})
+  })
+
+  test('undefined → 빈 객체', () => {
+    expect(_sanitizeEthereumTypeOptions(undefined)).toEqual({})
+  })
+
+  test('non-object (string) → 빈 객체', () => {
+    expect(_sanitizeEthereumTypeOptions('not-an-object' as any)).toEqual({})
+  })
+
+  test('maxFeePerGas: number (not string) → silent drop', () => {
+    const result = _sanitizeEthereumTypeOptions({ maxFeePerGas: 123 } as any)
+    expect(result).toEqual({})
+  })
+
+  test('maxPriorityFeePerGas: array (not string) → silent drop', () => {
+    const result = _sanitizeEthereumTypeOptions({ maxPriorityFeePerGas: [1, 2] } as any)
+    expect(result).toEqual({})
+  })
+
+  test('accessList: not array → silent drop, 결과는 빈 객체', () => {
+    const result = _sanitizeEthereumTypeOptions({ accessList: 'not-array' } as any)
+    expect(result).toEqual({})
+  })
+
+  test('accessList entry: storageKeys가 string array가 아니면 해당 entry drop', () => {
+    const result = _sanitizeEthereumTypeOptions({
+      accessList: [
+        { address: '0xabc', storageKeys: ['0x1'] }, // valid
+        { address: '0xdef', storageKeys: [123, 456] }, // invalid (number)
+        { address: 123, storageKeys: ['0x2'] }, // invalid (address number)
+      ],
+    } as any)
+    expect(result.accessList).toEqual([{ address: '0xabc', storageKeys: ['0x1'] }])
+  })
+
+  test('mutation isolation: 결과 객체 변경이 다음 호출에 leak 안 됨', () => {
+    const r1 = _sanitizeEthereumTypeOptions({ maxFeePerGas: '0x100' })
+    r1.maxFeePerGas = '0xff'
+    const r2 = _sanitizeEthereumTypeOptions({ maxFeePerGas: '0x100' })
+    expect(r2.maxFeePerGas).toBe('0x100')
+  })
+})

--- a/tests/unit/v2/sign/checkParameter.test.ts
+++ b/tests/unit/v2/sign/checkParameter.test.ts
@@ -1,0 +1,136 @@
+/**
+ * checkParameter 단위 테스트 (m08-01-03)
+ *
+ * T-U-CHK-01: 'numberString' + valid hex (0x123) → 통과
+ * T-U-CHK-02: 'numberString' + invalid → throw param_error
+ * T-U-CHK-03: 'numberString' + null/undefined/number → throw param_error
+ * T-U-CHK-04 / T-DRIFT-CHK-01: v2 결과가 v1 checkParameter 결과와 모든 fixture에서 일치
+ *
+ * 룰 준수:
+ *   - external-reference-edge-cases: edge case 다수(빈 문자열 / hex / decimal / 음수 / 한 자리)
+ *   - boundary-validation: invalid 입력은 silent return 금지 — 반드시 throw
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { checkParameter } from '../../../../src/sign/checkParameter'
+
+const expectV1ParamError = (matcher?: string) =>
+  expect.objectContaining({
+    body: {
+      error: matcher
+        ? expect.objectContaining({ code: 'param_error', message: expect.stringContaining(matcher) })
+        : expect.objectContaining({ code: 'param_error' }),
+    },
+  })
+
+describe('checkParameter — numberString happy path', () => {
+  test('T-U-CHK-01a: decimal "1234" → 그대로 반환', () => {
+    expect(checkParameter('numberString', '1234')).toBe('1234')
+  })
+
+  test('T-U-CHK-01b: hex "0x1a" → 그대로 반환', () => {
+    expect(checkParameter('numberString', '0x1a')).toBe('0x1a')
+  })
+
+  test('T-U-CHK-01c: hex with uppercase "0xABC" → 정규식 lowercase 매칭으로 통과 (v1과 동일)', () => {
+    expect(checkParameter('numberString', '0xABC')).toBe('0xABC')
+  })
+
+  test('T-U-CHK-01d: zero string "0" → 통과 (10진수 0)', () => {
+    expect(checkParameter('numberString', '0')).toBe('0')
+  })
+
+  test('T-U-CHK-01e: hex zero "0x0" → 통과', () => {
+    expect(checkParameter('numberString', '0x0')).toBe('0x0')
+  })
+})
+
+describe('checkParameter — numberString sad path (throw param_error)', () => {
+  test('T-U-CHK-02a: invalid 문자열 "abc" → throw', () => {
+    expect(() => checkParameter('numberString', 'abc')).toThrow()
+    try { checkParameter('numberString', 'abc') } catch (e) {
+      expect(e).toEqual(expectV1ParamError('Invaild Parameter'))
+    }
+  })
+
+  test('T-U-CHK-02b: 음수 "-1" → throw (v1 정규식이 양수만 허용)', () => {
+    try { checkParameter('numberString', '-1') } catch (e) {
+      expect(e).toEqual(expectV1ParamError('Invaild Parameter'))
+    }
+  })
+
+  test('T-U-CHK-02c: 빈 문자열 "" → throw', () => {
+    try { checkParameter('numberString', '') } catch (e) {
+      expect(e).toEqual(expectV1ParamError('Invaild Parameter'))
+    }
+  })
+
+  test('T-U-CHK-02d: hex with non-hex char "0xZZ" → throw', () => {
+    try { checkParameter('numberString', '0xZZ') } catch (e) {
+      expect(e).toEqual(expectV1ParamError('Invaild Parameter'))
+    }
+  })
+
+  test('T-U-CHK-03a: null 입력 → throw param_error (string 검증 실패)', () => {
+    expect(() => checkParameter('numberString', null as any)).toThrow()
+    try { checkParameter('numberString', null as any) } catch (e) {
+      expect(e).toEqual(expectV1ParamError('Invaild Parameter'))
+    }
+  })
+
+  test('T-U-CHK-03b: undefined 입력 → throw param_error', () => {
+    try { checkParameter('numberString', undefined as any) } catch (e) {
+      expect(e).toEqual(expectV1ParamError('Invaild Parameter'))
+    }
+  })
+
+  test('T-U-CHK-03c: number 입력 (123) → throw param_error (string이 아님)', () => {
+    try { checkParameter('numberString', 123 as any) } catch (e) {
+      expect(e).toEqual(expectV1ParamError('Invaild Parameter'))
+    }
+  })
+})
+
+describe('T-DRIFT-CHK-01: v2 checkParameter ↔ v1 checkParameter bytewise drift defense', () => {
+  // v1 src-v1/index.js를 직접 require하기 어려우므로 (src-v1은 module.exports 단일 객체),
+  // 같은 알고리즘을 명시적으로 재현한 reference fixture를 사용하여 drift를 단언.
+  //
+  // v1 logic (src-v1/index.js#l418):
+  //   const isNumberString = (str) => /^[0-9]+$/.test(str)
+  //   const isHexNumberString = (str) => /^(0x)?[0-9a-f]+$/.test(str.toLowerCase())
+  //   if (typeof param !== 'string') throw
+  //   if (param.indexOf('0x', 0) === -1) { if (isNumberString(param)) return param }
+  //   else if (param.indexOf('0x', 0) === 0) { if (isHexNumberString(param)) return param }
+  //   throw
+
+  function v1ReferenceCheckNumberString (param: unknown): string {
+    if (typeof param !== 'string') throw new Error('Invaild Parameter - ' + String(param))
+    if (param.indexOf('0x') === -1) {
+      if (/^[0-9]+$/.test(param)) return param
+    } else if (param.indexOf('0x') === 0) {
+      if (/^(0x)?[0-9a-f]+$/.test(param.toLowerCase())) return param
+    }
+    throw new Error('Invaild Parameter - - - ' + param)
+  }
+
+  const fixtures = ['0', '1', '12345', '0x0', '0x1', '0xff', '0xABC', '0xdeadbeef']
+  fixtures.forEach((input) => {
+    test(`drift: input="${input}" — v2 ↔ v1 reference 동일 결과`, () => {
+      const v1Result = v1ReferenceCheckNumberString(input)
+      const v2Result = checkParameter('numberString', input)
+      expect(v2Result).toBe(v1Result)
+    })
+  })
+
+  const sadFixtures = ['', 'abc', '-1', '0xZZ', '12.34', '1e10']
+  sadFixtures.forEach((input) => {
+    test(`drift sad: input="${input}" — v2와 v1 reference 모두 throw`, () => {
+      let v1Threw = false
+      let v2Threw = false
+      try { v1ReferenceCheckNumberString(input) } catch (_) { v1Threw = true }
+      try { checkParameter('numberString', input) } catch (_) { v2Threw = true }
+      expect(v2Threw).toBe(v1Threw)
+      expect(v2Threw).toBe(true)
+    })
+  })
+})

--- a/tests/unit/v2/sign/evm/getEthereumSignedMessage.test.ts
+++ b/tests/unit/v2/sign/evm/getEthereumSignedMessage.test.ts
@@ -1,0 +1,53 @@
+/**
+ * getEthereumSignedMessage 단위 테스트 (m08-01-03)
+ *
+ * T-U-EVMMSG-01: _call({method: 'getEthereumSignedMessage', params: {message, key}}) 호출
+ * T-U-EVMMSG-02: 응답 v1 호환 형식
+ *
+ * v1 인자 검증 없음 — message/key 그대로 pass-through (v1 src-v1/index.js#l1110-l1118).
+ */
+
+import { getEthereumSignedMessage } from '../../../../../src/sign/evm'
+import { ensureSingleton, _resetForTesting } from '../../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+describe('getEthereumSignedMessage — happy path', () => {
+  test('T-U-EVMMSG-01: _call에 method + params 단순 전달', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: { sign: { v: 27, r: '0x1', s: '0x2' } },
+    })
+
+    const resp = await getEthereumSignedMessage('Hello D\'CENT', "m/44'/60'/0'/0/0")
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getEthereumSignedMessage')
+    expect(callArg.params).toEqual({
+      message: 'Hello D\'CENT',
+      key: "m/44'/60'/0'/0/0",
+    })
+    expect(resp.header.status).toBe('success')
+  })
+
+  test('T-U-EVMMSG-02: 응답 v1 호환 형식 (header/body)', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r2',
+      result: { signed_message: '0xdeadbeef', address: '0xabc' },
+    })
+
+    const resp = await getEthereumSignedMessage('any', "m/44'/60'/0'/0/0")
+    expect(resp.header.version).toBe('1.0')
+    expect(resp.header.status).toBe('success')
+    expect(resp.body.parameter).toBeDefined()
+  })
+})

--- a/tests/unit/v2/sign/evm/getEthereumSignedTransaction.test.ts
+++ b/tests/unit/v2/sign/evm/getEthereumSignedTransaction.test.ts
@@ -1,0 +1,225 @@
+/**
+ * getEthereumSignedTransaction 단위 테스트 (m08-01-03)
+ *
+ * T-U-EVMTX-01: happy path (txType=0, ETHEREUM) — _call에 method='getEthereumSignedTransaction'
+ *               + snake_case params (gas_price, gas_limit, chain_id, tx_type, type_options)
+ * T-U-EVMTX-02: chainId !== number → throw 'Invaild Parameter'
+ * T-U-EVMTX-03: txType < 0 또는 > 2 → throw
+ * T-U-EVMTX-04: txType=1 (EIP-2930) → method='getEthereumSignedTypedTransaction', gas_price 검증됨
+ * T-U-EVMTX-05: txType=2 (EIP-1559) → method='getEthereumSignedTypedTransaction', gas_price checkParameter 호출 안 됨
+ * T-U-EVMTX-06: coinType=XDC → to가 XDCPrefixConverter로 변환됨
+ * T-U-EVMTX-07: 지원하지 않는 coinType → throw 'coin_type_error'
+ * T-U-EVMTX-08: invalid numberString → checkParameter throw
+ * T-U-EVMTX-09: 응답 형식 v1 호환 (header.status='success' + body.parameter.signed_tx)
+ *
+ * T-DRIFT-EVM-01 (partial — getEthereumSignedTransaction): 4개 wrapper의 _call params
+ *   key-by-key 동등 (snake_case 단언). 본 file은 wrapper 1개만 단언, 통합 drift는 별도 fixture.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { getEthereumSignedTransaction } from '../../../../../src/sign/evm'
+import { ensureSingleton, _resetForTesting } from '../../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+const expectV1Error = (code: string, messageContains?: string) =>
+  expect.objectContaining({
+    body: {
+      error: messageContains
+        ? expect.objectContaining({ code, message: expect.stringContaining(messageContains) })
+        : expect.objectContaining({ code }),
+    },
+  })
+
+describe('getEthereumSignedTransaction — happy path (T-U-EVMTX-01)', () => {
+  test('T-U-EVMTX-01: ETHEREUM + txType=0 → _call({method, params}) snake_case 단언', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: { signed_tx: '0xabc' },
+    })
+
+    const resp = await getEthereumSignedTransaction(
+      'ethereum', '0x1', '0x10', '0x21000', '0xrecipient', '0x100', '0x',
+      "m/44'/60'/0'/0/0", 1, 0, {}
+    )
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getEthereumSignedTransaction')
+    expect(callArg.params).toMatchObject({
+      coinType: 'ethereum',
+      nonce: '0x1',
+      gas_price: '0x10',
+      gas_limit: '0x21000',
+      to: '0xrecipient',
+      value: '0x100',
+      data: '0x',
+      key: "m/44'/60'/0'/0/0",
+      chain_id: 1,
+      tx_type: 0,
+      type_options: {},
+    })
+    expect(resp.header.status).toBe('success')
+  })
+})
+
+describe('getEthereumSignedTransaction — 인자 검증 (T-U-EVMTX-02/03/08)', () => {
+  test('T-U-EVMTX-02: chainId !== number → throw "Invaild Parameter"', async () => {
+    await expect(
+      getEthereumSignedTransaction(
+        'ethereum', '0x1', '0x10', '0x21000', '0xto', '0x100', '0x',
+        "m/44'/60'/0'/0/0", 'not-a-number' as any, 0, {}
+      )
+    ).rejects.toEqual(expectV1Error('param_error', 'Invaild Parameter'))
+  })
+
+  test('T-U-EVMTX-03a: txType < 0 → throw', async () => {
+    await expect(
+      getEthereumSignedTransaction(
+        'ethereum', '0x1', '0x10', '0x21000', '0xto', '0x100', '0x',
+        "m/44'/60'/0'/0/0", 1, -1, {}
+      )
+    ).rejects.toEqual(expectV1Error('param_error', 'Invaild Parameter'))
+  })
+
+  test('T-U-EVMTX-03b: txType > 2 → throw', async () => {
+    await expect(
+      getEthereumSignedTransaction(
+        'ethereum', '0x1', '0x10', '0x21000', '0xto', '0x100', '0x',
+        "m/44'/60'/0'/0/0", 1, 3, {}
+      )
+    ).rejects.toEqual(expectV1Error('param_error', 'Invaild Parameter'))
+  })
+
+  test('T-U-EVMTX-08: invalid numberString (nonce="abc") → throw param_error', async () => {
+    await expect(
+      getEthereumSignedTransaction(
+        'ethereum', 'abc', '0x10', '0x21000', '0xto', '0x100', '0x',
+        "m/44'/60'/0'/0/0", 1, 0, {}
+      )
+    ).rejects.toEqual(expectV1Error('param_error'))
+  })
+})
+
+describe('getEthereumSignedTransaction — txType !== 0 method 변경 (T-U-EVMTX-04/05)', () => {
+  test('T-U-EVMTX-04: txType=1 (EIP-2930) → method=getEthereumSignedTypedTransaction, gas_price 검증', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r2', result: {} })
+
+    await getEthereumSignedTransaction(
+      'ethereum', '0x1', '0x10', '0x21000', '0xto', '0x100', '0x',
+      "m/44'/60'/0'/0/0", 1, 1, {}
+    )
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getEthereumSignedTypedTransaction')
+    expect(callArg.params?.tx_type).toBe(1)
+    expect(callArg.params?.gas_price).toBe('0x10') // 검증 + 통과
+  })
+
+  test('T-U-EVMTX-05: txType=2 (EIP-1559) → method 변경 + gasPrice는 어떤 값이든 그대로 통과 (검증 안 함)', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r3', result: {} })
+
+    // gasPrice가 "garbage" — txType=2이면 v1과 동일하게 검증 안 함 (maxFeePerGas/maxPriorityFeePerGas로 대체됨)
+    await getEthereumSignedTransaction(
+      'ethereum', '0x1', 'garbage', '0x21000', '0xto', '0x100', '0x',
+      "m/44'/60'/0'/0/0", 1, 2, { maxFeePerGas: '0x20', maxPriorityFeePerGas: '0x5' }
+    )
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getEthereumSignedTypedTransaction')
+    expect(callArg.params?.tx_type).toBe(2)
+    expect(callArg.params?.gas_price).toBe('garbage') // 검증 없이 그대로
+    expect(callArg.params?.type_options).toEqual({ maxFeePerGas: '0x20', maxPriorityFeePerGas: '0x5' })
+  })
+
+  test('T-U-EVMTX-05b: txType=2 + typeOptions에 unknown key → sanitize로 drop', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r4', result: {} })
+
+    await getEthereumSignedTransaction(
+      'ethereum', '0x1', '0x10', '0x21000', '0xto', '0x100', '0x',
+      "m/44'/60'/0'/0/0", 1, 2, { maxFeePerGas: '0x20', evilKey: 'evil' } as any
+    )
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.params?.type_options).toEqual({ maxFeePerGas: '0x20' })
+  })
+})
+
+describe('getEthereumSignedTransaction — coinType switch (T-U-EVMTX-06/07)', () => {
+  test('T-U-EVMTX-06: coinType=XDC → to가 XDCPrefixConverter 변환됨 (xdc → 0x)', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r5', result: {} })
+
+    await getEthereumSignedTransaction(
+      'xinfin', '0x1', '0x10', '0x21000', 'xdcabcdef', '0x100', '0x',
+      "m/44'/550'/0'/0/0", 50, 0, {}
+    )
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.params?.to).toBe('0xabcdef')
+  })
+
+  test('T-U-EVMTX-06b: coinType=XDC + to가 이미 0x prefix이면 그대로', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r6', result: {} })
+
+    await getEthereumSignedTransaction(
+      'xinfin', '0x1', '0x10', '0x21000', '0xalready', '0x100', '0x',
+      "m/44'/550'/0'/0/0", 50, 0, {}
+    )
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.params?.to).toBe('0xalready')
+  })
+
+  test('T-U-EVMTX-07: 지원하지 않는 coinType → throw "coin_type_error"', async () => {
+    await expect(
+      getEthereumSignedTransaction(
+        'unknown_chain', '0x1', '0x10', '0x21000', '0xto', '0x100', '0x',
+        "m/44'/60'/0'/0/0", 1, 0, {}
+      )
+    ).rejects.toEqual(expectV1Error('coin_type_error', 'not supported coin type'))
+  })
+
+  test('T-U-EVMTX-07b: RSK / RSK_TESTNET 모두 통과 (그대로)', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r7', result: {} })
+
+    await getEthereumSignedTransaction(
+      'rsk', '0x1', '0x10', '0x21000', '0xrsk', '0x100', '0x',
+      "m/44'/137'/0'/0/0", 30, 0, {}
+    )
+
+    expect(sendSpy.mock.calls[0][0].params?.coinType).toBe('rsk')
+    expect(sendSpy.mock.calls[0][0].params?.to).toBe('0xrsk') // XDC 변환 안 됨
+  })
+})
+
+describe('getEthereumSignedTransaction — 응답 형식 (T-U-EVMTX-09)', () => {
+  test('T-U-EVMTX-09: 응답이 v1 호환 V1Response shape', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r8',
+      result: { signed_tx: '0xsigned', sign: { v: 27, r: '0x1', s: '0x2' } },
+    })
+
+    const resp = await getEthereumSignedTransaction(
+      'ethereum', '0x1', '0x10', '0x21000', '0xto', '0x100', '0x',
+      "m/44'/60'/0'/0/0", 1, 0, {}
+    )
+
+    expect(resp.header.status).toBe('success')
+    expect(resp.header.version).toBe('1.0')
+    expect(resp.body.parameter).toBeDefined()
+  })
+})

--- a/tests/unit/v2/sign/evm/getKlaytnSignedTransaction.test.ts
+++ b/tests/unit/v2/sign/evm/getKlaytnSignedTransaction.test.ts
@@ -1,0 +1,223 @@
+/**
+ * getKlaytnSignedTransaction 단위 테스트 (m08-01-03)
+ *
+ * T-U-KLAY-01: legacy + KLAYTN + from 제공 → snake_case params
+ * T-U-KLAY-02: from 미제공 → getAddress(KLAYTN, key) 호출, body.parameter.address 채워짐
+ * T-U-KLAY-03: KLAY_BAOBAB → coinType이 KLAYTN으로 정규화되어 params 송신
+ * T-U-KLAY-04: KCT_BAOBAB → coinType이 KLAYTN_KCT로 정규화
+ * T-U-KLAY-05: KCT (contract 인자 있음) → contract.decimals 검증 + params에 contract 포함
+ * T-U-KLAY-06: chainId !== number → throw param_error
+ * T-U-KLAY-07: txType falsy → klaytnTxType.LEGACY (0xff) fallback
+ *
+ * Klaytn from 자동 채움은 m08-01-02.5의 getAddress 의존 — 본 테스트는 transport.send 2회 호출
+ * (1번째: getAddress, 2번째: getKlaytnSignedTransaction)을 모두 spy로 검증.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { getKlaytnSignedTransaction } from '../../../../../src/sign/evm'
+import { klaytnTxType } from '../../../../../src/types/klaytnTxType'
+import { ensureSingleton, _resetForTesting } from '../../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+const expectV1Error = (code: string, msg?: string) =>
+  expect.objectContaining({
+    body: {
+      error: msg
+        ? expect.objectContaining({ code, message: expect.stringContaining(msg) })
+        : expect.objectContaining({ code }),
+    },
+  })
+
+describe('getKlaytnSignedTransaction — happy path (T-U-KLAY-01)', () => {
+  test('T-U-KLAY-01: legacy KLAYTN + from 제공 → snake_case params', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r1', result: {} })
+
+    await getKlaytnSignedTransaction(
+      'klaytn', '0x1', '0x10', '0x21000', '0xrecipient', '0x100', '0x',
+      "m/44'/8217'/0'/0/0", 8217, klaytnTxType.LEGACY, '0xfromaddr', '50'
+    )
+
+    expect(sendSpy).toHaveBeenCalledTimes(1) // from 제공이라 getAddress 호출 안 함
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getKlaytnSignedTransaction')
+    expect(callArg.params).toMatchObject({
+      coinType: 'klaytn',
+      nonce: '0x1',
+      gas_price: '0x10',
+      gas_limit: '0x21000',
+      to: '0xrecipient',
+      value: '0x100',
+      data: '0x',
+      key: "m/44'/8217'/0'/0/0",
+      chain_id: 8217,
+      tx_type: klaytnTxType.LEGACY,
+      from: '0xfromaddr',
+      fee_ratio: '50',
+    })
+  })
+})
+
+describe('getKlaytnSignedTransaction — from 자동 채움 (T-U-KLAY-02)', () => {
+  test('T-U-KLAY-02: from 미제공 + KLAYTN → getAddress 호출되어 body.parameter.address가 from에 채워짐', async () => {
+    const { transport } = ensureSingleton()
+    let callCount = 0
+    const sendSpy = jest.spyOn(transport, 'send').mockImplementation(async () => {
+      callCount += 1
+      if (callCount === 1) {
+        // 1st call = getAddress
+        return { id: 'r-addr', result: { address: '0xautofilled', path: "m/44'/8217'/0'/0/0" } }
+      }
+      // 2nd call = getKlaytnSignedTransaction
+      return { id: 'r-sign', result: {} }
+    })
+
+    await getKlaytnSignedTransaction(
+      'klaytn', '0x1', '0x10', '0x21000', '0xto', '0x100', '0x',
+      "m/44'/8217'/0'/0/0", 8217, klaytnTxType.LEGACY
+      // from / feeRatio / contract 미제공
+    )
+
+    expect(sendSpy).toHaveBeenCalledTimes(2)
+    expect(sendSpy.mock.calls[0][0].method).toBe('getAddress')
+    expect(sendSpy.mock.calls[0][0].params?.coinType).toBe('klaytn')
+
+    const signCall = sendSpy.mock.calls[1][0]
+    expect(signCall.method).toBe('getKlaytnSignedTransaction')
+    expect(signCall.params?.from).toBe('0xautofilled')
+  })
+})
+
+describe('getKlaytnSignedTransaction — coinType 정규화 (T-U-KLAY-03/04)', () => {
+  test('T-U-KLAY-03: KLAY_BAOBAB (klaytn-testnet) → coinType이 KLAYTN으로 정규화', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r3', result: {} })
+
+    await getKlaytnSignedTransaction(
+      'klaytn-testnet', '0x1', '0x10', '0x21000', '0xto', '0x100', '0x',
+      "m/44'/8217'/0'/0/0", 1001, klaytnTxType.LEGACY, '0xfrom'
+    )
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.params?.coinType).toBe('klaytn') // KLAY_BAOBAB → KLAYTN
+  })
+
+  test('T-U-KLAY-04: KCT_BAOBAB (krc20-testnet) → coinType이 KLAYTN_KCT로 정규화', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r4', result: {} })
+
+    await getKlaytnSignedTransaction(
+      'krc20-testnet', '0x1', '0x10', '0x21000', '0xto', '0x100', '0x',
+      "m/44'/8217'/0'/0/0", 1001, klaytnTxType.LEGACY, '0xfrom'
+    )
+
+    expect(sendSpy.mock.calls[0][0].params?.coinType).toBe('klaytn-erc20') // KLAYTN_KCT value
+  })
+
+  test('T-U-KLAY-04b: 지원하지 않는 coinType → throw "coin_type_error"', async () => {
+    await expect(
+      getKlaytnSignedTransaction(
+        'unknown', '0x1', '0x10', '0x21000', '0xto', '0x100', '0x',
+        "m/44'/8217'/0'/0/0", 8217, klaytnTxType.LEGACY, '0xfrom'
+      )
+    ).rejects.toEqual(expectV1Error('coin_type_error', 'not supported coin type'))
+  })
+})
+
+describe('getKlaytnSignedTransaction — KCT contract 분기 (T-U-KLAY-05)', () => {
+  test('T-U-KLAY-05: contract 인자 있음 → contract.decimals 검증 + params에 contract 포함', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r5', result: {} })
+
+    const contract = {
+      address: '0xtoken',
+      symbol: 'KCT',
+      decimals: '18', // numberString
+      value: '0x100',
+      to: '0xrecipient',
+    }
+
+    await getKlaytnSignedTransaction(
+      'klaytn-erc20', '0x1', '0x10', '0x21000', '0xto', '0x0', '0x',
+      "m/44'/8217'/0'/0/0", 8217, klaytnTxType.LEGACY, '0xfrom', undefined, contract
+    )
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.params?.contract).toEqual({
+      address: '0xtoken',
+      symbol: 'KCT',
+      decimals: '18',
+      value: '0x100',
+      to: '0xrecipient',
+    })
+  })
+})
+
+describe('getKlaytnSignedTransaction — 인자 검증 (T-U-KLAY-06/07)', () => {
+  test('T-U-KLAY-06: chainId !== number → throw param_error chainId 메시지', async () => {
+    await expect(
+      getKlaytnSignedTransaction(
+        'klaytn', '0x1', '0x10', '0x21000', '0xto', '0x100', '0x',
+        "m/44'/8217'/0'/0/0", 'not-number' as any, klaytnTxType.LEGACY, '0xfrom'
+      )
+    ).rejects.toEqual(expectV1Error('param_error', 'Invaild Parameter chainId'))
+  })
+
+  test('T-U-KLAY-07: txType falsy (0) → klaytnTxType.LEGACY (0xff) fallback', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r7', result: {} })
+
+    await getKlaytnSignedTransaction(
+      'klaytn', '0x1', '0x10', '0x21000', '0xto', '0x100', '0x',
+      "m/44'/8217'/0'/0/0", 8217, 0 as any, '0xfrom'
+    )
+
+    expect(sendSpy.mock.calls[0][0].params?.tx_type).toBe(klaytnTxType.LEGACY)
+  })
+
+  test('T-U-KLAY-07b: txType undefined → klaytnTxType.LEGACY fallback', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r8', result: {} })
+
+    await getKlaytnSignedTransaction(
+      'klaytn', '0x1', '0x10', '0x21000', '0xto', '0x100', '0x',
+      "m/44'/8217'/0'/0/0", 8217, undefined as any, '0xfrom'
+    )
+
+    expect(sendSpy.mock.calls[0][0].params?.tx_type).toBe(klaytnTxType.LEGACY)
+  })
+})
+
+describe('T-DRIFT-EVM-01 (Klaytn snake_case 단언)', () => {
+  test('Klaytn wrapper의 _call params keys는 v1과 동일한 snake_case', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r-d', result: {} })
+
+    await getKlaytnSignedTransaction(
+      'klaytn', '0x1', '0x10', '0x21000', '0xto', '0x100', '0x',
+      "m/44'/8217'/0'/0/0", 8217, klaytnTxType.LEGACY, '0xfrom', '50'
+    )
+
+    const params = sendSpy.mock.calls[0][0].params as Record<string, unknown>
+    // snake_case keys 단언
+    expect(Object.keys(params)).toEqual(
+      expect.arrayContaining([
+        'coinType', 'nonce', 'gas_price', 'gas_limit', 'to', 'value', 'data', 'key',
+        'chain_id', 'tx_type', 'from', 'fee_ratio', 'contract',
+      ])
+    )
+    // camelCase 변종 부재 확인
+    expect(params).not.toHaveProperty('gasPrice')
+    expect(params).not.toHaveProperty('gasLimit')
+    expect(params).not.toHaveProperty('chainId')
+    expect(params).not.toHaveProperty('txType')
+    expect(params).not.toHaveProperty('feeRatio')
+  })
+})

--- a/tests/unit/v2/sign/evm/getTokenSignedTransaction.test.ts
+++ b/tests/unit/v2/sign/evm/getTokenSignedTransaction.test.ts
@@ -1,0 +1,126 @@
+/**
+ * getTokenSignedTransaction 단위 테스트 (m08-01-03)
+ *
+ * T-U-TOKEN-01: ERC20 happy path — params keys snake_case (gas_price/gas_limit/chain_id)
+ * T-U-TOKEN-02: chainId 또는 contract.decimals 타입 위반 → throw param_error
+ * T-U-TOKEN-03: 지원하지 않는 token → throw 'coin_type_error: not supported token type'
+ * T-U-TOKEN-04: contract.value invalid → checkParameter throw
+ * T-U-TOKEN-05: token=XRC20 → contract.to + contract.address가 XDCPrefixConverter 변환됨
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { getTokenSignedTransaction } from '../../../../../src/sign/evm'
+import { ensureSingleton, _resetForTesting } from '../../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+const expectV1Error = (code: string, msg?: string) =>
+  expect.objectContaining({
+    body: {
+      error: msg
+        ? expect.objectContaining({ code, message: expect.stringContaining(msg) })
+        : expect.objectContaining({ code }),
+    },
+  })
+
+const baseContract = (): any => ({
+  address: '0xcontractaddr',
+  symbol: 'TST',
+  decimals: 18,
+  value: '0x1000',
+  to: '0xrecipient',
+})
+
+describe('getTokenSignedTransaction — happy path', () => {
+  test('T-U-TOKEN-01: ERC20 → snake_case params', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r1', result: {} })
+
+    await getTokenSignedTransaction(
+      'erc20', '0x1', '0x10', '0x21000', "m/44'/60'/0'/0/0", 1, baseContract()
+    )
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getTokenSignedTransaction')
+    expect(callArg.params).toMatchObject({
+      token: 'erc20',
+      nonce: '0x1',
+      gas_price: '0x10',
+      gas_limit: '0x21000',
+      key: "m/44'/60'/0'/0/0",
+      chain_id: 1,
+    })
+    expect(callArg.params?.contract).toBeDefined()
+  })
+
+  test('T-U-TOKEN-01b: KLAYTN_KCT (klaytn-erc20) 통과', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r2', result: {} })
+
+    await getTokenSignedTransaction(
+      'klaytn-erc20', '0x1', '0x10', '0x21000', "m/44'/8217'/0'/0/0", 8217, baseContract()
+    )
+
+    expect(sendSpy.mock.calls[0][0].params?.token).toBe('klaytn-erc20')
+  })
+})
+
+describe('getTokenSignedTransaction — 인자 검증', () => {
+  test('T-U-TOKEN-02a: chainId !== number → throw param_error', async () => {
+    await expect(
+      getTokenSignedTransaction(
+        'erc20', '0x1', '0x10', '0x21000', "m/44'/60'/0'/0/0",
+        'not-number' as any, baseContract()
+      )
+    ).rejects.toEqual(expectV1Error('param_error'))
+  })
+
+  test('T-U-TOKEN-02b: contract.decimals !== number → throw param_error', async () => {
+    const c = baseContract()
+    c.decimals = '18' // string
+    await expect(
+      getTokenSignedTransaction('erc20', '0x1', '0x10', '0x21000', "m/44'/60'/0'/0/0", 1, c)
+    ).rejects.toEqual(expectV1Error('param_error'))
+  })
+
+  test('T-U-TOKEN-04: contract.value invalid → checkParameter throw', async () => {
+    const c = baseContract()
+    c.value = 'garbage'
+    await expect(
+      getTokenSignedTransaction('erc20', '0x1', '0x10', '0x21000', "m/44'/60'/0'/0/0", 1, c)
+    ).rejects.toEqual(expectV1Error('param_error'))
+  })
+})
+
+describe('getTokenSignedTransaction — token switch (T-U-TOKEN-03/05)', () => {
+  test('T-U-TOKEN-03: unknown token → throw "not supported token type"', async () => {
+    await expect(
+      getTokenSignedTransaction(
+        'unknown_token', '0x1', '0x10', '0x21000', "m/44'/60'/0'/0/0", 1, baseContract()
+      )
+    ).rejects.toEqual(expectV1Error('coin_type_error', 'not supported token type'))
+  })
+
+  test('T-U-TOKEN-05: XRC20 → contract.to + contract.address XDC prefix 변환', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r3', result: {} })
+
+    const c = baseContract()
+    c.to = 'xdcrecipient1'
+    c.address = 'xdccontract2'
+
+    await getTokenSignedTransaction(
+      'xrc20', '0x1', '0x10', '0x21000', "m/44'/550'/0'/0/0", 50, c
+    )
+
+    const sentContract = sendSpy.mock.calls[0][0].params?.contract as any
+    expect(sentContract.to).toBe('0xrecipient1')
+    expect(sentContract.address).toBe('0xcontract2')
+  })
+})


### PR DESCRIPTION
## Summary

Epic m08-01 (DC-1998) — child #4. v1 EVM sign wrapper 4개를 v2 facade에 module-level 함수형으로 1:1 호환 port. dApp이 v0.16.0의 EVM 호출 코드를 무수정으로 v2 facade에서 동작시킬 수 있도록 한다.

- **Objective**: `objectives/m08-01-03-v1-evm-sign-wrappers.md`
- **Jira**: DC-2002 (Sub-task under Epic DC-1998)
- **Base branch**: `epic/DC-1998_m08-01-connector-v2-dapp-facade`
- **Depends on**: m08-01-02 (generic sign core), m08-01-02.5 (read-only + getAddress) — 둘 다 epic branch에 머지됨

## 신규 함수 (default + named export)

| 함수 | v1 source | 동작 |
|---|---|---|
| `getEthereumSignedTransaction(coinType, nonce, gasPrice, gasLimit, to, value, data, key, chainId, txType=0, typeOptions={})` | l961-l1032 | txType 0/1/2 → method 분기, XDC prefix, type_options sanitize |
| `getEthereumSignedMessage(message, key)` | l1110-l1118 | personal_sign / signTypedData (인자 검증 없음) |
| `getTokenSignedTransaction(token, nonce, gasPrice, gasLimit, key, chainId, contract)` | l1046-l1101 | ERC20 / RRC20 / KLAYTN_KCT / XRC20 (XRC20는 contract.to/address XDC 변환) |
| `getKlaytnSignedTransaction(coinType, nonce, gasPrice, gasLimit, to, value, data, key, chainId, txType, from?, feeRatio?, contract?)` | l1136-l1210 | fee delegation, KCT, from 자동 채움, coinType 정규화 |

## 신규 헬퍼

- `src/sign/checkParameter.ts` — v1 numberString 검증 helper. m08-01-04 wrapper들도 import.
- `src/sign/_sanitizeEthereumTypeOptions.ts` — typeOptions known fields whitelist (provider-security C3).
- `src/utils/xdc-prefix-converter.ts` — v1 `src-v1/utils/xdc-prefix-converter.js` v2 port.

## 🔴 Critical: snake_case params keys 보존

bridge sdk가 인식하는 v1 동일한 method 이름 + snake_case params keys (`gas_price`, `gas_limit`, `chain_id`, `tx_type`, `type_options`, `fee_ratio`)를 송신해야 한다. camelCase로 보내면 bridge sdk가 인식하지 못해 silent fail.

**T-DRIFT-EVM-01** 테스트가 모든 4개 wrapper에 대해 snake_case keys 존재 + camelCase 부재를 단언한다.

## v1 특이 동작 보존 (drift defense)

| 동작 | 보존 이유 |
|---|---|
| `'Invaild Parameter'` 오타 | v1 호환 — dApp의 `error.message.includes('Invaild')` 체크 가능 |
| `txType !== 0` → method 이름 `getEthereumSignedTypedTransaction` | EIP-2930 (1) / EIP-1559 (2) 별도 dispatch |
| `txType === 2`일 때 `gasPrice` 검증 skip | EIP-1559에서 maxFeePerGas/maxPriorityFeePerGas로 대체되어 v1은 검증 안 함 |
| Klaytn `KLAY_BAOBAB → KLAYTN`, `KCT_BAOBAB → KLAYTN_KCT` 정규화 | testnet 별칭을 mainnet enum으로 통합 (v1 동작) |
| Klaytn `from` 미제공 시 `getAddress(coinType, key)` 자동 호출 | fee delegation flow에서 v1 동작 1:1 |

## CAIP-19 매핑 사용 안 함

- 본 chain의 목적은 v1 무수정 호환 → wrapper들이 `_call({method, params})`을 직접 호출
- 통합 `sign({chain, payload})` API는 별도 path (m08-01-02 sign.ts)
- `coinTypeToCAIP19` 매핑은 향후 v1 wrapper deprecate 시 마이그레이션 자산으로 보존

## Rationale (왜 이렇게 결정했는지)

1. **module-level 함수형 export**: v2 facade가 class가 아닌 module exports로 일관성 유지 (m08-01-01/02/02.5와 동일 스타일).
2. **`_call` 직접 호출**: 통합 sign API의 chainToMethod 경로를 거치지 않는 이유는 v1 wrapper의 인자 검증 / snake_case params / XDC prefix / Klaytn from auto-fill 같은 v1 특이 동작이 통합 path에 fit하지 않기 때문.
3. **typeOptions whitelist**: dApp 입력 객체의 `__proto__` / unknown key를 silent drop하여 prototype pollution 방어 (provider-security C3).
4. **NO REVIEWERS**: chain orchestrator(main)가 즉시 머지하는 자동 모드. 사용자 정책에 따라 reviewer 미할당.

## Tested

- ✅ `npm run unit-v2` — 33 test suites, **493 tests** passing (검증 후 즉시 실행)
- ✅ `npx tsc --noEmit` — 0 errors
- ✅ `npx eslint --ext .ts src` — 0 errors, 0 warnings
- ✅ `npm run build` — webpack production build 성공 (asset size warning은 v1/v2 통합 번들 특성)
- ✅ `node -e "..."`로 default export에 4개 wrapper + checkParameter 노출 확인 (function 타입)
- ✅ `npm pack --dry-run` — `dist/v2/sign/{evm,checkParameter,_sanitizeEthereumTypeOptions}.d.ts` + `dist/v2/utils/xdc-prefix-converter.d.ts` 모두 포함

### T-XX 커버리지

| T-XX | 통과 |
|---|---|
| T-U-EVMTX-01..09 (getEthereumSignedTransaction) | ✅ |
| T-U-EVMMSG-01..02 (getEthereumSignedMessage) | ✅ |
| T-U-TOKEN-01..05 (getTokenSignedTransaction) | ✅ |
| T-U-KLAY-01..07 (getKlaytnSignedTransaction) | ✅ |
| T-U-CHK-01..03 (checkParameter) | ✅ |
| T-DRIFT-CHK-01 (v2 ↔ v1 reference fixture 동등) | ✅ |
| T-DRIFT-EVM-01 (Klaytn snake_case 단언) | ✅ |
| T-SEC-WHITE-EVM-01..03 (_sanitizeEthereumTypeOptions) | ✅ |
| T-BUILD-01 / T-PACK-01 / T-DEFAULT-01 / T-LINT-01 | ✅ |

## Constraints

- **PR diff 일반 코드 543 LOC** (소스만, 테스트 제외) — 600 LOC 권장 한도 이내
- **`package.json` `version` 미수정** (`no-version-bump` 룰 — release manager가 담당)
- **PR base = epic branch** (`epic/DC-1998_m08-01-connector-v2-dapp-facade`)
- **Cross-repo 영향 없음** — bridge sdk는 v1과 동일한 method 이름 + snake_case params shape 사용 (변경 불필요)
- **머지는 사람** (`objective-no-auto-merge` 룰) — 단, autopilot chain mode에서는 main(orchestrator)이 즉시 머지

## Test plan

- [x] `npm run unit-v2 -- tests/unit/v2/sign/evm/`
- [x] `npm run unit-v2 -- tests/unit/v2/sign/checkParameter.test.ts`
- [x] `npm run unit-v2 -- tests/unit/v2/sign/_sanitizeEthereumTypeOptions.test.ts`
- [x] `npm run build`
- [x] `npm pack --dry-run | grep -E '(sign/evm|sign/checkParameter)'`
- [x] `node -e "..."` default export 함수 타입 확인
- [x] `npx eslint --ext .ts src`