### PR TITLE
[DC-2003] feat(v2): connector v2 v1 non-EVM simple sign wrappers (m08-01-04)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,15 @@ import {
   getKlaytnSignedTransaction,
   checkParameter,
   _sanitizeEthereumTypeOptions,
+  // m08-01-04: v1 non-EVM simple sign wrappers (8개)
+  getBitcoinSignedTransaction,
+  getXrpSignedTransaction,
+  getHederaSignedTransaction,
+  getHederaSignedMessage,
+  getStellarSignedTransaction,
+  getTronSignedTransaction,
+  getSignedMessage,
+  getSignedData,
 } from './sign'
 
 // === 기존 named exports (m02-01·m02-02·m07-02 SHIPPED) ===
@@ -149,6 +158,25 @@ export {
 } from './sign'
 export type { EvmTokenContract, KlaytnContract, EthereumTypeOptions } from './sign'
 
+// === 새 named exports (m08-01-04 — v1 non-EVM simple sign wrappers) ===
+export {
+  getBitcoinSignedTransaction,
+  getXrpSignedTransaction,
+  getHederaSignedTransaction,
+  getHederaSignedMessage,
+  getStellarSignedTransaction,
+  getTronSignedTransaction,
+  getSignedMessage,
+  getSignedData,
+} from './sign'
+export type {
+  XrpTxObject,
+  HederaTxParams,
+  HederaMsgParams,
+  StellarTxParams,
+  TronTxParams,
+} from './sign'
+
 // === default export object (v1 호환 패턴) ===
 //
 // dApp이 `import dcent from 'dcent-web-connector'` 또는 `const dcent = require(...)`로
@@ -201,6 +229,15 @@ const dcent = {
   getKlaytnSignedTransaction,
   checkParameter,
   _sanitizeEthereumTypeOptions,
+  // m08-01-04: v1 non-EVM simple sign wrappers (8개)
+  getBitcoinSignedTransaction,
+  getXrpSignedTransaction,
+  getHederaSignedTransaction,
+  getHederaSignedMessage,
+  getStellarSignedTransaction,
+  getTronSignedTransaction,
+  getSignedMessage,
+  getSignedData,
 } as const
 
 export default dcent

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -59,3 +59,22 @@ export type { EvmTokenContract, KlaytnContract } from './evm'
 export { checkParameter } from './checkParameter'
 export { _sanitizeEthereumTypeOptions } from './_sanitizeEthereumTypeOptions'
 export type { EthereumTypeOptions } from './_sanitizeEthereumTypeOptions'
+
+// m08-01-04: v1 non-EVM simple sign wrappers (8개 — pass-through 패턴)
+export {
+  getBitcoinSignedTransaction,
+  getXrpSignedTransaction,
+  getHederaSignedTransaction,
+  getHederaSignedMessage,
+  getStellarSignedTransaction,
+  getTronSignedTransaction,
+  getSignedMessage,
+  getSignedData,
+} from './nonEvmSimple'
+export type {
+  XrpTxObject,
+  HederaTxParams,
+  HederaMsgParams,
+  StellarTxParams,
+  TronTxParams,
+} from './nonEvmSimple'

--- a/src/sign/nonEvmSimple.ts
+++ b/src/sign/nonEvmSimple.ts
@@ -1,0 +1,274 @@
+/**
+ * v1 non-EVM simple sign wrappers — module-level functions (m08-01-04)
+ *
+ * v1 src-v1/index.js의 단순 pass-through 패턴 8개 sign 함수를 v2 facade에 1:1 호환 port:
+ *   - getBitcoinSignedTransaction (l929-942)
+ *   - getXrpSignedTransaction (l1240-1263)
+ *   - getHederaSignedTransaction (l1265-1280)
+ *   - getHederaSignedMessage (l1282-1293)
+ *   - getStellarSignedTransaction (l1295-1308)
+ *   - getTronSignedTransaction (l1310-1323)
+ *   - getSignedMessage (l1212-1221, coin-agnostic)
+ *   - getSignedData (l1223-1230, coin-agnostic)
+ *
+ * 핵심 동작:
+ *   - 모두 인자 검증 + `_call({method, params})` 직접 dispatch
+ *   - UnitConverter 변환 / coinType remap / response 후처리 없음 (그건 m08-01-04.5의 복잡 wrapper에서 처리)
+ *   - bridge sdk wire format이 snake_case를 기대하는 곳은 `unsignedTx → unsigned_tx` 매핑
+ *     (Hedera/Stellar/Tron) → camelCase로 보내면 silent fail
+ *   - Hedera Message는 v1 동작과 동일하게 `unsignedMsg`를 받아 `message` 키로 forward
+ *   - XRP는 Account/TransactionType/Fee/Sequence 타입 검증 + xrpTxType enum lookup +
+ *     Fee numberString 검증 (v1 1:1)
+ *
+ * 룰 준수:
+ *   - boundary-validation: 입력 객체의 type/필드 존재 검증, 실패 시 throw (silent return 금지)
+ *   - error-handling-consistency: 검증 실패는 throw, popup/network 에러는 _call이 v1 호환 응답으로 변환
+ *   - mutation-isolation: _call이 매 호출마다 새 V1Response 객체 반환
+ *   - cross-repo-interface-edit: bridge sdk가 알아야 하는 method 이름 + snake_case params shape 보존
+ *   - reuse-shared-utils: `_call`, `dcentException`, `checkParameter`, `xrpTxType` 모두 재사용
+ *   - dapp-input-sanitization: 현 v1 동작 그대로 보존 — C3 sanitization은 후속 m08-01-06에서 강화
+ *   - external-reference-edge-cases: pass-through wrapper라 primitive 변환 없음. 해당 없음
+ *   - no-version-bump: package.json version 미수정
+ */
+
+/* eslint-disable camelcase */
+
+import { _call } from './call'
+import { checkParameter } from './checkParameter'
+import { dcentException } from '../v1/dcent-exception'
+import { xrpTxType as dcentXrpTxType } from '../types/xrpTxType'
+import type { V1Response } from './types'
+import type { BitcoinTxObject } from './bitcoinTxBuilder'
+
+/** XRP 트랜잭션 객체 — bridge sdk가 받는 wire shape (v1과 동일). */
+export interface XrpTxObject {
+  /** classic XRP address — 'r...' */
+  Account: string
+  /** XRP TransactionType — Payment / TrustSet / OfferCreate 등 (xrpTxType enum 참조) */
+  TransactionType: string
+  /** Fee in drops, numberString 형태 — '12' 등 */
+  Fee: string
+  /** Sequence number — uint32 */
+  Sequence: number
+  /** XRP wire format 추가 필드 (Amount, Destination, Memos 등 — bridge sdk가 직접 파싱) */
+  [key: string]: unknown
+}
+
+/** Hedera 트랜잭션 wrapper 인자 — destructured. */
+export interface HederaTxParams {
+  /** unsigned tx hex/base64 — bridge로 forward 시 `unsigned_tx` (snake_case) 키로 변환 */
+  unsignedTx: string
+  /** BIP44 path — `m/44'/3030'/0'/0/0` 등 */
+  path: string
+  /** 토큰 symbol (Hedera HTS) */
+  symbol?: string
+  /** 토큰 decimals (Hedera HTS) */
+  decimals?: number | string
+}
+
+/** Hedera 메시지 wrapper 인자 — destructured. */
+export interface HederaMsgParams {
+  /** unsigned message — bridge로 forward 시 `message` (key 변경) 키로 변환 */
+  unsignedMsg: string
+  /** BIP44 path */
+  path: string
+}
+
+/** Stellar 트랜잭션 wrapper 인자 — destructured. */
+export interface StellarTxParams {
+  /** unsigned tx — bridge로 forward 시 `unsigned_tx` 키로 변환 */
+  unsignedTx: string
+  /** Stellar fee (stroops) — 변환 없이 그대로 forward (m08-01-04.5의 UnitConverter 적용 안 함) */
+  fee: string | number
+  /** BIP44 path */
+  path: string
+}
+
+/** Tron 트랜잭션 wrapper 인자 — destructured. */
+export interface TronTxParams {
+  /** unsigned tx — bridge로 forward 시 `unsigned_tx` 키로 변환 */
+  unsignedTx: string
+  /** Tron fee — 변환 없이 그대로 forward (TRC token wrapper는 m08-01-04.5) */
+  fee: string | number
+  /** BIP44 path */
+  path: string
+}
+
+/**
+ * v1 dcent.getBitcoinSignedTransaction (src-v1/index.js#l929-942) 1:1 port.
+ *
+ * 동작:
+ *   1. transaction === null || undefined → `dcentException('param_error', '...')` throw
+ *   2. `_call({method: 'getBitcoinSignedTransaction', params: {transaction}})` dispatch
+ *
+ * @param transaction Bitcoin tx object (BitcoinTxObject 타입 — bitcoinTxBuilder가 만든 객체)
+ * @returns V1Response (v1 호환 `{header, body}` shape)
+ */
+export async function getBitcoinSignedTransaction (
+  transaction: BitcoinTxObject
+): Promise<V1Response> {
+  if (transaction === null || typeof transaction === 'undefined') {
+    throw dcentException('param_error', 'transaction object is undefined or null')
+  }
+  return _call({
+    method: 'getBitcoinSignedTransaction',
+    params: { transaction },
+  })
+}
+
+/**
+ * v1 dcent.getXrpSignedTransaction (src-v1/index.js#l1240-1263) 1:1 port.
+ *
+ * 동작:
+ *   1. Account/TransactionType/Fee/Sequence 타입 검증 → 위반 시 throw 'TypeError: Required field type is not matched'
+ *   2. xrpTxType[transaction.TransactionType] === undefined → throw 'Invalid Transaction Type: ...'
+ *   3. checkParameter('numberString', Fee) → invalid이면 checkParameter가 throw
+ *   4. `_call({method: 'getXrpSignedTransaction', params: {key, transaction}})` dispatch
+ *
+ * v1 try/catch는 throw를 단순 propagate하므로 v2에서는 try/catch 생략 (동등 의미).
+ */
+export async function getXrpSignedTransaction (
+  transaction: XrpTxObject,
+  key: string
+): Promise<V1Response> {
+  if (
+    typeof transaction.Account !== 'string' ||
+    typeof transaction.TransactionType !== 'string' ||
+    typeof transaction.Fee !== 'string' ||
+    typeof transaction.Sequence !== 'number'
+  ) {
+    throw dcentException('param_error', 'TypeError: Required field type is not matched')
+  }
+
+  if (typeof (dcentXrpTxType as Record<string, unknown>)[transaction.TransactionType] === 'undefined') {
+    throw dcentException('param_error', 'Invalid Transaction Type: ' + transaction.TransactionType)
+  }
+
+  checkParameter('numberString', transaction.Fee)
+
+  return _call({
+    method: 'getXrpSignedTransaction',
+    params: { key, transaction },
+  })
+}
+
+/**
+ * v1 dcent.getHederaSignedTransaction (src-v1/index.js#l1265-1280) 1:1 port.
+ *
+ * 동작: destructure → `unsignedTx → unsigned_tx` snake_case 변환 후 forward.
+ */
+export async function getHederaSignedTransaction ({
+  unsignedTx,
+  path,
+  symbol,
+  decimals,
+}: HederaTxParams): Promise<V1Response> {
+  return _call({
+    method: 'getHederaSignedTransaction',
+    params: {
+      unsigned_tx: unsignedTx,
+      path,
+      symbol,
+      decimals,
+    },
+  })
+}
+
+/**
+ * v1 dcent.getHederaSignedMessage (src-v1/index.js#l1282-1293) 1:1 port.
+ *
+ * 동작: destructure → `unsignedMsg → message` 키 변경 후 forward (v1 동작과 동일).
+ */
+export async function getHederaSignedMessage ({
+  unsignedMsg,
+  path,
+}: HederaMsgParams): Promise<V1Response> {
+  return _call({
+    method: 'getHederaSignedMessage',
+    params: {
+      message: unsignedMsg,
+      path,
+    },
+  })
+}
+
+/**
+ * v1 dcent.getStellarSignedTransaction (src-v1/index.js#l1295-1308) 1:1 port.
+ *
+ * 동작: destructure → `unsignedTx → unsigned_tx`, fee는 변환 없이 그대로 forward.
+ * (UnitConverter 적용은 m08-01-04.5의 복잡 wrapper 영역 — 본 wrapper는 fee를 raw string/number 그대로)
+ */
+export async function getStellarSignedTransaction ({
+  unsignedTx,
+  fee,
+  path,
+}: StellarTxParams): Promise<V1Response> {
+  return _call({
+    method: 'getStellarSignedTransaction',
+    params: {
+      unsigned_tx: unsignedTx,
+      fee,
+      path,
+    },
+  })
+}
+
+/**
+ * v1 dcent.getTronSignedTransaction (src-v1/index.js#l1310-1323) 1:1 port.
+ *
+ * 동작: destructure → `unsignedTx → unsigned_tx`, fee는 변환 없이 그대로 forward.
+ * method 이름은 `'getTronSignedTransaction'` (Tron 자체의 wrapper — TRC token은 m08-01-04.5).
+ */
+export async function getTronSignedTransaction ({
+  unsignedTx,
+  fee,
+  path,
+}: TronTxParams): Promise<V1Response> {
+  return _call({
+    method: 'getTronSignedTransaction',
+    params: {
+      unsigned_tx: unsignedTx,
+      fee,
+      path,
+    },
+  })
+}
+
+/**
+ * v1 dcent.getSignedMessage (src-v1/index.js#l1212-1221) 1:1 port.
+ *
+ * coin-agnostic — 모든 chain이 공통으로 사용. params는 camelCase 그대로 forward
+ * (v1 wire format이 camelCase 사용 — snake_case 변환 안 함).
+ *
+ * @param coinType v1 coinType 문자열 (예: 'BITCOIN', 'ETHEREUM' 등)
+ * @param key BIP44 path
+ * @param message 서명할 메시지 (hex 또는 utf-8 — bridge가 dispatch)
+ */
+export async function getSignedMessage (
+  coinType: string,
+  key: string,
+  message: string
+): Promise<V1Response> {
+  return _call({
+    method: 'getSignedMessage',
+    params: { coinType, key, message },
+  })
+}
+
+/**
+ * v1 dcent.getSignedData (src-v1/index.js#l1223-1230) 1:1 port.
+ *
+ * coin-agnostic — typed data 서명. params는 camelCase 그대로 forward.
+ *
+ * @param key BIP44 path
+ * @param message 서명할 typed data (chain-specific encoding)
+ */
+export async function getSignedData (
+  key: string,
+  message: string
+): Promise<V1Response> {
+  return _call({
+    method: 'getSignedData',
+    params: { key, message },
+  })
+}

--- a/tests/unit/v2/sign/nonEvm/getBitcoinSignedTransaction.test.ts
+++ b/tests/unit/v2/sign/nonEvm/getBitcoinSignedTransaction.test.ts
@@ -1,0 +1,87 @@
+/**
+ * getBitcoinSignedTransaction 단위 테스트 (m08-01-04)
+ *
+ * T-U-BTC-01: happy path — _call에 method='getBitcoinSignedTransaction' + params:{transaction}
+ * T-U-BTC-02: transaction === null → throw 'transaction object is undefined or null'
+ * T-U-BTC-03: transaction === undefined → throw
+ * T-RESP-01 (BTC): _call mock이 v1 fixture {header, body} 반환 시 wrapper가 변환 없이 그대로 return
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { getBitcoinSignedTransaction } from '../../../../../src/sign/nonEvmSimple'
+import { ensureSingleton, _resetForTesting } from '../../../../../src/singleton'
+import type { BitcoinTxObject } from '../../../../../src/sign/bitcoinTxBuilder'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+const expectV1Error = (code: string, messageContains?: string) =>
+  expect.objectContaining({
+    body: {
+      error: messageContains
+        ? expect.objectContaining({ code, message: expect.stringContaining(messageContains) })
+        : expect.objectContaining({ code }),
+    },
+  })
+
+const sampleBtcTx: BitcoinTxObject = {
+  coinType: 'BITCOIN',
+  parameter: {
+    inputs: [],
+    outputs: [],
+    fee: '1000',
+  } as any,
+}
+
+describe('getBitcoinSignedTransaction — happy path (T-U-BTC-01)', () => {
+  test('T-U-BTC-01: tx 객체 → _call({method, params:{transaction}}) 단언', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: { signed_tx: '0xabc' },
+    })
+
+    const resp = await getBitcoinSignedTransaction(sampleBtcTx)
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getBitcoinSignedTransaction')
+    expect(callArg.params).toEqual({ transaction: sampleBtcTx })
+    expect(resp.header.status).toBe('success')
+  })
+})
+
+describe('getBitcoinSignedTransaction — null/undefined 가드 (T-U-BTC-02/03)', () => {
+  test('T-U-BTC-02: transaction === null → throw param_error', async () => {
+    await expect(getBitcoinSignedTransaction(null as any)).rejects.toEqual(
+      expectV1Error('param_error', 'transaction object is undefined or null')
+    )
+  })
+
+  test('T-U-BTC-03: transaction === undefined → throw param_error', async () => {
+    await expect(getBitcoinSignedTransaction(undefined as any)).rejects.toEqual(
+      expectV1Error('param_error', 'transaction object is undefined or null')
+    )
+  })
+})
+
+describe('getBitcoinSignedTransaction — 응답 형식 forward (T-RESP-01 BTC)', () => {
+  test('T-RESP-01: _call이 v1 fixture를 반환하면 wrapper가 변환 없이 그대로 return', async () => {
+    const { transport } = ensureSingleton()
+    // call.ts가 raw payload를 wrapV1Success로 감싸므로, 우리는 raw payload만 보낸다.
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: { signed_tx: '0xdeadbeef', pubkey: '0xpub' },
+    })
+
+    const resp = await getBitcoinSignedTransaction(sampleBtcTx)
+
+    expect(resp.header.status).toBe('success')
+    expect(resp.body.parameter).toEqual({ signed_tx: '0xdeadbeef', pubkey: '0xpub' })
+  })
+})

--- a/tests/unit/v2/sign/nonEvm/getHederaSignedMessage.test.ts
+++ b/tests/unit/v2/sign/nonEvm/getHederaSignedMessage.test.ts
@@ -1,0 +1,63 @@
+/**
+ * getHederaSignedMessage 단위 테스트 (m08-01-04)
+ *
+ * T-U-HEDERA-MSG-01: happy path — destructure → params에 `message` 키 (key 변경) 단언
+ * T-RESP-01 (Hedera Msg): 응답 v1 호환 형식 그대로 forward
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { getHederaSignedMessage } from '../../../../../src/sign/nonEvmSimple'
+import { ensureSingleton, _resetForTesting } from '../../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+describe('getHederaSignedMessage — happy path + 키 매핑 (T-U-HEDERA-MSG-01)', () => {
+  test('T-U-HEDERA-MSG-01: unsignedMsg → message 키 변경 + path forward', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: { sign: '0xmsgsigned' },
+    })
+
+    const resp = await getHederaSignedMessage({
+      unsignedMsg: 'hello hedera',
+      path: "m/44'/3030'/0'/0/0",
+    })
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getHederaSignedMessage')
+    // 키 매핑 단언 — `message` 키 (불 `unsignedMsg`나 `unsigned_msg`가 아님)
+    expect(callArg.params).toEqual({
+      message: 'hello hedera',
+      path: "m/44'/3030'/0'/0/0",
+    })
+    expect(callArg.params).not.toHaveProperty('unsignedMsg')
+    expect(callArg.params).not.toHaveProperty('unsigned_msg')
+    expect(resp.header.status).toBe('success')
+  })
+})
+
+describe('getHederaSignedMessage — 응답 형식 forward (T-RESP-01 Hedera Msg)', () => {
+  test('T-RESP-01: _call이 v1 fixture 반환 시 변환 없이 forward', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: { sign: '0xmsg', pubkey: '0xpub' },
+    })
+
+    const resp = await getHederaSignedMessage({
+      unsignedMsg: 'hi',
+      path: "m/44'/3030'/0'/0/0",
+    })
+
+    expect(resp.header.status).toBe('success')
+    expect(resp.body.parameter).toEqual({ sign: '0xmsg', pubkey: '0xpub' })
+  })
+})

--- a/tests/unit/v2/sign/nonEvm/getHederaSignedTransaction.test.ts
+++ b/tests/unit/v2/sign/nonEvm/getHederaSignedTransaction.test.ts
@@ -1,0 +1,84 @@
+/**
+ * getHederaSignedTransaction 단위 테스트 (m08-01-04)
+ *
+ * T-U-HEDERA-TX-01: happy path — destructure → params에 `unsigned_tx` (snake_case) 변환 단언
+ * T-RESP-01 (Hedera Tx): 응답 v1 호환 형식 그대로 forward
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { getHederaSignedTransaction } from '../../../../../src/sign/nonEvmSimple'
+import { ensureSingleton, _resetForTesting } from '../../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+describe('getHederaSignedTransaction — happy path + snake_case 변환 (T-U-HEDERA-TX-01)', () => {
+  test('T-U-HEDERA-TX-01: unsignedTx → unsigned_tx 변환 + path/symbol/decimals forward', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: { signed_tx: '0xhederasigned' },
+    })
+
+    const resp = await getHederaSignedTransaction({
+      unsignedTx: '0xrawhedera',
+      path: "m/44'/3030'/0'/0/0",
+      symbol: 'HBAR',
+      decimals: 8,
+    })
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getHederaSignedTransaction')
+    // snake_case 변환 단언 — camelCase 'unsignedTx' 키가 없어야 함
+    expect(callArg.params).toEqual({
+      unsigned_tx: '0xrawhedera',
+      path: "m/44'/3030'/0'/0/0",
+      symbol: 'HBAR',
+      decimals: 8,
+    })
+    expect(callArg.params).not.toHaveProperty('unsignedTx')
+    expect(resp.header.status).toBe('success')
+  })
+
+  test('T-U-HEDERA-TX-01b: optional symbol/decimals 미제공 → undefined로 forward', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r2', result: {} })
+
+    await getHederaSignedTransaction({
+      unsignedTx: '0xrawhedera',
+      path: "m/44'/3030'/0'/0/0",
+    })
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.params).toMatchObject({
+      unsigned_tx: '0xrawhedera',
+      path: "m/44'/3030'/0'/0/0",
+    })
+    expect(callArg.params?.symbol).toBeUndefined()
+    expect(callArg.params?.decimals).toBeUndefined()
+  })
+})
+
+describe('getHederaSignedTransaction — 응답 형식 forward (T-RESP-01 Hedera Tx)', () => {
+  test('T-RESP-01: _call이 v1 fixture 반환 시 변환 없이 forward', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: { signed_tx: '0xhsigned', pubkey: '0xhpub' },
+    })
+
+    const resp = await getHederaSignedTransaction({
+      unsignedTx: '0xrawhedera',
+      path: "m/44'/3030'/0'/0/0",
+    })
+
+    expect(resp.header.status).toBe('success')
+    expect(resp.body.parameter).toEqual({ signed_tx: '0xhsigned', pubkey: '0xhpub' })
+  })
+})

--- a/tests/unit/v2/sign/nonEvm/getSignedData.test.ts
+++ b/tests/unit/v2/sign/nonEvm/getSignedData.test.ts
@@ -1,0 +1,57 @@
+/**
+ * getSignedData 단위 테스트 (m08-01-04)
+ *
+ * T-U-DATA-01: happy path — coin-agnostic, params {key, message} 그대로 forward
+ * T-RESP-01 (SignedData): 응답 v1 호환 형식 그대로 forward
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { getSignedData } from '../../../../../src/sign/nonEvmSimple'
+import { ensureSingleton, _resetForTesting } from '../../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+describe('getSignedData — happy path (T-U-DATA-01)', () => {
+  test('T-U-DATA-01: 2 인자 → params {key, message} 그대로 forward', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: { sign: '0xsigneddata' },
+    })
+
+    const resp = await getSignedData(
+      "m/44'/60'/0'/0/0",
+      '{"types":{...},"domain":{...},"message":{...}}'
+    )
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getSignedData')
+    expect(callArg.params).toEqual({
+      key: "m/44'/60'/0'/0/0",
+      message: '{"types":{...},"domain":{...},"message":{...}}',
+    })
+    expect(resp.header.status).toBe('success')
+  })
+})
+
+describe('getSignedData — 응답 형식 forward (T-RESP-01 SignedData)', () => {
+  test('T-RESP-01: _call이 v1 fixture 반환 시 변환 없이 forward', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: { sign: '0xtypedsig', pubkey: '0xpub' },
+    })
+
+    const resp = await getSignedData("m/44'/60'/0'/0/0", '{}')
+
+    expect(resp.header.status).toBe('success')
+    expect(resp.body.parameter).toEqual({ sign: '0xtypedsig', pubkey: '0xpub' })
+  })
+})

--- a/tests/unit/v2/sign/nonEvm/getSignedMessage.test.ts
+++ b/tests/unit/v2/sign/nonEvm/getSignedMessage.test.ts
@@ -1,0 +1,73 @@
+/**
+ * getSignedMessage 단위 테스트 (m08-01-04)
+ *
+ * T-U-MSG-01: happy path — coin-agnostic, params {coinType, key, message} 그대로 forward
+ * T-RESP-01 (SignedMessage): 응답 v1 호환 형식 그대로 forward
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { getSignedMessage } from '../../../../../src/sign/nonEvmSimple'
+import { ensureSingleton, _resetForTesting } from '../../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+describe('getSignedMessage — happy path (T-U-MSG-01)', () => {
+  test('T-U-MSG-01: 3 인자 → params {coinType, key, message} 그대로 forward', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: { sign: '0xsignedmsg' },
+    })
+
+    const resp = await getSignedMessage(
+      'BITCOIN',
+      "m/44'/0'/0'/0/0",
+      'hello world'
+    )
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getSignedMessage')
+    expect(callArg.params).toEqual({
+      coinType: 'BITCOIN',
+      key: "m/44'/0'/0'/0/0",
+      message: 'hello world',
+    })
+    expect(resp.header.status).toBe('success')
+  })
+
+  test('T-U-MSG-01b: 다른 coinType (ETHEREUM) — 동일하게 그대로 forward (coin-agnostic)', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r2', result: {} })
+
+    await getSignedMessage('ETHEREUM', "m/44'/60'/0'/0/0", 'eth msg')
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.params).toEqual({
+      coinType: 'ETHEREUM',
+      key: "m/44'/60'/0'/0/0",
+      message: 'eth msg',
+    })
+  })
+})
+
+describe('getSignedMessage — 응답 형식 forward (T-RESP-01 SignedMessage)', () => {
+  test('T-RESP-01: _call이 v1 fixture 반환 시 변환 없이 forward', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: { sign: '0xsigmsg', pubkey: '0xpubmsg' },
+    })
+
+    const resp = await getSignedMessage('BITCOIN', "m/44'/0'/0'/0/0", 'hi')
+
+    expect(resp.header.status).toBe('success')
+    expect(resp.body.parameter).toEqual({ sign: '0xsigmsg', pubkey: '0xpubmsg' })
+  })
+})

--- a/tests/unit/v2/sign/nonEvm/getStellarSignedTransaction.test.ts
+++ b/tests/unit/v2/sign/nonEvm/getStellarSignedTransaction.test.ts
@@ -1,0 +1,81 @@
+/**
+ * getStellarSignedTransaction 단위 테스트 (m08-01-04)
+ *
+ * T-U-STELLAR-01: happy path — fee 변환 없이 그대로 forward (UnitConverter 호출 없음 회귀 가드)
+ * T-RESP-01 (Stellar): 응답 v1 호환 형식 그대로 forward
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { getStellarSignedTransaction } from '../../../../../src/sign/nonEvmSimple'
+import { ensureSingleton, _resetForTesting } from '../../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+describe('getStellarSignedTransaction — happy path + fee raw forward (T-U-STELLAR-01)', () => {
+  test('T-U-STELLAR-01: fee="100" → 변환 없이 그대로 forward + unsigned_tx snake_case', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: { signed_tx: '0xstellarsigned' },
+    })
+
+    const resp = await getStellarSignedTransaction({
+      unsignedTx: '0xrawstellar',
+      fee: '100',
+      path: "m/44'/148'/0'/0/0",
+    })
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getStellarSignedTransaction')
+    // fee가 그대로 — UnitConverter 변환 없음
+    expect(callArg.params).toEqual({
+      unsigned_tx: '0xrawstellar',
+      fee: '100',
+      path: "m/44'/148'/0'/0/0",
+    })
+    expect(callArg.params?.fee).toBe('100')
+    expect(callArg.params).not.toHaveProperty('unsignedTx')
+    expect(resp.header.status).toBe('success')
+  })
+
+  test('T-U-STELLAR-01b: fee=number → number 그대로 forward (변환 없음 회귀 가드)', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r2', result: {} })
+
+    await getStellarSignedTransaction({
+      unsignedTx: '0xraw',
+      fee: 200,
+      path: "m/44'/148'/0'/0/0",
+    })
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.params?.fee).toBe(200)
+    expect(typeof callArg.params?.fee).toBe('number')
+  })
+})
+
+describe('getStellarSignedTransaction — 응답 형식 forward (T-RESP-01 Stellar)', () => {
+  test('T-RESP-01: _call이 v1 fixture 반환 시 변환 없이 forward', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: { signed_tx: '0xss', sign: '0xstellar' },
+    })
+
+    const resp = await getStellarSignedTransaction({
+      unsignedTx: '0xraw',
+      fee: '100',
+      path: "m/44'/148'/0'/0/0",
+    })
+
+    expect(resp.header.status).toBe('success')
+    expect(resp.body.parameter).toEqual({ signed_tx: '0xss', sign: '0xstellar' })
+  })
+})

--- a/tests/unit/v2/sign/nonEvm/getTronSignedTransaction.test.ts
+++ b/tests/unit/v2/sign/nonEvm/getTronSignedTransaction.test.ts
@@ -1,0 +1,83 @@
+/**
+ * getTronSignedTransaction 단위 테스트 (m08-01-04)
+ *
+ * T-U-TRON-01: happy path — fee 변환 없이 그대로 forward + method='getTronSignedTransaction'
+ *              (TRC token wrapper getTrcTokenSignedTransaction은 m08-01-04.5)
+ * T-RESP-01 (Tron): 응답 v1 호환 형식 그대로 forward
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { getTronSignedTransaction } from '../../../../../src/sign/nonEvmSimple'
+import { ensureSingleton, _resetForTesting } from '../../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+describe('getTronSignedTransaction — happy path + method 단언 (T-U-TRON-01)', () => {
+  test('T-U-TRON-01: fee/unsignedTx → snake_case 변환 + method=getTronSignedTransaction', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: { signed_tx: '0xtronsigned' },
+    })
+
+    const resp = await getTronSignedTransaction({
+      unsignedTx: '0xrawtron',
+      fee: '1000000',
+      path: "m/44'/195'/0'/0/0",
+    })
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    const callArg = sendSpy.mock.calls[0][0]
+    // method 회귀 가드 — TRC token wrapper(m08-01-04.5)와 헷갈리지 않도록 명시 단언
+    expect(callArg.method).toBe('getTronSignedTransaction')
+    expect(callArg.params).toEqual({
+      unsigned_tx: '0xrawtron',
+      fee: '1000000',
+      path: "m/44'/195'/0'/0/0",
+    })
+    // fee 변환 없음 회귀 가드
+    expect(callArg.params?.fee).toBe('1000000')
+    expect(callArg.params).not.toHaveProperty('unsignedTx')
+    expect(resp.header.status).toBe('success')
+  })
+
+  test('T-U-TRON-01b: fee=number → number 그대로 forward (변환 없음 회귀)', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r2', result: {} })
+
+    await getTronSignedTransaction({
+      unsignedTx: '0xraw',
+      fee: 1000000,
+      path: "m/44'/195'/0'/0/0",
+    })
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.params?.fee).toBe(1000000)
+    expect(typeof callArg.params?.fee).toBe('number')
+  })
+})
+
+describe('getTronSignedTransaction — 응답 형식 forward (T-RESP-01 Tron)', () => {
+  test('T-RESP-01: _call이 v1 fixture 반환 시 변환 없이 forward', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: { signed_tx: '0xts', sign: '0xtron' },
+    })
+
+    const resp = await getTronSignedTransaction({
+      unsignedTx: '0xraw',
+      fee: '100',
+      path: "m/44'/195'/0'/0/0",
+    })
+
+    expect(resp.header.status).toBe('success')
+    expect(resp.body.parameter).toEqual({ signed_tx: '0xts', sign: '0xtron' })
+  })
+})

--- a/tests/unit/v2/sign/nonEvm/getXrpSignedTransaction.test.ts
+++ b/tests/unit/v2/sign/nonEvm/getXrpSignedTransaction.test.ts
@@ -1,0 +1,128 @@
+/**
+ * getXrpSignedTransaction 단위 테스트 (m08-01-04)
+ *
+ * T-U-XRP-01: happy path — _call에 method='getXrpSignedTransaction' + params:{key, transaction}
+ * T-U-XRP-VALIDATION-01: Account non-string → throw 'TypeError: Required field type is not matched'
+ * T-U-XRP-VALIDATION-02: TransactionType non-string → throw
+ * T-U-XRP-VALIDATION-03: Fee non-string → throw
+ * T-U-XRP-VALIDATION-04: Sequence non-number → throw
+ * T-U-XRP-VALIDATION-05: 알 수 없는 TransactionType → throw 'Invalid Transaction Type: ...'
+ * T-U-XRP-VALIDATION-06: Fee가 numberString 위반 (예: 'abc') → checkParameter throw
+ * T-RESP-01 (XRP): 응답 v1 호환 형식 그대로 forward
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  getXrpSignedTransaction,
+  type XrpTxObject,
+} from '../../../../../src/sign/nonEvmSimple'
+import { ensureSingleton, _resetForTesting } from '../../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+const expectV1Error = (code: string, messageContains?: string) =>
+  expect.objectContaining({
+    body: {
+      error: messageContains
+        ? expect.objectContaining({ code, message: expect.stringContaining(messageContains) })
+        : expect.objectContaining({ code }),
+    },
+  })
+
+const sampleXrpTx: XrpTxObject = {
+  Account: 'rXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  TransactionType: 'Payment',
+  Fee: '12',
+  Sequence: 100,
+  Amount: '1000000',
+  Destination: 'rDestXXXXXXXXXXXXXXXXXXXXXXXXX',
+}
+
+const KEY = "m/44'/144'/0'/0/0"
+
+describe('getXrpSignedTransaction — happy path (T-U-XRP-01)', () => {
+  test('T-U-XRP-01: 정상 입력 → _call({method, params:{key, transaction}}) 단언', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: { sign: '0xsig', pubkey: '0xpub', accountId: 'r...' },
+    })
+
+    const resp = await getXrpSignedTransaction(sampleXrpTx, KEY)
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getXrpSignedTransaction')
+    expect(callArg.params).toEqual({ key: KEY, transaction: sampleXrpTx })
+    expect(resp.header.status).toBe('success')
+  })
+})
+
+describe('getXrpSignedTransaction — 인자 type 검증 (T-U-XRP-VALIDATION-01..04)', () => {
+  test('T-U-XRP-VALIDATION-01: Account non-string → throw param_error', async () => {
+    await expect(
+      getXrpSignedTransaction({ ...sampleXrpTx, Account: 123 as any }, KEY)
+    ).rejects.toEqual(expectV1Error('param_error', 'Required field type is not matched'))
+  })
+
+  test('T-U-XRP-VALIDATION-02: TransactionType non-string → throw param_error', async () => {
+    await expect(
+      getXrpSignedTransaction({ ...sampleXrpTx, TransactionType: 999 as any }, KEY)
+    ).rejects.toEqual(expectV1Error('param_error', 'Required field type is not matched'))
+  })
+
+  test('T-U-XRP-VALIDATION-03: Fee non-string → throw param_error', async () => {
+    await expect(
+      getXrpSignedTransaction({ ...sampleXrpTx, Fee: 12 as any }, KEY)
+    ).rejects.toEqual(expectV1Error('param_error', 'Required field type is not matched'))
+  })
+
+  test('T-U-XRP-VALIDATION-04: Sequence non-number → throw param_error', async () => {
+    await expect(
+      getXrpSignedTransaction({ ...sampleXrpTx, Sequence: '100' as any }, KEY)
+    ).rejects.toEqual(expectV1Error('param_error', 'Required field type is not matched'))
+  })
+})
+
+describe('getXrpSignedTransaction — TransactionType enum lookup (T-U-XRP-VALIDATION-05)', () => {
+  test('T-U-XRP-VALIDATION-05: 알 수 없는 TransactionType → throw "Invalid Transaction Type: NotARealType"', async () => {
+    await expect(
+      getXrpSignedTransaction({ ...sampleXrpTx, TransactionType: 'NotARealType' }, KEY)
+    ).rejects.toEqual(expectV1Error('param_error', 'Invalid Transaction Type: NotARealType'))
+  })
+})
+
+describe('getXrpSignedTransaction — Fee numberString 검증 (T-U-XRP-VALIDATION-06)', () => {
+  test('T-U-XRP-VALIDATION-06: Fee="abc" → checkParameter throw param_error', async () => {
+    await expect(
+      getXrpSignedTransaction({ ...sampleXrpTx, Fee: 'abc' }, KEY)
+    ).rejects.toEqual(expectV1Error('param_error'))
+  })
+
+  test('T-U-XRP-VALIDATION-06b: Fee="0xZZ" → checkParameter throw param_error', async () => {
+    await expect(
+      getXrpSignedTransaction({ ...sampleXrpTx, Fee: '0xZZ' }, KEY)
+    ).rejects.toEqual(expectV1Error('param_error'))
+  })
+})
+
+describe('getXrpSignedTransaction — 응답 형식 forward (T-RESP-01 XRP)', () => {
+  test('T-RESP-01: _call이 v1 fixture 반환 시 변환 없이 forward', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: { sign: '0xsignhex', pubkey: '0xpub', accountId: 'rABC' },
+    })
+
+    const resp = await getXrpSignedTransaction(sampleXrpTx, KEY)
+
+    expect(resp.header.status).toBe('success')
+    expect(resp.body.parameter).toEqual({ sign: '0xsignhex', pubkey: '0xpub', accountId: 'rABC' })
+  })
+})


### PR DESCRIPTION
## Summary

v1 sign wrapper 중 **단순 pass-through 패턴**(인자 검증 + `_call` 직접 dispatch) 인 8개를 v2 facade에 module-level 함수형으로 도입.

- Epic: m08-01 (connector v2 dApp facade) — DC-1998
- Depends on: m08-01-03 (EVM wrappers + checkParameter helper)
- Subtask: DC-2003

## 8개 단순 wrapper 인벤토리

| Wrapper | 패턴 | bridge method |
|---|---|---|
| `getBitcoinSignedTransaction(transaction)` | null guard | `'getBitcoinSignedTransaction'` |
| `getXrpSignedTransaction(transaction, key)` | type/enum/numberString 검증 | `'getXrpSignedTransaction'` |
| `getHederaSignedTransaction({...})` | destructure + `unsigned_tx` snake_case | `'getHederaSignedTransaction'` |
| `getHederaSignedMessage({...})` | destructure + `unsignedMsg→message` 키 변경 | `'getHederaSignedMessage'` |
| `getStellarSignedTransaction({...})` | destructure + fee 변환 없음 | `'getStellarSignedTransaction'` |
| `getTronSignedTransaction({...})` | destructure + fee 변환 없음 | `'getTronSignedTransaction'` |
| `getSignedMessage(coinType, key, message)` | coin-agnostic | `'getSignedMessage'` |
| `getSignedData(key, message)` | coin-agnostic | `'getSignedData'` |

복잡 wrapper(UnitConverter / method drift / response 후처리 9개 — `getTrcTokenSignedTransaction`, `getTezosSignedTransaction`, `getVechainSignedTransaction`, `getNearSignedTransaction`, `getHavahSignedTransaction`, `getPolkadotSignedTransaction`, `getCosmosSignedTransaction`, `getAlgorandSignedTransaction`, `getParachainSignedTransaction`)는 후속 child **m08-01-04.5에서 별도 처리**.

## Rationale

- **1:1 v1 호환** — params keys, throw vs return semantics, snake_case wire format 모두 v1 동등. m08-01-04 머지 시점에 v2 facade에서 v1 단순 sign API 무수정 호환.
- **m08-01-03 패턴 재사용** — evm.ts와 동일한 module-level 함수 + `_call({method, params})` dispatch + `dcentException` throw 구조.
- **XRP 입력 검증** — Account/TransactionType/Fee/Sequence 타입 4종 + xrpTxType enum lookup + Fee numberString 검증을 v1 1:1로 옮김 (boundary-validation, error-handling-consistency 룰 준수).
- **fee 변환 없음** (Stellar/Tron) — UnitConverter 적용은 m08-01-04.5의 복잡 wrapper 영역. 본 wrapper는 raw forward로 v1 동작 보존.

## Tested

자동 검증 5종 모두 PASS:

| 명령 | 결과 |
|---|---|
| `npm run unit-v2 -- tests/unit/v2/sign/nonEvm/` | ✅ 522 passed (8 nonEvm 신규 포함) |
| `npm run build` | ✅ webpack 5.106.2 (size warnings는 pre-existing) |
| `npm pack --dry-run \| grep sign/nonEvmSimple` | ✅ 매칭 |
| `node -e "default export 8 wrappers..."` | ✅ "all 8 simple wrappers exported" |
| `npx eslint --ext .ts src` | ✅ 0 errors |

T-XX 커버리지: T-U-BTC-01..03, T-U-XRP-01 + T-U-XRP-VALIDATION-01..06, T-U-HEDERA-TX-01, T-U-HEDERA-MSG-01, T-U-STELLAR-01, T-U-TRON-01, T-U-MSG-01, T-U-DATA-01, T-RESP-01 (× 8 wrapper), T-BUILD-01, T-PACK-01, T-DEFAULT-01, T-LINT-01.

## Constraints

- **다소 큰 diff (986 LOC)**: 코드 본체 ~330 LOC + 테스트 8개 ~656 LOC. 코드 본체만 보면 가이드 600 안. `pr-size-exception` 불필요.
- **package.json `version` 미수정** (`no-version-bump` 룰 준수).
- **`src/types/xrpTxType.ts` 경로**: objective 본문은 `src/sign/types/`로 인용했지만 실제 위치는 `src/types/`. 구현은 올바른 경로로 import.
- **머지 정책**: epic branch에 머지. epic dev 머지는 m08-01 epic 전체가 끝난 후 별도 PR로.

## Related

- Epic: DC-1998 (m08-01 connector v2 dApp facade)
- Depends: DC-2002 (m08-01-03 EVM wrappers, MERGED_TO_EPIC)
- Followup: m08-01-04.5 (복잡 non-EVM wrappers), m08-01-05 (playground rewrite + migration guide)

## Definition of Done

- [x] 자동 검증 명령 5/5 PASS
- [x] PR base = epic/DC-1998_m08-01-connector-v2-dapp-facade
- [x] PR description에 epic ID + 의존 + 8개 wrapper 인벤토리 + m08-01-04.5 분리 명시
- [x] `package.json` version 미수정
- [ ] 머지는 사람이 (objective-no-auto-merge)