### PR TITLE
[DC-2004] m08-01-04.5: v1 non-EVM complex sign wrapper 9개 v2 facade 도입

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,8 @@ import {
   klaytnTxType,
   xrpTxType,
   state,
+  // m08-01-04.5
+  coinDecimals,
 } from './types'
 import { unitConverter } from './utils/unitConverter'
 import {
@@ -62,6 +64,17 @@ import {
   getTronSignedTransaction,
   getSignedMessage,
   getSignedData,
+  // m08-01-04.5: v1 non-EVM complex sign wrappers (9개) + Cosmos czone helper
+  getTrcTokenSignedTransaction,
+  getTezosSignedTransaction,
+  getVechainSignedTransaction,
+  getNearSignedTransaction,
+  getHavahSignedTransaction,
+  getPolkadotSignedTransaction,
+  getCosmosSignedTransaction,
+  getAlgorandSignedTransaction,
+  getParachainSignedTransaction,
+  getCzonDecimal,
 } from './sign'
 
 // === 기존 named exports (m02-01·m02-02·m07-02 SHIPPED) ===
@@ -91,6 +104,8 @@ export {
   klaytnTxType,
   xrpTxType,
   state,
+  // m08-01-04.5
+  coinDecimals,
 } from './types'
 export type {
   CoinType,
@@ -107,6 +122,10 @@ export type {
   XrpTxTypeValue,
   State,
   StateValue,
+  // m08-01-04.5
+  CoinDecimals,
+  CoinDecimalsKey,
+  CoinDecimalsValue,
 } from './types'
 
 export { unitConverter } from './utils/unitConverter'
@@ -177,6 +196,20 @@ export type {
   TronTxParams,
 } from './sign'
 
+// === 새 named exports (m08-01-04.5 — v1 non-EVM complex sign wrappers + Cosmos czone helper) ===
+export {
+  getTrcTokenSignedTransaction,
+  getTezosSignedTransaction,
+  getVechainSignedTransaction,
+  getNearSignedTransaction,
+  getHavahSignedTransaction,
+  getPolkadotSignedTransaction,
+  getCosmosSignedTransaction,
+  getAlgorandSignedTransaction,
+  getParachainSignedTransaction,
+  getCzonDecimal,
+} from './sign'
+
 // === default export object (v1 호환 패턴) ===
 //
 // dApp이 `import dcent from 'dcent-web-connector'` 또는 `const dcent = require(...)`로
@@ -196,6 +229,8 @@ const dcent = {
   klaytnTxType,
   xrpTxType,
   state,
+  // m08-01-04.5: coinDecimals enum (v1 deferred port)
+  coinDecimals,
   // utils
   unitConverter,
   // sign (m08-01-02)
@@ -238,6 +273,17 @@ const dcent = {
   getTronSignedTransaction,
   getSignedMessage,
   getSignedData,
+  // m08-01-04.5: v1 non-EVM complex sign wrappers (9개) + Cosmos czone helper
+  getTrcTokenSignedTransaction,
+  getTezosSignedTransaction,
+  getVechainSignedTransaction,
+  getNearSignedTransaction,
+  getHavahSignedTransaction,
+  getPolkadotSignedTransaction,
+  getCosmosSignedTransaction,
+  getAlgorandSignedTransaction,
+  getParachainSignedTransaction,
+  getCzonDecimal,
 } as const
 
 export default dcent

--- a/src/sign/getCzonDecimal.ts
+++ b/src/sign/getCzonDecimal.ts
@@ -1,0 +1,38 @@
+/**
+ * v1 getCzonDecimal helper port (m08-01-04.5)
+ *
+ * v1 src-v1/index.js#l690-697의 `getCzonDecimal`을 1:1 port한다.
+ * Cosmos czone family(현재 COREUM)의 decimal lookup helper.
+ * Cosmos wrapper(getCosmosSignedTransaction)에서만 사용되므로 sign/ scope에 위치
+ * (`reuse-shared-utils` 룰 — caller scope 좁힘).
+ *
+ * v1 동작:
+ *   - 입력 coinType.toLowerCase()를 dcentCoinType.COREUM과 비교 (현재 COREUM만 등록)
+ *   - 매치 → coinDecimals.COREUM 반환
+ *   - 미매치 → dcentException('coin_type_error', 'not supported coin type --- ' + coinType) throw
+ *
+ * 룰 준수:
+ *   - boundary-validation: switch default에서 throw — silent return 금지
+ *   - error-handling-consistency: invalid input은 throw (caller가 try/catch로 propagate)
+ *   - reuse-shared-utils: m08-01-01의 v2 enum + m08-01-02.5의 dcentException 재사용
+ */
+
+import { coinType as dcentCoinType } from '../types/coinType'
+import { coinDecimals } from '../types/coinDecimals'
+import { dcentException } from '../v1/dcent-exception'
+
+/**
+ * v1 getCzonDecimal (src-v1/index.js#l690-697) 1:1 port.
+ *
+ * @param coinType v1 coinType 문자열 (예: 'COREUM')
+ * @returns 해당 coinType의 decimals (현재 COREUM=6만 등록)
+ * @throws v1 동등 dcentException — 'coin_type_error' / 'not supported coin type --- {coinType}'
+ */
+export function getCzonDecimal (coinType: string): number {
+  switch (coinType.toLowerCase()) {
+    case dcentCoinType.COREUM.toLowerCase():
+      return coinDecimals.COREUM
+    default:
+      throw dcentException('coin_type_error', 'not supported coin type --- ' + coinType)
+  }
+}

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -78,3 +78,19 @@ export type {
   StellarTxParams,
   TronTxParams,
 } from './nonEvmSimple'
+
+// m08-01-04.5: v1 non-EVM complex sign wrappers (9개 — UnitConverter + Union method 통합 + 후처리)
+export {
+  getTrcTokenSignedTransaction,
+  getTezosSignedTransaction,
+  getVechainSignedTransaction,
+  getNearSignedTransaction,
+  getHavahSignedTransaction,
+  getPolkadotSignedTransaction,
+  getCosmosSignedTransaction,
+  getAlgorandSignedTransaction,
+  getParachainSignedTransaction,
+} from './nonEvmComplex'
+
+// m08-01-04.5: Cosmos czone family helper (Cosmos wrapper에서만 사용 — sibling export)
+export { getCzonDecimal } from './getCzonDecimal'

--- a/src/sign/nonEvmComplex.ts
+++ b/src/sign/nonEvmComplex.ts
@@ -1,0 +1,458 @@
+/**
+ * v1 non-EVM complex sign wrappers — module-level functions (m08-01-04.5)
+ *
+ * v1 src-v1/index.js의 9개 복잡 wrapper를 v2 facade에 1:1 호환 port:
+ *   - getTrcTokenSignedTransaction (l1325-1338) — method drift `'getTronSignedTransaction'` (R1/D-14)
+ *   - getTezosSignedTransaction (l1340-1365) — UnitConverter(fee, TEZOS) padStart 16 + Union method
+ *   - getVechainSignedTransaction (l1367-1391) — UnitConverter(fee, VECHAIN) padStart 16 + Union
+ *   - getNearSignedTransaction (l1393-1420) — magic prefix `'000000ef'+'00000010'` + UnitConverter
+ *     padStart 32, fee=`'00'`, optionParam concat (`+=`)
+ *   - getHavahSignedTransaction (l1422-1447) — UnitConverter(fee, HAVAH) padStart 16 + Union
+ *   - getPolkadotSignedTransaction (l1449-1473) — UnitConverter(fee, POLKADOT) padStart 16 + Union
+ *   - getCosmosSignedTransaction (l1475-1511) — getCzonDecimal lookup + isCzoneCoinType remap +
+ *     response_from === 'czone' 시 원래 coinType 복원
+ *   - getAlgorandSignedTransaction (l1513-1538) — UnitConverter(fee, ALGORAND) padStart 16 + Union
+ *   - getParachainSignedTransaction (l1540-1576) — UnitConverter(fee, dApp feeDecimals) padStart 16 +
+ *     Union + success 응답 시 signed_tx에 '0x00' prefix (R2)
+ *
+ * 핵심 동작:
+ *   - 8개 wrapper가 `'getUnionSignedTransaction'` 단일 method로 dispatch (TrcToken만 method drift)
+ *   - fee 인코딩: UnitConverter(fee, decimals).bignum.toString(16).padStart(16/32, '0')
+ *   - Cosmos: coinType remap (czone family → 'czone') + response_from remap (응답 복원)
+ *   - Parachain: success 응답의 signed_tx에 '0x00' prefix (failure이면 그대로)
+ *   - inline destructured object type (F-05) — 별도 TxParams interface 파일 미신설
+ *
+ * 룰 준수:
+ *   - boundary-validation: Cosmos getCzonDecimal lookup이 unknown coinType 시 throw (v1 1:1)
+ *   - error-handling-consistency: Cosmos lookup 실패 throw, 그 외는 _call 위임
+ *   - mutation-isolation: _call이 매 호출마다 새 V1Response 객체 반환 (cloneV1Response).
+ *     Cosmos / Parachain 응답 mutation은 자기 wrapper가 받은 새 객체 내부에서만 수행
+ *   - cross-repo-interface-edit: TrcToken method drift는 sdk dispatcher 의존성 보존 (R1/D-14)
+ *   - reuse-shared-utils: _call, isCzoneCoinType (m08-01-02.5), coinType (m08-01-01),
+ *     coinDecimals + getCzonDecimal (본 child 신설), unitConverter (m08-01-01) 모두 재사용
+ *   - dapp-input-sanitization: 현 v1 동작 그대로 보존 — C3 sanitization은 후속 m08-01-06
+ *   - external-reference-edge-cases: UnitConverter padStart 정책은 v1 src-v1을 외부 레퍼런스로
+ *     bytewise parity 테스트(T-PARITY-01)로 검증
+ *   - no-version-bump: package.json version 미수정
+ */
+
+/* eslint-disable camelcase */
+
+import { _call } from './call'
+import { isCzoneCoinType } from './coinTypeValidators'
+import { getCzonDecimal } from './getCzonDecimal'
+import { coinType as dcentCoinType } from '../types/coinType'
+import { coinDecimals } from '../types/coinDecimals'
+import { unitConverter } from '../utils/unitConverter'
+import type { V1Response } from './types'
+
+/**
+ * v1 dcent.getTrcTokenSignedTransaction (src-v1/index.js#l1325-1338) 1:1 port.
+ *
+ * **method drift (R1/D-14)**: wrapper 이름이 `getTrcTokenSignedTransaction`이지만 dispatch하는
+ * method는 `'getTronSignedTransaction'`이다. sdk popup의 dispatcher가 Tron과 같은 핸들러를
+ * 공유하므로 의도적으로 보존. 변경하려면 cross-repo (dcent-web-sdk dispatcher) 변경 필요 —
+ * 본 chain 범위 초과.
+ */
+export async function getTrcTokenSignedTransaction ({
+  unsignedTx,
+  fee,
+  path,
+}: {
+  unsignedTx: string
+  fee: string | number
+  path: string
+}): Promise<V1Response> {
+  return _call({
+    method: 'getTronSignedTransaction', // 의도적 method drift — v1 1:1 보존 (R1/D-14)
+    params: {
+      unsigned_tx: unsignedTx,
+      fee,
+      path,
+    },
+  })
+}
+
+/**
+ * v1 dcent.getTezosSignedTransaction (src-v1/index.js#l1340-1365) 1:1 port.
+ *
+ * 동작: UnitConverter(fee, coinDecimals.TEZOS=6).bignum.toString(16).padStart(16, '0').
+ * method='getUnionSignedTransaction'.
+ * 선택 인자: nonce / optionParam (truthy일 때만 params에 추가).
+ */
+export async function getTezosSignedTransaction ({
+  coinType,
+  sigHash,
+  fee,
+  decimals,
+  nonce,
+  path,
+  symbol,
+  optionParam,
+}: {
+  coinType: string
+  sigHash: string
+  fee: string
+  decimals: number | string
+  nonce?: string
+  path: string
+  symbol: string
+  optionParam?: string
+}): Promise<V1Response> {
+  const params: Record<string, unknown> = {
+    coinType,
+    decimals,
+    sig_hash: sigHash,
+    fee: unitConverter(fee, coinDecimals.TEZOS).bignum.toString(16).padStart(16, '0'),
+    path,
+    symbol,
+  }
+  if (nonce) params.nonce = nonce
+  if (optionParam) params.optionParam = optionParam
+
+  return _call({
+    method: 'getUnionSignedTransaction',
+    params,
+  })
+}
+
+/**
+ * v1 dcent.getVechainSignedTransaction (src-v1/index.js#l1367-1391) 1:1 port.
+ *
+ * 동일 패턴 — coinDecimals.VECHAIN=18.
+ */
+export async function getVechainSignedTransaction ({
+  coinType,
+  sigHash,
+  fee,
+  decimals,
+  nonce,
+  path,
+  symbol,
+  optionParam,
+}: {
+  coinType: string
+  sigHash: string
+  fee: string
+  decimals: number | string
+  nonce?: string
+  path: string
+  symbol: string
+  optionParam?: string
+}): Promise<V1Response> {
+  const params: Record<string, unknown> = {
+    coinType,
+    decimals,
+    sig_hash: sigHash,
+    fee: unitConverter(fee, coinDecimals.VECHAIN).bignum.toString(16).padStart(16, '0'),
+    path,
+    symbol,
+  }
+  if (nonce) params.nonce = nonce
+  if (optionParam) params.optionParam = optionParam
+
+  return _call({
+    method: 'getUnionSignedTransaction',
+    params,
+  })
+}
+
+/**
+ * v1 dcent.getNearSignedTransaction (src-v1/index.js#l1393-1420) 1:1 port.
+ *
+ * 특수 동작:
+ *   - magic prefix `'000000ef' + '00000010'` + UnitConverter(fee, NEAR=24) padStart 32 (16 아님)
+ *   - params.fee는 literal `'00'` (실제 fee 값은 optionParam으로 전달)
+ *   - optionParam에 nearFee를 먼저 넣고, dApp이 optionParam을 추가 전달하면 `+=`로 concat
+ */
+export async function getNearSignedTransaction ({
+  coinType,
+  sigHash,
+  fee,
+  decimals,
+  nonce,
+  path,
+  symbol,
+  optionParam,
+}: {
+  coinType: string
+  sigHash: string
+  fee: string
+  decimals: number | string
+  nonce?: string
+  path: string
+  symbol: string
+  optionParam?: string
+}): Promise<V1Response> {
+  const nearFee = '000000ef' + '00000010' +
+    unitConverter(fee, coinDecimals.NEAR).bignum.toString(16).padStart(32, '0')
+
+  const params: Record<string, unknown> = {
+    coinType,
+    decimals,
+    sig_hash: sigHash,
+    fee: '00',
+    path,
+    symbol,
+    optionParam: nearFee,
+  }
+  if (nonce) params.nonce = nonce
+  // v1 l1414: dApp optionParam은 nearFee에 concat (`+=`)
+  if (optionParam) params.optionParam = (params.optionParam as string) + optionParam
+
+  return _call({
+    method: 'getUnionSignedTransaction',
+    params,
+  })
+}
+
+/**
+ * v1 dcent.getHavahSignedTransaction (src-v1/index.js#l1422-1447) 1:1 port.
+ *
+ * 동일 패턴 — coinDecimals.HAVAH=18.
+ */
+export async function getHavahSignedTransaction ({
+  coinType,
+  sigHash,
+  fee,
+  decimals,
+  nonce,
+  path,
+  symbol,
+  optionParam,
+}: {
+  coinType: string
+  sigHash: string
+  fee: string
+  decimals: number | string
+  nonce?: string
+  path: string
+  symbol: string
+  optionParam?: string
+}): Promise<V1Response> {
+  const params: Record<string, unknown> = {
+    coinType,
+    decimals,
+    sig_hash: sigHash,
+    fee: unitConverter(fee, coinDecimals.HAVAH).bignum.toString(16).padStart(16, '0'),
+    path,
+    symbol,
+  }
+  if (nonce) params.nonce = nonce
+  if (optionParam) params.optionParam = optionParam
+
+  return _call({
+    method: 'getUnionSignedTransaction',
+    params,
+  })
+}
+
+/**
+ * v1 dcent.getPolkadotSignedTransaction (src-v1/index.js#l1449-1473) 1:1 port.
+ *
+ * 동일 패턴 — coinDecimals.POLKADOT=10.
+ */
+export async function getPolkadotSignedTransaction ({
+  coinType,
+  sigHash,
+  fee,
+  decimals,
+  nonce,
+  path,
+  symbol,
+  optionParam,
+}: {
+  coinType: string
+  sigHash: string
+  fee: string
+  decimals: number | string
+  nonce?: string
+  path: string
+  symbol: string
+  optionParam?: string
+}): Promise<V1Response> {
+  const params: Record<string, unknown> = {
+    coinType,
+    decimals,
+    sig_hash: sigHash,
+    fee: unitConverter(fee, coinDecimals.POLKADOT).bignum.toString(16).padStart(16, '0'),
+    path,
+    symbol,
+  }
+  if (nonce) params.nonce = nonce
+  if (optionParam) params.optionParam = optionParam
+
+  return _call({
+    method: 'getUnionSignedTransaction',
+    params,
+  })
+}
+
+/**
+ * v1 dcent.getCosmosSignedTransaction (src-v1/index.js#l1475-1511) 1:1 port.
+ *
+ * 특수 동작:
+ *   - decimal 결정: COSMOS면 coinDecimals.COSMOS, 아니면 getCzonDecimal(coinType) (czone family lookup)
+ *   - getCzonDecimal이 unknown coinType에 throw — v1처럼 그대로 propagate
+ *   - coinType remap: isCzoneCoinType(coinType)이 true면 'czone'으로 remap (czone wallet 그룹)
+ *   - 응답 후처리: response_from === 'czone'이면 원래 coinType으로 복원
+ *     → dApp은 czone 그룹이라는 사실을 모르고 자기가 보낸 coinType 그대로 응답받음
+ *
+ * 매개변수 alias: 인자명 `ct`로 받지 않고 `coinType`으로 받되, dcentCoinType enum import와의
+ * 변수명 충돌은 enum을 `dcentCoinType`으로 alias함으로써 해결.
+ */
+export async function getCosmosSignedTransaction ({
+  coinType,
+  sigHash,
+  fee,
+  decimals,
+  nonce,
+  path,
+  symbol,
+  optionParam,
+}: {
+  coinType: string
+  sigHash: string
+  fee: string
+  decimals: number | string
+  nonce?: string
+  path: string
+  symbol: string
+  optionParam?: string
+}): Promise<V1Response> {
+  let decimal: number
+  try {
+    decimal = (coinType.toLowerCase() === dcentCoinType.COSMOS.toLowerCase())
+      ? coinDecimals.COSMOS
+      : getCzonDecimal(coinType) // unknown coinType → throw
+  } catch (error) {
+    throw error
+  }
+
+  const params: Record<string, unknown> = {
+    coinType: isCzoneCoinType(coinType) ? 'czone' : coinType,
+    decimals,
+    sig_hash: sigHash,
+    fee: unitConverter(fee, decimal).bignum.toString(16).padStart(16, '0'),
+    path,
+    symbol,
+  }
+  if (nonce) params.nonce = nonce
+  if (optionParam) params.optionParam = optionParam
+
+  const res = await _call({
+    method: 'getUnionSignedTransaction',
+    params,
+  })
+
+  // v1 l1507-1509 — czone family 응답은 원래 coinType으로 복원
+  if (res.header.response_from === 'czone') {
+    res.header.response_from = coinType
+  }
+  return res
+}
+
+/**
+ * v1 dcent.getAlgorandSignedTransaction (src-v1/index.js#l1513-1538) 1:1 port.
+ *
+ * 동일 패턴 — coinDecimals.ALGORAND=6.
+ */
+export async function getAlgorandSignedTransaction ({
+  coinType,
+  sigHash,
+  fee,
+  decimals,
+  nonce,
+  path,
+  symbol,
+  optionParam,
+}: {
+  coinType: string
+  sigHash: string
+  fee: string
+  decimals: number | string
+  nonce?: string
+  path: string
+  symbol: string
+  optionParam?: string
+}): Promise<V1Response> {
+  const params: Record<string, unknown> = {
+    coinType,
+    decimals,
+    sig_hash: sigHash,
+    fee: unitConverter(fee, coinDecimals.ALGORAND).bignum.toString(16).padStart(16, '0'),
+    path,
+    symbol,
+  }
+  if (nonce) params.nonce = nonce
+  if (optionParam) params.optionParam = optionParam
+
+  return _call({
+    method: 'getUnionSignedTransaction',
+    params,
+  })
+}
+
+/**
+ * v1 dcent.getParachainSignedTransaction (src-v1/index.js#l1540-1576) 1:1 port.
+ *
+ * 특수 동작:
+ *   - feeDecimals는 dApp 인자 (다른 wrapper와 달리 상수가 아님)
+ *   - RPCUrl, feeSymbol, feeDecimals 모두 params에 forward (Parachain 전용)
+ *   - 응답 후처리 (R2): success 응답이면 signed_tx에 '0x00' prefix 추가
+ *     - 기존 signed_tx가 '0x'로 시작하면 strip 후 '0x00' prepend
+ *     - '0x'로 시작하지 않으면 그대로 '0x00' prepend
+ *   - failure 응답이면 그대로 return (prefix 추가 안 함 — failure 회귀 가드)
+ */
+export async function getParachainSignedTransaction ({
+  coinType,
+  sigHash,
+  fee,
+  decimals,
+  nonce,
+  path,
+  symbol,
+  RPCUrl,
+  feeSymbol,
+  feeDecimals,
+  optionParam,
+}: {
+  coinType: string
+  sigHash: string
+  fee: string
+  decimals: number | string
+  nonce?: string
+  path: string
+  symbol: string
+  RPCUrl: string
+  feeSymbol: string
+  feeDecimals: number | string
+  optionParam?: string
+}): Promise<V1Response> {
+  const params: Record<string, unknown> = {
+    coinType,
+    sig_hash: sigHash,
+    fee: unitConverter(fee, feeDecimals).bignum.toString(16).padStart(16, '0'),
+    decimals,
+    path,
+    symbol,
+    RPCUrl,
+    feeSymbol,
+    feeDecimals,
+  }
+  if (nonce) params.nonce = nonce
+  if (optionParam) params.optionParam = optionParam
+
+  const res = await _call({
+    method: 'getUnionSignedTransaction',
+    params,
+  })
+
+  // v1 l1572-1574 — success 응답일 때만 signed_tx에 '0x00' prefix
+  if (res.header.status === 'success' && res.body.parameter && typeof res.body.parameter.signed_tx === 'string') {
+    const signedTx = res.body.parameter.signed_tx as string
+    res.body.parameter.signed_tx = '0x00' +
+      (signedTx.startsWith('0x') ? signedTx.substr(2) : signedTx)
+  }
+  return res
+}

--- a/src/types/coinDecimals.ts
+++ b/src/types/coinDecimals.ts
@@ -1,0 +1,32 @@
+/**
+ * v2 facade — coinDecimals enum (m08-01-04.5)
+ *
+ * v1 src-v1/type/dcent-web-type.js#l242-251의 `coinDecimals`와 키·값 1:1 일치.
+ * m08-01-01에서 명시적으로 deferred되었던 항목 — 본 child가 nonEvmComplex wrapper에서
+ * UnitConverter(fee, coinDecimals.{KEY})로 사용하기 위해 신설.
+ *
+ * tests/unit/v2/types/coinDecimals-drift.test.ts가 require('src-v1/type/dcent-web-type')로
+ * v1을 직접 로드하여 키·값 일치를 단언 (T-DRIFT-COIN-DECIMALS-01) — 수동 동기화 정책.
+ *
+ * Object.freeze로 mutation 격리 (`mutation-isolation` 룰).
+ * `as const`로 union literal 타입 자동 추론.
+ *
+ * 룰 준수:
+ *   - mutation-isolation: Object.freeze로 enum 객체 자체 mutation 차단
+ *   - reuse-shared-utils: 다른 wrapper들이 import하여 사용 (단일 진실)
+ */
+
+export const coinDecimals = Object.freeze({
+  TEZOS: 6,
+  VECHAIN: 18,
+  NEAR: 24,
+  HAVAH: 18,
+  POLKADOT: 10,
+  COSMOS: 6,
+  COREUM: 6,
+  ALGORAND: 6,
+} as const)
+
+export type CoinDecimals = typeof coinDecimals
+export type CoinDecimalsKey = keyof CoinDecimals
+export type CoinDecimalsValue = CoinDecimals[CoinDecimalsKey]

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,3 +12,5 @@ export { bitcoinTxType, type BitcoinTxType, type BitcoinTxTypeValue } from './bi
 export { klaytnTxType, type KlaytnTxType, type KlaytnTxTypeValue } from './klaytnTxType'
 export { xrpTxType, type XrpTxType, type XrpTxTypeValue } from './xrpTxType'
 export { state, type State, type StateValue } from './state'
+// m08-01-04.5: coinDecimals enum (v1 src-v1/type/dcent-web-type.js#l242-251 deferred port)
+export { coinDecimals, type CoinDecimals, type CoinDecimalsKey, type CoinDecimalsValue } from './coinDecimals'

--- a/tests/unit/v2/sign/getCzonDecimal-drift.test.ts
+++ b/tests/unit/v2/sign/getCzonDecimal-drift.test.ts
@@ -1,0 +1,44 @@
+/**
+ * getCzonDecimal drift 방어 단위 테스트 (m08-01-04.5)
+ *
+ * v1 src-v1/index.js#l690-697의 `getCzonDecimal`은 module-internal이므로 require 직접 비교 불가.
+ * 대신 v1 source의 case enum (현재 COREUM만 등록)을 hardcoded fixture로 추출하여 v2 .ts 결과와 대조.
+ *
+ * T-DRIFT-CZON-DECIMAL-01: known coinType (COREUM, lowercase 'coreum') → coinDecimals.COREUM=6 반환
+ * T-DRIFT-CZON-DECIMAL-02: unknown coinType → throw dcentException ('coin_type_error')
+ *
+ * Fixture 출처: src-v1/index.js#l690-697 + dcentCoinType.COREUM = 'coreum'.
+ */
+
+import { getCzonDecimal } from '../../../../src/sign/getCzonDecimal'
+import { coinDecimals } from '../../../../src/types/coinDecimals'
+
+describe('getCzonDecimal drift 방어 — v1 src-v1/index.js#l690-697 ↔ v2 .ts', () => {
+  test('T-DRIFT-CZON-DECIMAL-01: COREUM → coinDecimals.COREUM (=6)', () => {
+    expect(getCzonDecimal('COREUM')).toBe(coinDecimals.COREUM)
+    expect(getCzonDecimal('COREUM')).toBe(6)
+  })
+
+  test('T-DRIFT-CZON-DECIMAL-01b: lowercase "coreum"도 매치 (toLowerCase 비교)', () => {
+    expect(getCzonDecimal('coreum')).toBe(6)
+    expect(getCzonDecimal('Coreum')).toBe(6)
+  })
+
+  test('T-DRIFT-CZON-DECIMAL-02: 알 수 없는 coinType → throw dcentException("coin_type_error")', () => {
+    expect(() => getCzonDecimal('UNKNOWN_CHAIN')).toThrow()
+    try {
+      getCzonDecimal('UNKNOWN_CHAIN')
+    } catch (e: unknown) {
+      const err = e as { header: { status: string }; body: { error: { code: string; message: string } } }
+      expect(err.header.status).toBe('error')
+      expect(err.body.error.code).toBe('coin_type_error')
+      expect(err.body.error.message).toContain('not supported coin type')
+      expect(err.body.error.message).toContain('UNKNOWN_CHAIN')
+    }
+  })
+
+  test('T-DRIFT-CZON-DECIMAL-03: COSMOS는 czone family가 아니므로 throw', () => {
+    // v1 동작: getCzonDecimal('COSMOS') → throw (Cosmos 자체는 wrapper에서 별도 분기 처리)
+    expect(() => getCzonDecimal('COSMOS')).toThrow()
+  })
+})

--- a/tests/unit/v2/sign/nonEvm/getAlgorandSignedTransaction.test.ts
+++ b/tests/unit/v2/sign/nonEvm/getAlgorandSignedTransaction.test.ts
@@ -1,0 +1,39 @@
+/**
+ * getAlgorandSignedTransaction 단위 테스트 (m08-01-04.5)
+ *
+ * T-U-ALGO-01: happy — UnitConverter(fee, ALGORAND=6) padStart 16
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any, camelcase */
+import { getAlgorandSignedTransaction } from '../../../../../src/sign/nonEvmComplex'
+import { ensureSingleton, _resetForTesting } from '../../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+describe('getAlgorandSignedTransaction — UnitConverter(ALGORAND) (T-U-ALGO-01)', () => {
+  test('T-U-ALGO-01: fee="0.001" → unitConverter(0.001, 6) padStart 16', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r1', result: {} })
+
+    await getAlgorandSignedTransaction({
+      coinType: 'ALGORAND',
+      sigHash: '0xsighash',
+      fee: '0.001',
+      decimals: 6,
+      path: "m/44'/283'/0'/0/0",
+      symbol: 'ALGO',
+    })
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getUnionSignedTransaction')
+    // 0.001 * 10^6 = 1000 = 0x3e8 → padStart(16) = '00000000000003e8'
+    expect(callArg.params?.fee).toBe('00000000000003e8')
+    expect(callArg.params?.coinType).toBe('ALGORAND')
+  })
+})

--- a/tests/unit/v2/sign/nonEvm/getCosmosSignedTransaction.test.ts
+++ b/tests/unit/v2/sign/nonEvm/getCosmosSignedTransaction.test.ts
@@ -1,0 +1,140 @@
+/**
+ * getCosmosSignedTransaction 단위 테스트 (m08-01-04.5)
+ *
+ * T-U-COSMOS-01: COSMOS happy — params.coinType='COSMOS' (remap 안 함) + coinDecimals.COSMOS=6 사용
+ * T-U-COSMOS-02: czone family (COREUM) happy — params.coinType='czone' remap + getCzonDecimal 사용
+ * T-U-COSMOS-03: 알 수 없는 coinType → getCzonDecimal throw → wrapper rethrow
+ * T-U-COSMOS-04: 응답 response_from='czone' → 원래 coinType으로 복원
+ * T-U-COSMOS-05: 응답 response_from!='czone' → mutation 안 함 (그대로 return)
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any, camelcase */
+import { getCosmosSignedTransaction } from '../../../../../src/sign/nonEvmComplex'
+import { ensureSingleton, _resetForTesting } from '../../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+describe('getCosmosSignedTransaction — coinType remap + response 후처리 (T-U-COSMOS-*)', () => {
+  test('T-U-COSMOS-01: coinType=COSMOS — params.coinType="COSMOS" (remap 안 함) + decimals=COSMOS(6)', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: {
+        header: { version: '1.0', status: 'success', response_from: 'COSMOS' },
+        body: { command: 'transaction', parameter: { signed_tx: '0xcosmosigned' } },
+      },
+    })
+
+    const resp = await getCosmosSignedTransaction({
+      coinType: 'COSMOS',
+      sigHash: '0xsighash',
+      fee: '0.001',
+      decimals: 6,
+      path: "m/44'/118'/0'/0/0",
+      symbol: 'ATOM',
+    })
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getUnionSignedTransaction')
+    expect(callArg.params?.coinType).toBe('COSMOS') // remap 안 됨
+    // 0.001 * 10^6 = 1000 = 0x3e8 → padStart 16 = '00000000000003e8'
+    expect(callArg.params?.fee).toBe('00000000000003e8')
+    expect(resp.header.status).toBe('success')
+  })
+
+  test('T-U-COSMOS-02: coinType=COREUM (czone family) — params.coinType="czone" remap + getCzonDecimal 사용', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r2',
+      result: {
+        header: { version: '1.0', status: 'success', response_from: 'czone' },
+        body: { command: 'transaction', parameter: { signed_tx: '0xcoreumsigned' } },
+      },
+    })
+
+    const resp = await getCosmosSignedTransaction({
+      coinType: 'COREUM',
+      sigHash: '0xsighash',
+      fee: '0.001',
+      decimals: 6,
+      path: "m/44'/990'/0'/0/0",
+      symbol: 'CORE',
+    })
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.params?.coinType).toBe('czone') // remap됨
+    // getCzonDecimal('COREUM') = 6 → 0.001 * 10^6 = 1000 = 0x3e8 → padStart 16
+    expect(callArg.params?.fee).toBe('00000000000003e8')
+    // T-U-COSMOS-04와 결합: response_from='czone' → 원래 coinType('COREUM')으로 복원됨
+    expect(resp.header.response_from).toBe('COREUM')
+  })
+
+  test('T-U-COSMOS-03: 알 수 없는 coinType → getCzonDecimal throw → wrapper rethrow', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r3', result: {} })
+
+    await expect(
+      getCosmosSignedTransaction({
+        coinType: 'UNKNOWN_CHAIN',
+        sigHash: '0x',
+        fee: '0',
+        decimals: 6,
+        path: "m/44'/118'/0'/0/0",
+        symbol: 'X',
+      }),
+    ).rejects.toMatchObject({
+      header: { status: 'error' },
+      body: { error: { code: 'coin_type_error' } },
+    })
+  })
+
+  test('T-U-COSMOS-04: 응답 response_from="czone" → 원래 coinType으로 복원', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r4',
+      result: {
+        header: { version: '1.0', status: 'success', response_from: 'czone' },
+        body: { command: 'transaction', parameter: { signed_tx: '0xsig' } },
+      },
+    })
+
+    const resp = await getCosmosSignedTransaction({
+      coinType: 'COREUM',
+      sigHash: '0x',
+      fee: '0.001',
+      decimals: 6,
+      path: "m/44'/990'/0'/0/0",
+      symbol: 'CORE',
+    })
+
+    expect(resp.header.response_from).toBe('COREUM')
+  })
+
+  test('T-U-COSMOS-05: 응답 response_from="COSMOS" (czone 아님) → 그대로 return (mutation 안 함)', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r5',
+      result: {
+        header: { version: '1.0', status: 'success', response_from: 'COSMOS' },
+        body: { command: 'transaction', parameter: { signed_tx: '0xsig' } },
+      },
+    })
+
+    const resp = await getCosmosSignedTransaction({
+      coinType: 'COSMOS',
+      sigHash: '0x',
+      fee: '0.001',
+      decimals: 6,
+      path: "m/44'/118'/0'/0/0",
+      symbol: 'ATOM',
+    })
+
+    expect(resp.header.response_from).toBe('COSMOS') // 변환 없음
+  })
+})

--- a/tests/unit/v2/sign/nonEvm/getHavahSignedTransaction.test.ts
+++ b/tests/unit/v2/sign/nonEvm/getHavahSignedTransaction.test.ts
@@ -1,0 +1,39 @@
+/**
+ * getHavahSignedTransaction 단위 테스트 (m08-01-04.5)
+ *
+ * T-U-HAVAH-01: happy — UnitConverter(fee, HAVAH=18) padStart 16
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any, camelcase */
+import { getHavahSignedTransaction } from '../../../../../src/sign/nonEvmComplex'
+import { ensureSingleton, _resetForTesting } from '../../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+describe('getHavahSignedTransaction — UnitConverter(HAVAH) (T-U-HAVAH-01)', () => {
+  test('T-U-HAVAH-01: fee="0.001" → unitConverter(0.001, 18) padStart 16', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r1', result: {} })
+
+    await getHavahSignedTransaction({
+      coinType: 'HAVAH',
+      sigHash: '0xsighash',
+      fee: '0.001',
+      decimals: 18,
+      path: "m/44'/9999999'/0'/0/0",
+      symbol: 'HVH',
+    })
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getUnionSignedTransaction')
+    // 0.001 * 10^18 = 1e15 = 0x38d7ea4c68000 (13 hex) → padStart(16) = '00038d7ea4c68000'
+    expect(callArg.params?.fee).toBe('00038d7ea4c68000')
+    expect(callArg.params?.coinType).toBe('HAVAH')
+  })
+})

--- a/tests/unit/v2/sign/nonEvm/getNearSignedTransaction.test.ts
+++ b/tests/unit/v2/sign/nonEvm/getNearSignedTransaction.test.ts
@@ -1,0 +1,62 @@
+/**
+ * getNearSignedTransaction 단위 테스트 (m08-01-04.5)
+ *
+ * T-U-NEAR-01: happy — params.fee='00' (literal) + optionParam에 magic prefix '000000ef'+'00000010'+
+ *              UnitConverter(fee, NEAR=24) padStart 32 단언
+ * T-U-NEAR-02: dApp이 optionParam 전달 시 nearFee + dApp optionParam concat (`+=`) 단언
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any, camelcase */
+import { getNearSignedTransaction } from '../../../../../src/sign/nonEvmComplex'
+import { ensureSingleton, _resetForTesting } from '../../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+describe('getNearSignedTransaction — magic prefix + optionParam concat (T-U-NEAR-01/02)', () => {
+  test('T-U-NEAR-01: fee="1" → params.fee="00", optionParam = "000000ef"+"00000010"+padStart(32) of unitConverter(1,24)', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r1', result: {} })
+
+    await getNearSignedTransaction({
+      coinType: 'NEAR',
+      sigHash: '0xsighash',
+      fee: '1',
+      decimals: 24,
+      path: "m/44'/397'/0'/0/0",
+      symbol: 'NEAR',
+    })
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getUnionSignedTransaction')
+    // 1 * 10^24 = 0xd3c21bcecceda1000000 (20 hex) → padStart(32) = '000000000000d3c21bcecceda1000000'
+    expect(callArg.params?.fee).toBe('00')
+    expect(callArg.params?.optionParam).toBe(
+      '000000ef' + '00000010' + '000000000000d3c21bcecceda1000000',
+    )
+  })
+
+  test('T-U-NEAR-02: dApp optionParam 전달 시 nearFee + dApp optionParam concat (`+=`)', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r2', result: {} })
+
+    await getNearSignedTransaction({
+      coinType: 'NEAR',
+      sigHash: '0xsighash',
+      fee: '1',
+      decimals: 24,
+      path: "m/44'/397'/0'/0/0",
+      symbol: 'NEAR',
+      optionParam: 'EXTRA',
+    })
+
+    const callArg = sendSpy.mock.calls[0][0]
+    const expectedNearFee = '000000ef' + '00000010' + '000000000000d3c21bcecceda1000000'
+    expect(callArg.params?.optionParam).toBe(expectedNearFee + 'EXTRA')
+  })
+})

--- a/tests/unit/v2/sign/nonEvm/getParachainSignedTransaction.test.ts
+++ b/tests/unit/v2/sign/nonEvm/getParachainSignedTransaction.test.ts
@@ -1,0 +1,142 @@
+/**
+ * getParachainSignedTransaction 단위 테스트 (m08-01-04.5)
+ *
+ * T-U-PARA-01: happy — UnitConverter(fee, dApp feeDecimals) padStart 16 + RPCUrl/feeSymbol/feeDecimals forward
+ * T-U-PARA-02: success 응답 + signed_tx='abcdef' (no '0x') → '0x00abcdef'
+ * T-U-PARA-03: success 응답 + signed_tx='0xabcdef' → '0x' strip 후 '0x00' prepend = '0x00abcdef'
+ * T-U-PARA-04: failure 응답 → prefix 추가 없이 그대로 return (R2 회귀 가드)
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any, camelcase */
+import { getParachainSignedTransaction } from '../../../../../src/sign/nonEvmComplex'
+import { ensureSingleton, _resetForTesting } from '../../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+describe('getParachainSignedTransaction — feeDecimals + signed_tx prefix (T-U-PARA-*)', () => {
+  test('T-U-PARA-01: feeDecimals=10 → unitConverter(fee, 10) padStart 16 + RPCUrl/feeSymbol forward', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: {
+        header: { version: '1.0', status: 'success' },
+        body: { command: 'transaction', parameter: { signed_tx: '0xparasigned' } },
+      },
+    })
+
+    await getParachainSignedTransaction({
+      coinType: 'PARA',
+      sigHash: '0xsighash',
+      fee: '0.5',
+      decimals: 10,
+      path: "m/44'/354'/0'/0/0",
+      symbol: 'DOT',
+      RPCUrl: 'wss://rpc.example',
+      feeSymbol: 'DOT',
+      feeDecimals: 10,
+    })
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getUnionSignedTransaction')
+    // 0.5 * 10^10 = 5e9 = 0x12a05f200 → padStart 16 = '000000012a05f200'
+    expect(callArg.params?.fee).toBe('000000012a05f200')
+    expect(callArg.params).toMatchObject({
+      coinType: 'PARA',
+      sig_hash: '0xsighash',
+      decimals: 10,
+      path: "m/44'/354'/0'/0/0",
+      symbol: 'DOT',
+      RPCUrl: 'wss://rpc.example',
+      feeSymbol: 'DOT',
+      feeDecimals: 10,
+    })
+  })
+
+  test('T-U-PARA-02: success + signed_tx="abcdef" (no 0x) → "0x00abcdef" prefix 적용', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r2',
+      result: {
+        header: { version: '1.0', status: 'success' },
+        body: { command: 'transaction', parameter: { signed_tx: 'abcdef' } },
+      },
+    })
+
+    const resp = await getParachainSignedTransaction({
+      coinType: 'PARA',
+      sigHash: '0x',
+      fee: '0',
+      decimals: 10,
+      path: "m/44'/354'/0'/0/0",
+      symbol: 'DOT',
+      RPCUrl: 'wss://rpc',
+      feeSymbol: 'DOT',
+      feeDecimals: 10,
+    })
+
+    expect(resp.header.status).toBe('success')
+    expect(resp.body.parameter?.signed_tx).toBe('0x00abcdef')
+  })
+
+  test('T-U-PARA-03: success + signed_tx="0xabcdef" → "0x" strip 후 "0x00" prepend = "0x00abcdef"', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r3',
+      result: {
+        header: { version: '1.0', status: 'success' },
+        body: { command: 'transaction', parameter: { signed_tx: '0xabcdef' } },
+      },
+    })
+
+    const resp = await getParachainSignedTransaction({
+      coinType: 'PARA',
+      sigHash: '0x',
+      fee: '0',
+      decimals: 10,
+      path: "m/44'/354'/0'/0/0",
+      symbol: 'DOT',
+      RPCUrl: 'wss://rpc',
+      feeSymbol: 'DOT',
+      feeDecimals: 10,
+    })
+
+    expect(resp.body.parameter?.signed_tx).toBe('0x00abcdef')
+  })
+
+  test('T-U-PARA-04: failure 응답 → prefix 추가 없이 그대로 return (R2 회귀 가드)', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r4',
+      result: {
+        header: { version: '1.0', status: 'failure' },
+        body: {
+          command: 'transaction',
+          error: { code: 'user_cancel', message: 'cancelled' },
+        },
+      },
+    })
+
+    const resp = await getParachainSignedTransaction({
+      coinType: 'PARA',
+      sigHash: '0x',
+      fee: '0',
+      decimals: 10,
+      path: "m/44'/354'/0'/0/0",
+      symbol: 'DOT',
+      RPCUrl: 'wss://rpc',
+      feeSymbol: 'DOT',
+      feeDecimals: 10,
+    })
+
+    expect(resp.header.status).toBe('failure')
+    // signed_tx가 응답에 없으므로 prefix 추가 없음
+    expect(resp.body.parameter?.signed_tx).toBeUndefined()
+    expect(resp.body.error?.code).toBe('user_cancel')
+  })
+})

--- a/tests/unit/v2/sign/nonEvm/getPolkadotSignedTransaction.test.ts
+++ b/tests/unit/v2/sign/nonEvm/getPolkadotSignedTransaction.test.ts
@@ -1,0 +1,39 @@
+/**
+ * getPolkadotSignedTransaction 단위 테스트 (m08-01-04.5)
+ *
+ * T-U-DOT-01: happy — UnitConverter(fee, POLKADOT=10) padStart 16
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any, camelcase */
+import { getPolkadotSignedTransaction } from '../../../../../src/sign/nonEvmComplex'
+import { ensureSingleton, _resetForTesting } from '../../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+describe('getPolkadotSignedTransaction — UnitConverter(POLKADOT) (T-U-DOT-01)', () => {
+  test('T-U-DOT-01: fee="0.5" → unitConverter(0.5, 10) padStart 16', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r1', result: {} })
+
+    await getPolkadotSignedTransaction({
+      coinType: 'POLKADOT',
+      sigHash: '0xsighash',
+      fee: '0.5',
+      decimals: 10,
+      path: "m/44'/354'/0'/0/0",
+      symbol: 'DOT',
+    })
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getUnionSignedTransaction')
+    // 0.5 * 10^10 = 5e9 = 0x12a05f200 (9 hex) → padStart(16) = '000000012a05f200'
+    expect(callArg.params?.fee).toBe('000000012a05f200')
+    expect(callArg.params?.coinType).toBe('POLKADOT')
+  })
+})

--- a/tests/unit/v2/sign/nonEvm/getTezosSignedTransaction.test.ts
+++ b/tests/unit/v2/sign/nonEvm/getTezosSignedTransaction.test.ts
@@ -1,0 +1,93 @@
+/**
+ * getTezosSignedTransaction 단위 테스트 (m08-01-04.5)
+ *
+ * T-U-TEZOS-01: happy — UnitConverter(fee, TEZOS=6).bignum.toString(16).padStart(16,'0') 정확 단언
+ *               + method='getUnionSignedTransaction'
+ * T-U-TEZOS-02: nonce 누락 시 params.nonce 키 부재
+ * T-U-TEZOS-03: optionParam 전달 시 params.optionParam에 그대로 forward
+ * T-RESP-01 (Tezos): v1 호환 응답 형식 그대로 forward
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any, camelcase */
+import { getTezosSignedTransaction } from '../../../../../src/sign/nonEvmComplex'
+import { ensureSingleton, _resetForTesting } from '../../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+describe('getTezosSignedTransaction — happy + UnitConverter(TEZOS) (T-U-TEZOS-01)', () => {
+  test('T-U-TEZOS-01: fee="1000000" → padStart 16, method=getUnionSignedTransaction', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: { signed_tx: '0xtezosigned' },
+    })
+
+    const resp = await getTezosSignedTransaction({
+      coinType: 'TEZOS',
+      sigHash: '0xsighash',
+      fee: '1000000',
+      decimals: 6,
+      path: "m/44'/1729'/0'/0/0",
+      symbol: 'XTZ',
+    })
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getUnionSignedTransaction')
+    // fee = unitConverter('1000000', 6).bignum.toString(16).padStart(16,'0')
+    // = (1000000 * 10^6).toString(16).padStart(16,'0') = '38d7ea4c68000'.padStart(16,'0')
+    // 1000000 * 10^6 = 1e12 = 0xe8d4a51000 (10 hex chars) → padStart(16, '0') = '000000e8d4a51000'
+    expect(callArg.params?.fee).toBe('000000e8d4a51000')
+    expect(callArg.params).toMatchObject({
+      coinType: 'TEZOS',
+      decimals: 6,
+      sig_hash: '0xsighash',
+      path: "m/44'/1729'/0'/0/0",
+      symbol: 'XTZ',
+    })
+    expect(resp.header.status).toBe('success')
+  })
+
+  test('T-U-TEZOS-02: nonce 누락 시 params.nonce 키 부재', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r2', result: {} })
+
+    await getTezosSignedTransaction({
+      coinType: 'TEZOS',
+      sigHash: '0xsighash',
+      fee: '1',
+      decimals: 6,
+      path: "m/44'/1729'/0'/0/0",
+      symbol: 'XTZ',
+    })
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.params).not.toHaveProperty('nonce')
+  })
+
+  test('T-U-TEZOS-03: optionParam 전달 시 params.optionParam에 그대로 forward', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r3', result: {} })
+
+    await getTezosSignedTransaction({
+      coinType: 'TEZOS',
+      sigHash: '0xsighash',
+      fee: '1',
+      decimals: 6,
+      path: "m/44'/1729'/0'/0/0",
+      symbol: 'XTZ',
+      optionParam: 'opt-data',
+      nonce: '1',
+    })
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.params?.optionParam).toBe('opt-data')
+    expect(callArg.params?.nonce).toBe('1')
+  })
+})

--- a/tests/unit/v2/sign/nonEvm/getTrcTokenSignedTransaction.test.ts
+++ b/tests/unit/v2/sign/nonEvm/getTrcTokenSignedTransaction.test.ts
@@ -1,0 +1,49 @@
+/**
+ * getTrcTokenSignedTransaction 단위 테스트 (m08-01-04.5)
+ *
+ * T-U-TRCTKN-01: method drift 회귀 가드 — wrapper 이름은 getTrcTokenSignedTransaction이지만
+ *                dispatch하는 method는 'getTronSignedTransaction'이어야 함 (R1/D-14)
+ *                sdk popup의 dispatcher가 Tron과 같은 핸들러를 공유하므로 의도적 보존.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { getTrcTokenSignedTransaction } from '../../../../../src/sign/nonEvmComplex'
+import { ensureSingleton, _resetForTesting } from '../../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+describe('getTrcTokenSignedTransaction — method drift (T-U-TRCTKN-01)', () => {
+  test('T-U-TRCTKN-01: method=getTronSignedTransaction (자기 이름 아님 — R1/D-14)', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: { signed_tx: '0xtrctokensigned' },
+    })
+
+    const resp = await getTrcTokenSignedTransaction({
+      unsignedTx: '0xrawtrctoken',
+      fee: '1000000',
+      path: "m/44'/195'/0'/0/0",
+    })
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    const callArg = sendSpy.mock.calls[0][0]
+    // CRITICAL: method drift 회귀 가드 — getTrcTokenSignedTransaction이 아닌 'getTronSignedTransaction'
+    expect(callArg.method).toBe('getTronSignedTransaction')
+    expect(callArg.method).not.toBe('getTrcTokenSignedTransaction')
+    // unsignedTx → unsigned_tx snake_case 변환
+    expect(callArg.params).toEqual({
+      unsigned_tx: '0xrawtrctoken',
+      fee: '1000000',
+      path: "m/44'/195'/0'/0/0",
+    })
+    expect(callArg.params).not.toHaveProperty('unsignedTx')
+    expect(resp.header.status).toBe('success')
+  })
+})

--- a/tests/unit/v2/sign/nonEvm/getVechainSignedTransaction.test.ts
+++ b/tests/unit/v2/sign/nonEvm/getVechainSignedTransaction.test.ts
@@ -1,0 +1,49 @@
+/**
+ * getVechainSignedTransaction 단위 테스트 (m08-01-04.5)
+ *
+ * T-U-VECHAIN-01: happy — UnitConverter(fee, VECHAIN=18) padStart 16, method=getUnionSignedTransaction
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any, camelcase */
+import { getVechainSignedTransaction } from '../../../../../src/sign/nonEvmComplex'
+import { ensureSingleton, _resetForTesting } from '../../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+describe('getVechainSignedTransaction — UnitConverter(VECHAIN) (T-U-VECHAIN-01)', () => {
+  test('T-U-VECHAIN-01: fee="1" → unitConverter(1, 18) padStart 16', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: { signed_tx: '0xvechainsigned' },
+    })
+
+    const resp = await getVechainSignedTransaction({
+      coinType: 'VECHAIN',
+      sigHash: '0xsighash',
+      fee: '1',
+      decimals: 18,
+      path: "m/44'/818'/0'/0/0",
+      symbol: 'VET',
+    })
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getUnionSignedTransaction')
+    // 1 * 10^18 = 0xde0b6b3a7640000 (15 hex) → padStart(16) = '0de0b6b3a7640000'
+    expect(callArg.params?.fee).toBe('0de0b6b3a7640000')
+    expect(callArg.params).toMatchObject({
+      coinType: 'VECHAIN',
+      decimals: 18,
+      sig_hash: '0xsighash',
+      path: "m/44'/818'/0'/0/0",
+      symbol: 'VET',
+    })
+    expect(resp.header.status).toBe('success')
+  })
+})

--- a/tests/unit/v2/sign/nonEvm/parity-complex.test.ts
+++ b/tests/unit/v2/sign/nonEvm/parity-complex.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Bytewise parity test — v2 nonEvmComplex 9 wrapper ↔ v1 src-v1/index.js (m08-01-04.5)
+ *
+ * T-PARITY-01: 본 child 9 wrapper 각각에 대해 (method, params)가 v1 wrapper가 만든 것과 byte 단위로 같은지 단언.
+ *              v1 wrapper는 src-v1/index.js의 dcent.* 멤버 함수를 직접 require + dcent.call을 mock하여
+ *              송신 직전의 (method, params) 페이로드를 캡처하는 방식.
+ *              wrapper별 1 fixture (UnitConverter padStart 정책 회귀 가드).
+ *
+ * T-RESP-01: 모든 9 wrapper의 _call mock이 v1 fixture 응답을 반환하면 wrapper가 v1과 동일한
+ *            response shape을 return. Cosmos response_from remap, Parachain signed_tx prefix가
+ *            fixture에 정확히 적용됨 단언.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-var-requires, camelcase */
+
+import {
+  getTrcTokenSignedTransaction,
+  getTezosSignedTransaction,
+  getVechainSignedTransaction,
+  getNearSignedTransaction,
+  getHavahSignedTransaction,
+  getPolkadotSignedTransaction,
+  getCosmosSignedTransaction,
+  getAlgorandSignedTransaction,
+  getParachainSignedTransaction,
+} from '../../../../../src/sign/nonEvmComplex'
+import { ensureSingleton, _resetForTesting } from '../../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+/**
+ * v1 wrapper와 v2 wrapper의 (method, params)를 동일 입력으로 비교.
+ * v1은 src-v1/index.js의 dcent.* 함수를 직접 require + dcent.call을 spy.
+ * v2는 transport.send를 spy.
+ *
+ * 양쪽 페이로드가 byte-equivalent (JSON.stringify 비교)임을 단언.
+ */
+async function compareV1V2 (
+  wrapperName: string,
+  v2Fn: (...args: unknown[]) => Promise<unknown>,
+  v2Args: unknown[],
+  v1FnName: string,
+  v1Args: unknown[],
+): Promise<{ v1: { method: string; params: unknown }; v2: { method: string; params: unknown } }> {
+  const dcentV1 = require('../../../../../src-v1/index.js')
+  const v1CallSpy = jest.spyOn(dcentV1, 'call').mockResolvedValue({
+    header: { version: '1.0', status: 'success' },
+    body: { command: 'transaction', parameter: { signed_tx: '0xv1signed' } },
+  } as never)
+
+  await dcentV1[v1FnName](...v1Args)
+  const v1Captured = v1CallSpy.mock.calls[0][0] as { method: string; params: unknown }
+  v1CallSpy.mockRestore()
+
+  const { transport } = ensureSingleton()
+  const v2SendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+    id: 'r-' + wrapperName,
+    result: {
+      header: { version: '1.0', status: 'success' },
+      body: { command: 'transaction', parameter: { signed_tx: '0xv2signed' } },
+    },
+  })
+
+  await v2Fn(...v2Args)
+  const v2Captured = v2SendSpy.mock.calls[0][0] as { method: string; params: unknown }
+  v2SendSpy.mockRestore()
+
+  return { v1: v1Captured, v2: v2Captured }
+}
+
+describe('T-PARITY-01: v2 nonEvmComplex ↔ v1 src-v1 bytewise parity (method, params)', () => {
+  test('TrcToken — method drift "getTronSignedTransaction"', async () => {
+    const args = { unsignedTx: '0xrawtrctoken', fee: '1000000', path: "m/44'/195'/0'/0/0" }
+    const { v1, v2 } = await compareV1V2(
+      'TrcToken',
+      getTrcTokenSignedTransaction as never,
+      [args],
+      'getTrcTokenSignedTransaction',
+      [args],
+    )
+    expect(v2.method).toBe(v1.method)
+    expect(JSON.stringify(v2.params)).toBe(JSON.stringify(v1.params))
+  })
+
+  test('Tezos — UnitConverter(TEZOS=6) padStart 16', async () => {
+    const args = {
+      coinType: 'TEZOS',
+      sigHash: '0xsig',
+      fee: '1000000',
+      decimals: 6,
+      path: "m/44'/1729'/0'/0/0",
+      symbol: 'XTZ',
+    }
+    const { v1, v2 } = await compareV1V2(
+      'Tezos', getTezosSignedTransaction as never, [args], 'getTezosSignedTransaction', [args],
+    )
+    expect(v2.method).toBe(v1.method)
+    expect(JSON.stringify(v2.params)).toBe(JSON.stringify(v1.params))
+  })
+
+  test('Vechain — UnitConverter(VECHAIN=18)', async () => {
+    const args = {
+      coinType: 'VECHAIN', sigHash: '0xsig', fee: '1', decimals: 18,
+      path: "m/44'/818'/0'/0/0", symbol: 'VET',
+    }
+    const { v1, v2 } = await compareV1V2(
+      'Vechain', getVechainSignedTransaction as never, [args], 'getVechainSignedTransaction', [args],
+    )
+    expect(v2.method).toBe(v1.method)
+    expect(JSON.stringify(v2.params)).toBe(JSON.stringify(v1.params))
+  })
+
+  test('Near — magic prefix + UnitConverter(NEAR=24) padStart 32 + optionParam concat', async () => {
+    const args = {
+      coinType: 'NEAR', sigHash: '0xsig', fee: '1', decimals: 24,
+      path: "m/44'/397'/0'/0/0", symbol: 'NEAR', optionParam: 'EXTRA',
+    }
+    const { v1, v2 } = await compareV1V2(
+      'Near', getNearSignedTransaction as never, [args], 'getNearSignedTransaction', [args],
+    )
+    expect(v2.method).toBe(v1.method)
+    expect(JSON.stringify(v2.params)).toBe(JSON.stringify(v1.params))
+  })
+
+  test('Havah — UnitConverter(HAVAH=18)', async () => {
+    const args = {
+      coinType: 'HAVAH', sigHash: '0xsig', fee: '0.001', decimals: 18,
+      path: "m/44'/9999999'/0'/0/0", symbol: 'HVH',
+    }
+    const { v1, v2 } = await compareV1V2(
+      'Havah', getHavahSignedTransaction as never, [args], 'getHavahSignedTransaction', [args],
+    )
+    expect(v2.method).toBe(v1.method)
+    expect(JSON.stringify(v2.params)).toBe(JSON.stringify(v1.params))
+  })
+
+  test('Polkadot — UnitConverter(POLKADOT=10)', async () => {
+    const args = {
+      coinType: 'POLKADOT', sigHash: '0xsig', fee: '0.5', decimals: 10,
+      path: "m/44'/354'/0'/0/0", symbol: 'DOT',
+    }
+    const { v1, v2 } = await compareV1V2(
+      'Polkadot', getPolkadotSignedTransaction as never, [args], 'getPolkadotSignedTransaction', [args],
+    )
+    expect(v2.method).toBe(v1.method)
+    expect(JSON.stringify(v2.params)).toBe(JSON.stringify(v1.params))
+  })
+
+  test('Cosmos (COSMOS) — coinType remap 안 함 + coinDecimals.COSMOS', async () => {
+    const args = {
+      coinType: 'COSMOS', sigHash: '0xsig', fee: '0.001', decimals: 6,
+      path: "m/44'/118'/0'/0/0", symbol: 'ATOM',
+    }
+    const { v1, v2 } = await compareV1V2(
+      'Cosmos', getCosmosSignedTransaction as never, [args], 'getCosmosSignedTransaction', [args],
+    )
+    expect(v2.method).toBe(v1.method)
+    expect(JSON.stringify(v2.params)).toBe(JSON.stringify(v1.params))
+  })
+
+  test('Cosmos (COREUM, czone family) — coinType="czone" remap + getCzonDecimal', async () => {
+    const args = {
+      coinType: 'COREUM', sigHash: '0xsig', fee: '0.001', decimals: 6,
+      path: "m/44'/990'/0'/0/0", symbol: 'CORE',
+    }
+    const { v1, v2 } = await compareV1V2(
+      'Cosmos-coreum', getCosmosSignedTransaction as never, [args], 'getCosmosSignedTransaction', [args],
+    )
+    expect(v2.method).toBe(v1.method)
+    expect(JSON.stringify(v2.params)).toBe(JSON.stringify(v1.params))
+  })
+
+  test('Algorand — UnitConverter(ALGORAND=6)', async () => {
+    const args = {
+      coinType: 'ALGORAND', sigHash: '0xsig', fee: '0.001', decimals: 6,
+      path: "m/44'/283'/0'/0/0", symbol: 'ALGO',
+    }
+    const { v1, v2 } = await compareV1V2(
+      'Algorand', getAlgorandSignedTransaction as never, [args], 'getAlgorandSignedTransaction', [args],
+    )
+    expect(v2.method).toBe(v1.method)
+    expect(JSON.stringify(v2.params)).toBe(JSON.stringify(v1.params))
+  })
+
+  test('Parachain — UnitConverter(feeDecimals dApp arg)', async () => {
+    const args = {
+      coinType: 'PARA', sigHash: '0xsig', fee: '0.5', decimals: 10,
+      path: "m/44'/354'/0'/0/0", symbol: 'DOT',
+      RPCUrl: 'wss://rpc', feeSymbol: 'DOT', feeDecimals: 10,
+    }
+    const { v1, v2 } = await compareV1V2(
+      'Parachain', getParachainSignedTransaction as never, [args], 'getParachainSignedTransaction', [args],
+    )
+    expect(v2.method).toBe(v1.method)
+    expect(JSON.stringify(v2.params)).toBe(JSON.stringify(v1.params))
+  })
+})
+
+describe('T-RESP-01: 9 wrapper response shape — v1 fixture 응답 forward + 후처리 적용', () => {
+  test('Tezos — v1 fixture response shape 그대로 forward', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r1',
+      result: {
+        header: { version: '1.0', status: 'success', response_from: 'TEZOS' },
+        body: { command: 'transaction', parameter: { signed_tx: '0xtez' } },
+      },
+    })
+    const resp = await getTezosSignedTransaction({
+      coinType: 'TEZOS', sigHash: '0x', fee: '1', decimals: 6,
+      path: "m/44'/1729'/0'/0/0", symbol: 'XTZ',
+    })
+    expect(resp.header.status).toBe('success')
+    expect(resp.header.response_from).toBe('TEZOS')
+    expect(resp.body.parameter?.signed_tx).toBe('0xtez')
+  })
+
+  test('Cosmos — response_from="czone" → 원래 coinType("COREUM")으로 복원 (post-process 적용)', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r2',
+      result: {
+        header: { version: '1.0', status: 'success', response_from: 'czone' },
+        body: { command: 'transaction', parameter: { signed_tx: '0xcoreum' } },
+      },
+    })
+    const resp = await getCosmosSignedTransaction({
+      coinType: 'COREUM', sigHash: '0x', fee: '0.001', decimals: 6,
+      path: "m/44'/990'/0'/0/0", symbol: 'CORE',
+    })
+    expect(resp.header.response_from).toBe('COREUM')
+  })
+
+  test('Parachain — success + signed_tx에 "0x00" prefix 적용 (post-process)', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r3',
+      result: {
+        header: { version: '1.0', status: 'success' },
+        body: { command: 'transaction', parameter: { signed_tx: '0xdeadbeef' } },
+      },
+    })
+    const resp = await getParachainSignedTransaction({
+      coinType: 'PARA', sigHash: '0x', fee: '0', decimals: 10,
+      path: "m/44'/354'/0'/0/0", symbol: 'DOT',
+      RPCUrl: 'wss://rpc', feeSymbol: 'DOT', feeDecimals: 10,
+    })
+    expect(resp.body.parameter?.signed_tx).toBe('0x00deadbeef')
+  })
+})

--- a/tests/unit/v2/types/coinDecimals-drift.test.ts
+++ b/tests/unit/v2/types/coinDecimals-drift.test.ts
@@ -1,0 +1,46 @@
+/**
+ * coinDecimals drift 방어 단위 테스트 (m08-01-04.5)
+ *
+ * v1 src-v1/type/dcent-web-type.js의 `coinDecimals` (l242-251)와 v2 src/types/coinDecimals.ts가
+ * 키·값 1:1 일치하는지 자동 단언. v1 변경 시 본 테스트가 깨져 drift를 즉시 감지 (수동 동기화 정책).
+ *
+ * T-DRIFT-COIN-DECIMALS-01
+ */
+
+import { coinDecimals } from '../../../../src/types/coinDecimals'
+
+// v1 .js를 직접 require — babel-jest가 transform
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const v1Type = require('../../../../src-v1/type/dcent-web-type')
+
+describe('coinDecimals drift 방어 — v1 src-v1 ↔ v2 src/types 키·값 1:1', () => {
+  test('T-DRIFT-COIN-DECIMALS-01: v2 coinDecimals == v1 coinDecimals (키·값 1:1)', () => {
+    // false-positive guard: v1 export가 빈 객체가 아님을 사전 단언
+    expect(Object.keys(v1Type.coinDecimals).length).toBeGreaterThan(0)
+
+    // 키 set 일치
+    expect(Object.keys(coinDecimals).sort()).toEqual(Object.keys(v1Type.coinDecimals).sort())
+
+    // 각 키의 값이 정확히 일치 (`.toBe`로 strict equality — primitive number)
+    Object.keys(v1Type.coinDecimals).forEach((k) => {
+      expect((coinDecimals as Record<string, number>)[k]).toBe(
+        (v1Type.coinDecimals as Record<string, number>)[k],
+      )
+    })
+  })
+
+  test('T-DRIFT-COIN-DECIMALS-02: known constants — TEZOS=6 / VECHAIN=18 / NEAR=24 / HAVAH=18 / POLKADOT=10 / COSMOS=6 / COREUM=6 / ALGORAND=6', () => {
+    expect(coinDecimals.TEZOS).toBe(6)
+    expect(coinDecimals.VECHAIN).toBe(18)
+    expect(coinDecimals.NEAR).toBe(24)
+    expect(coinDecimals.HAVAH).toBe(18)
+    expect(coinDecimals.POLKADOT).toBe(10)
+    expect(coinDecimals.COSMOS).toBe(6)
+    expect(coinDecimals.COREUM).toBe(6)
+    expect(coinDecimals.ALGORAND).toBe(6)
+  })
+
+  test('T-DRIFT-COIN-DECIMALS-03: Object.frozen — 외부 mutation 차단', () => {
+    expect(Object.isFrozen(coinDecimals)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

v1 sign wrapper 중 fee `UnitConverter` 변환 + `getUnionSignedTransaction` 통합 method + coinType remap + response 후처리가 있는 **9개 복잡 wrapper**를 v2 facade에 1:1 호환 port. 본 child 머지 시점에 v1 sign wrapper 전체(simple 8 + complex 9 = **17개**)가 v2 facade에서 무수정 호환된다.

- Objective: `objectives/m08-01-04.5-v1-non-evm-complex.md`
- Jira: [DC-2004](https://iotrust.atlassian.net/browse/DC-2004) (Subtask of Epic [DC-1998](https://iotrust.atlassian.net/browse/DC-1998))
- Epic: m08-01 — connector v2 dApp facade

## 9개 복잡 wrapper 인벤토리

| Wrapper | bridge method | 핵심 변환 |
|---|---|---|
| `getTrcTokenSignedTransaction` | `'getTronSignedTransaction'` (method drift, R1/D-14) | destructure만, 메서드 이름이 wrapper 이름과 다름 |
| `getTezosSignedTransaction` | `'getUnionSignedTransaction'` | `unitConverter(fee, coinDecimals.TEZOS).bignum.toString(16).padStart(16, '0')` |
| `getVechainSignedTransaction` | `'getUnionSignedTransaction'` | `unitConverter(fee, coinDecimals.VECHAIN)` |
| `getNearSignedTransaction` | `'getUnionSignedTransaction'` | magic prefix `'000000ef'+'00000010'` + `unitConverter(fee, NEAR).padStart(32,'0')`, fee=`'00'`, optionParam concat (`+=`) |
| `getHavahSignedTransaction` | `'getUnionSignedTransaction'` | `unitConverter(fee, coinDecimals.HAVAH)` |
| `getPolkadotSignedTransaction` | `'getUnionSignedTransaction'` | `unitConverter(fee, coinDecimals.POLKADOT)` |
| `getCosmosSignedTransaction` | `'getUnionSignedTransaction'` | `getCzonDecimal(coinType)` lookup + `isCzoneCoinType ? 'czone' : coinType` remap + 응답 `response_from === 'czone'` 시 원래 coinType 복원 |
| `getAlgorandSignedTransaction` | `'getUnionSignedTransaction'` | `unitConverter(fee, coinDecimals.ALGORAND)` |
| `getParachainSignedTransaction` | `'getUnionSignedTransaction'` | `unitConverter(fee, **dApp feeDecimals**)` + success 응답 시 `signed_tx '0x00' prefix` (R2) |

## 신규 helper port

- `src/types/coinDecimals.ts` — v1 `dcent-web-type.js#l242-251`의 `coinDecimals` enum 1:1 port (TEZOS=6, VECHAIN=18, NEAR=24, HAVAH=18, POLKADOT=10, COSMOS=6, COREUM=6, ALGORAND=6) + `Object.freeze` + `as const`. m08-01-01에서 deferred된 항목.
- `src/sign/getCzonDecimal.ts` — v1 `src-v1/index.js#l690-697`의 Cosmos 전용 czone family decimal lookup helper. Cosmos wrapper만 사용하므로 sign/ scope.
- **`isCzoneCoinType`은 m08-01-02.5의 `src/sign/coinTypeValidators.ts`에서 import** (중복 신설 금지, F-04)

## 주요 결정사항

- **R1/D-14 (TrcToken method drift)**: TrcToken은 v1 1:1 호환을 위해 `'getTronSignedTransaction'` method를 그대로 dispatch — sdk popup의 dispatcher가 Tron과 같은 핸들러를 공유하기 때문. 변경하려면 cross-repo (dcent-web-sdk dispatcher 추가) 필요 → 본 chain 범위 초과 (`cross-repo-interface-edit` 룰).
- **R2 (Parachain signed_tx prefix)**: signed_tx '0x00' prefix는 Parachain wrapper의 동작 (XRP 아님). v1 line-by-line 인벤토리 (l1572-1574)로 확정. failure 응답에는 prefix 추가 없음 (회귀 가드 T-U-PARA-04).
- **F-04 (Helper port 결정)**: `getCzonDecimal` / `coinDecimals` 본 child에서 신설 port (m08-01-01 deferred). `isCzoneCoinType`은 m08-01-02.5에서 import (중복 신설 안 함).
- **F-05 (Inline destructured object types)**: 9개 wrapper 시그니처 모두 inline destructured object type. 별도 `TxParams` interface 파일 미신설. v1 `dcent.getXSignedTransaction = async function ({ ... })` ergonomics 보존.

## Rationale

- v1 본문 line-by-line 인벤토리 결과 8개 wrapper가 `'getUnionSignedTransaction'` 단일 method를 공유하고 fee 인코딩 정책만 다름. 이를 단일 파일(`nonEvmComplex.ts`)로 묶어 v1 1:1 보존 + dApp 호출 표면 유지.
- TrcToken method drift는 의도적 보존이 안전한 선택 — sdk dispatcher 변경 없이 dApp 호환성 유지. cross-repo 변경은 별도 objective로 분리해 리스크 격리.
- Cosmos `coinType` remap을 `isCzoneCoinType` (m08-01-02.5에서 이미 단일 출처)에서 import하여 중복 신설 회피 → drift 위험 0.

## Tested

- ✅ `npm run unit-v2`: **561 tests pass** (53 suites). 신규 추가:
  - 9개 wrapper별 단위 테스트 (T-U-TRCTKN-01 / T-U-TEZOS-01..03 / T-U-VECHAIN-01 / T-U-HAVAH-01 / T-U-DOT-01 / T-U-COSMOS-01..05 / T-U-ALGO-01 / T-U-NEAR-01..02 / T-U-PARA-01..04)
  - Bytewise parity (T-PARITY-01): v1 `src-v1/index.js`의 wrapper와 (method, params) `JSON.stringify` 일치 — 9 wrapper × 1 fixture
  - Response shape (T-RESP-01): Cosmos `response_from='czone'` → 원래 coinType 복원 + Parachain `signed_tx '0x00' prefix` 후처리 적용 단언
  - Drift defense (T-DRIFT-COIN-DECIMALS-01..03 + T-DRIFT-CZON-DECIMAL-01..03): v1 `src-v1` ↔ v2 .ts 키·값 1:1 + frozen guard
- ✅ `npx eslint --ext .ts src`: PASS
- ✅ `npm run build`: webpack PASS (3 size warnings only — 기존)
- ✅ `npm run tsc`: PASS (`tsc --noEmit`)
- ✅ Default export 검증 (bundle 로드): 9 wrapper + `coinDecimals` enum 노출 확인 (`d.coinDecimals.TEZOS === 6`)
- ✅ `npm pack --dry-run`: `dist/v2/sign/nonEvmComplex.d.ts`, `dist/v2/sign/getCzonDecimal.d.ts`, `dist/v2/types/coinDecimals.d.ts` 모두 포함

## Constraints

- PR diff: **1590 LOC** total (src 592 LOC + tests 998 LOC). Source 영역이 가이드 (~550-650 LOC) 범위 내.
- `package.json` `version` 필드 미수정 (`no-version-bump` 룰)
- 머지는 사람이 수행 (`objective-no-auto-merge` 룰)
- PR base = `epic/DC-1998_m08-01-connector-v2-dapp-facade` (epic child)
- CI는 epic-base PR에서 자동 트리거되지 않음 (분기상 정상)