### PR TITLE
[DC-2006] m08-01-05: playground rewrite + main 전환 + 마이그레이션 가이드

### DIFF
--- a/MIGRATION-v1-to-v2.md
+++ b/MIGRATION-v1-to-v2.md
@@ -1,0 +1,169 @@
+# dcent-web-connector v0.16.0 → v2 Facade 마이그레이션 가이드
+
+`dcent-web-connector` v2 facade는 dApp이 v0.16.0에서 사용하던 모든 API를 **무수정으로 호환**하면서, 새로운 통합 sign API와 더 명확한 타입 시스템을 제공한다.
+
+본 가이드는 v0.16.0 사용자가 v2로 옮길 때 알아야 할 사항을 정리한다.
+
+---
+
+## 변경 없음 (Backward Compatible)
+
+기존 dApp 코드는 **무수정으로 동작**한다.
+
+- 진입점은 동일: `import dcent from 'dcent-web-connector'` 또는 `const dcent = require('dcent-web-connector')`
+- v1 sign wrapper 함수 시그니처 1:1 호환:
+  - EVM: `getEthereumSignedTransaction`, `getEthereumSignedMessage`, `getTokenSignedTransaction`, `getKlaytnSignedTransaction`
+  - Bitcoin / XRP / Hedera / Stellar / Tron: `getBitcoinSignedTransaction`, `getXrpSignedTransaction`, `getHederaSignedTransaction`, `getHederaSignedMessage`, `getStellarSignedTransaction`, `getTronSignedTransaction`
+  - 기타 generic: `getSignedMessage`, `getSignedData`
+  - Complex chains: `getTrcTokenSignedTransaction`, `getTezosSignedTransaction`, `getVechainSignedTransaction`, `getNearSignedTransaction`, `getHavahSignedTransaction`, `getPolkadotSignedTransaction`, `getCosmosSignedTransaction`, `getAlgorandSignedTransaction`, `getParachainSignedTransaction`
+- v1 read-only / configure / Bitcoin tx-builder 모두 동일 시그니처:
+  - `info`, `getDeviceInfo`, `getAccountInfo`, `getAddress`, `getXPUB`, `setLabel`, `syncAccount`, `selectAddress`
+  - `getBitcoinTransactionObject`, `addBitcoinTransactionInput`, `addBitcoinTransactionOutput`
+  - `isAvaliableCoinType`, `isCzoneCoinType`, `isParachainCoinType`, `isBitcoinTxCoinType`, `isTokenType`, `getCzonePrifix`, `isAvaliableLabel`, `isAvaliableCoinGroup`, `isAvailableSyncAccountCoinName`, `getCzonDecimal`
+- v1 lifecycle 동일: `setTimeOutMs`, `setConnectionListener`, `popupWindowClose`
+- v1 enum 동일: `coinType`, `coinGroup`, `coinName`, `bitcoinTxType`, `klaytnTxType`, `xrpTxType`, `state`, `coinDecimals`
+- v1 utility 동일: `unitConverter`
+
+```javascript
+// v0.16.0 코드 — v2에서 그대로 동작
+const dcent = require('dcent-web-connector')
+
+dcent.setTimeOutMs(30000)
+const info = await dcent.info()
+const tx = await dcent.getEthereumSignedTransaction(
+  dcent.coinType.ETHEREUM,
+  '0x0', '0x77359400', '0x5208',
+  '0x0000000000000000000000000000000000000000', '0x0', '0x',
+  "m/44'/60'/0'/0/0", 1
+)
+dcent.popupWindowClose()
+```
+
+응답 형식, 에러 형식, 호출 패턴 모두 v0.16.0과 동일하다.
+
+---
+
+## 새 통합 sign API
+
+v2는 모든 chain에 사용할 수 있는 **단일 통합 sign API**를 추가했다. 기존 wrapper와 병행 사용 가능하다.
+
+```javascript
+const dcent = require('dcent-web-connector')
+
+// CAIP-19 chain 식별자 사용 (eip155:1 = Ethereum mainnet)
+const signed = await dcent.sign({
+  chain: 'eip155:1',
+  payload: {
+    chainId: 'eip155:1',
+    keyPath: "m/44'/60'/0'/0/0",
+    transaction: { /* tx fields */ }
+  }
+})
+
+// CAIP-19 미정의 네트워크는 v1 method 문자열 fallback (chainToMethod 매핑)
+const signedSui = await dcent.sign({
+  chain: 'signTransaction',  // bridge sdk가 인식하는 v1 method 이름
+  payload: { coinType: 'SUI', /* ... */ }
+})
+```
+
+내부적으로 `dcent.sign({chain, payload})`은:
+1. `chain` 인자를 sanitize (whitelist + prototype key 제거 + length/type 검증)
+2. CAIP-19 prefix 매칭 (`eip155:` → `signTransaction`, `bip122:` → `signTransaction`, etc.) 또는 v1 method 문자열로 fallback
+3. popup으로 송신 후 응답을 v1 호환 envelope으로 반환
+
+---
+
+## 신규 네트워크 추가 시나리오
+
+새 네트워크(예: Sui)를 추가하려는 dApp은 더 이상 connector SDK에 wrapper를 추가할 필요가 없다.
+
+1. `dcent-bridge-service`(popup UI 측)에 새 method 핸들러 추가 — connector 외부 작업
+2. dApp이 `dcent.sign({ chain: 'sip-1:...', payload })` 호출 — connector는 그대로 popup으로 pass-through
+
+기존 v1 wrapper 패턴(`getSuiSignedTransaction`)을 새로 추가할 필요가 없다. 통합 sign API가 모든 chain을 커버한다.
+
+---
+
+## breaking change 없음
+
+v0.16.0 → v2 minor bump. dApp 코드는 무수정으로 동작.
+
+| 변경 영역 | v0.16.0 | v2 |
+|---|---|---|
+| 진입점 | `require('dcent-web-connector')` | 동일 |
+| Default export shape | dcent object (50+ methods) | 동일 + 신규 `sign` 메서드 추가 |
+| Named exports | 미제공 (default object 안에서만) | 추가 — `import { coinType, getEthereumSignedTransaction } from ...` 가능 |
+| TypeScript types | 미제공 | 추가 — `dist/v2/index.d.ts` |
+| Sign wrapper 시그니처 | 21개 함수 동일 | 100% 호환 |
+| Lifecycle / read-only / enum | 동일 | 동일 |
+| postMessage popup URL | `https://bridge.dcentwallet.com/v2` | 동일 |
+| 에러 응답 형식 | v1 envelope | 동일 (v2는 ProviderError를 internal에서 사용 + dApp 시야에는 v1 형식으로 매핑) |
+
+---
+
+## 내부 변화 (참고 — dApp 영향 없음)
+
+v2 facade는 다음 layer로 구성:
+
+- `src/index.ts` — 모든 named exports + default export object
+- `src/lifecycle.ts` — setTimeOutMs / setConnectionListener / popupWindowClose
+- `src/types/` — 8개 enum + 23개 type
+- `src/sign/` — 통합 `sign` + `_call` helper + 21개 v1 wrapper + 11개 read-only/configure + 9개 v1 validator + ProviderError 매퍼
+- `src/transport/PopupTransport.ts` — popup window 관리 + postMessage 통신 (m02-01 SHIPPED)
+- `src/queue/RequestQueue.ts` — SerialRequestQueue (단일 inflight 보장, m02-02 SHIPPED)
+- `src/error/{ErrorCode,ProviderError}.ts` — JSON-RPC 2.0 호환 에러 (m07-02 SHIPPED)
+- `src/singleton.ts` — module-level lazy singleton (PopupTransport + SerialRequestQueue 자동 관리, dApp이 직접 인스턴스화할 필요 없음)
+
+dApp은 이 내부 구조를 알 필요가 없다. v1 호환 표면(default export object)만 사용하면 된다.
+
+---
+
+## error 형식
+
+v1 호환 envelope 그대로 유지:
+
+```javascript
+try {
+  await dcent.getEthereumSignedTransaction(...)
+} catch (err) {
+  // err: { header: { status: 'failure' }, body: { error: { code, message } } }
+}
+```
+
+`code` 값은 v1과 동일:
+
+| Code | 의미 |
+|---|---|
+| `'pop-up_closed'` | 사용자가 popup을 닫음 |
+| `'time_out'` | 디바이스 응답 타임아웃 |
+| `'user_cancel'` | 사용자가 디바이스에서 거절 |
+| `'param_error'` | 입력 파라미터 검증 실패 |
+| `'connection_failed'` | popup ↔ device 통신 실패 |
+
+v2 내부 에러(ProviderError, JSON-RPC 2.0 형식)는 dApp 경계에서 v1 envelope으로 자동 매핑되므로 기존 `try/catch` 코드는 무수정.
+
+---
+
+## 살아있는 reference — playground
+
+리포 root의 `playground.js`(브라우저에서 `index-v2.html`로 실행)가 v1 wrapper + 통합 sign API 양쪽 사용 패턴의 살아있는 예시다. m08-01-05에서 facade default export 호출로 전환되었다.
+
+```bash
+# 빌드
+npm run build
+
+# 브라우저에서 열기
+open index-v2.html
+# 또는 dev server
+npm run dev  # http://localhost:9090/index-v2.html
+```
+
+playground 코드는 v0.16.0 dApp이 작성하는 패턴과 동일하다 — `require('dcent-web-connector')` 대신 `<script>` 태그로 로드 후 `window.dcent.<method>()`를 호출하는 차이만 있다.
+
+---
+
+## 참고
+
+- m08-01 chain의 5개 PR(facade 뼈대, 통합 sign, read-only, EVM/non-EVM wrappers, playground rewrite)에 v2 구현 상세
+- v1 코드는 `src-v1/`에 read-only로 보존 — npm published 패키지의 진입점은 v2이지만 v1 소스 파일은 디버깅 reference로 남아있음

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This is package for connecting WEB and D'CENT biometric wallet.<br>
 User interface is presented in a popup window served from `https://bridge.dcentwallet.com/v2`.
 
 - [Integration](doc/index.md)
+- v0.16.0 → v2 마이그레이션 가이드: [MIGRATION-v1-to-v2.md](./MIGRATION-v1-to-v2.md)
 
 ## Installation
 
@@ -87,4 +88,4 @@ open index-v2.html
 - **Request Log** — append-only log with JSONL export (`Copy all`)
 - **Form (B1 pattern)** — per-method input form with boundary validation
 
-> Note: `index-v2.html` and `playground.js` are excluded from the npm tarball (`.npmignore`).
+> Note: `index-v2.html` and `playground.js` are included in the npm tarball as a living reference for v0.16.0 → v2 migration. See [MIGRATION-v1-to-v2.md](./MIGRATION-v1-to-v2.md) for details.

--- a/index-v2.html
+++ b/index-v2.html
@@ -280,8 +280,12 @@
 
 </div>
 
-<!-- v2 dist bundle (libraryTarget: 'this' → window globals) -->
+<!-- v2 dist bundle (m08-01-05 D-02 A: window.dcent = entire module exports) -->
 <script src="/dist/v2/dcent-web-connector.min.js"></script>
+<!-- m08-01-05 (D-04 B align): default export object 별칭 — window.dcent = facade default
+     이로써 playground이 dcent.getDeviceInfo() / dcent.sign(...) / dcent.getEthereumSignedTransaction(...)을
+     v0.16.0 dApp이 require()로 받는 것과 동일한 shape으로 호출 -->
+<script>window.dcent = (window.dcent && window.dcent.default) || window.dcent;</script>
 <script src="/playground.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -2,8 +2,18 @@
   "name": "dcent-web-connector",
   "version": "0.16.0",
   "description": "D'CENT Web SDK Connector",
-  "main": "src-v1/index.js",
-  "module": "src-v1/index.js",
+  "main": "dist/v2/dcent-web-connector.min.js",
+  "module": "dist/v2/dcent-web-connector.min.js",
+  "types": "dist/v2/index.d.ts",
+  "files": [
+    "dist/v2/",
+    "src/",
+    "playground.js",
+    "index-v2.html",
+    "MIGRATION-v1-to-v2.md",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "dev": "yarn build-dev && webpack-dev-server --mode development",
     "build-dev": "webpack --mode development",

--- a/playground.js
+++ b/playground.js
@@ -2,8 +2,12 @@
  * playground.js — D'CENT Connector v2 Playground
  *
  * 외부 라이브러리 0, 표준 DOM API만 사용.
- * dist/v2/dcent-web-connector.min.js 로드 후 window 전역:
- *   PopupTransport, SerialRequestQueue, ErrorCode, ProviderError
+ * dist/v2/dcent-web-connector.min.js 로드 후 index-v2.html에서 alias:
+ *   <script>window.dcent = (window.dcent && window.dcent.default) || window.dcent;</script>
+ * 결과: window.dcent === facade default export object (v0.16.0 dApp이 require()로 받는 것과 동일 shape)
+ *
+ * m08-01-05 (D-04 B finality): playground이 PopupTransport / SerialRequestQueue / _genId 직접 사용 패턴을
+ * 모두 제거하고 facade의 `dcent.<method>()` 호출로 단순화. transport/queue는 facade singleton이 내부 관리.
  *
  * 룰 준수:
  *   - error-handling-consistency: 모든 실패 경로는 appendLog({ error: ... }) 통일
@@ -236,9 +240,9 @@
   }
 
   // ── 전역 상태 ──
+  // m08-01-05: transport / queue는 facade singleton이 내부 관리 — playground은 connected boolean만 추적
   var state = {
-    transport: null, // PopupTransport 인스턴스 또는 null
-    queue: null, // SerialRequestQueue
+    connected: false, // dcent facade 사용 여부 (true이면 popup이 활성/대기 상태)
     device: null, // 마지막 getDeviceInfo 응답
     selectedMethodId: null, // 현재 선택된 트리 아이템 id
     selectedMethodDef: null, // 선택된 메서드 정의 객체
@@ -247,6 +251,9 @@
     sdkVersion: null, // dist에서 추출한 packageVersion (있으면)
     evmChainsLoaded: false, // chains.json 로드 완료 여부 (EVM + 비-EVM 통합)
     nonEvmChainsLoaded: false, // 비-EVM chains/presets 로드 완료 여부 (m06-01-03)
+    // 테스트용 inject — simulateConnect가 mock 함수 객체를 주입할 때 사용
+    // null이면 진짜 window.dcent 사용
+    _testDcent: null,
   }
 
   // ── DOM refs ──
@@ -265,10 +272,13 @@
   var btnClear = $('btn-clear')
   var btnCopy = $('btn-copy')
 
-  // ── SDK globals (window에 노출됨 by dist libraryTarget: 'this') ──
-  var PopupTransport = window.PopupTransport
-  var SerialRequestQueue = window.SerialRequestQueue
-  // ProviderError는 window.ProviderError로 직접 접근 (테스트 API에서 참조)
+  // ── SDK facade reference (m08-01-05) ──
+  // index-v2.html이 window.dcent를 default export object로 alias함:
+  //   <script>window.dcent = (window.dcent && window.dcent.default) || window.dcent;</script>
+  // _getDcent()는 매 호출 시점에 facade를 lookup → simulateConnect의 mock inject도 지원
+  function _getDcent () {
+    return state._testDcent || window.dcent
+  }
 
   // ── Build Tree DOM ──
   function buildTree () {
@@ -793,33 +803,43 @@
     onDisconnect()
   })
 
+  // m08-01-05: state listener는 connect/disconnect 사이클과 독립적으로 1회 등록
+  // facade가 listener를 cached하므로 reset 후에도 자동 복구 (singleton.ts 동작)
+  var _stateListenerRegistered = false
+  function _ensureStateListener () {
+    if (_stateListenerRegistered) return
+    var dcent = _getDcent()
+    if (!dcent || typeof dcent.setConnectionListener !== 'function') return
+    dcent.setConnectionListener(function (transportState) {
+      if (transportState === 'disconnected' && state.connected) {
+        onTransportDisconnected('Popup was closed')
+      }
+    })
+    _stateListenerRegistered = true
+  }
+
   function onConnect () {
     btnConnect.disabled = true
     connDot.className = ''
     deviceInfoEl.textContent = 'Connecting...'
 
-    try {
-      state.transport = new PopupTransport({ popUpUrl: 'https://bridge.dcentwallet.com/v2' })
-      state.queue = new SerialRequestQueue(state.transport)
-    } catch (e) {
-      updateIndicator({ connected: false, error: true, msg: 'Init failed: ' + e.message })
+    var dcent = _getDcent()
+    if (!dcent || typeof dcent.getDeviceInfo !== 'function') {
+      updateIndicator({ connected: false, error: true, msg: 'Init failed: window.dcent not loaded' })
       btnConnect.disabled = false
       return
     }
 
-    // Listen for transport state changes (popup close, etc.)
-    state.transport.on('state', function (transportState) {
-      if (transportState === 'disconnected') {
-        onTransportDisconnected('Popup was closed')
-      }
-    })
+    // m08-01-05: facade가 transport/queue를 lazy 생성 — listener는 1회만 등록
+    _ensureStateListener()
 
     var startMs = Date.now()
-    state.queue.enqueue(function () {
-      return state.transport.send({ id: _genId(), method: 'getDeviceInfo' })
-    }).then(function (resp) {
-      var device = resp && resp.result ? resp.result : {}
+    // m08-01-05: dcent.getDeviceInfo()는 v1 호환 응답 ({header, body}) 반환
+    dcent.getDeviceInfo().then(function (resp) {
+      // v1 응답 형식: { header: {status: 'success'}, body: { parameter: {...device fields...} } }
+      var device = (resp && resp.body && resp.body.parameter) || (resp && resp.result) || {}
       state.device = device
+      state.connected = true
       var latencyMs = Date.now() - startMs
       updateIndicator({ connected: true, model: device.model, fw: device.firmware })
       btnConnect.style.display = 'none'
@@ -846,11 +866,12 @@
   }
 
   function onDisconnect () {
-    if (state.transport) {
-      state.transport.close().catch(function () {})
+    // m08-01-05: facade의 popupWindowClose가 transport singleton을 close
+    var dcent = _getDcent()
+    if (dcent && typeof dcent.popupWindowClose === 'function') {
+      try { dcent.popupWindowClose() } catch (e) { /* defensive noop */ }
     }
-    state.transport = null
-    state.queue = null
+    state.connected = false
     state.device = null
     updateIndicator({ connected: false })
     btnConnect.style.display = ''
@@ -861,8 +882,7 @@
   }
 
   function onTransportDisconnected (reason) {
-    state.transport = null
-    state.queue = null
+    state.connected = false
     updateIndicator({ connected: false, error: true, msg: reason || 'Disconnected' })
     btnConnect.style.display = ''
     btnConnect.disabled = false
@@ -894,7 +914,7 @@
 
   // ── Send ──
   btnSend.addEventListener('click', function () {
-    if (!state.transport) return
+    if (!state.connected) return
     var methodId = state.selectedMethodId
     if (!methodId) return
 
@@ -915,7 +935,7 @@
 
   function updateSendBtn () {
     // disabled when: not connected OR no method selected
-    var canSend = !!state.transport && !!state.selectedMethodId
+    var canSend = !!state.connected && !!state.selectedMethodId
     btnSend.disabled = !canSend
     if (!canSend) {
       btnSend.setAttribute('aria-disabled', 'true')
@@ -926,10 +946,10 @@
 
   function sendGetDeviceInfo () {
     var startMs = Date.now()
-    state.queue.enqueue(function () {
-      return state.transport.send({ id: _genId(), method: 'getDeviceInfo' })
-    }).then(function (resp) {
-      var result = resp && resp.result ? resp.result : resp
+    var dcent = _getDcent()
+    // m08-01-05: facade의 v1 호환 API — 응답은 v1 envelope ({header, body.parameter})
+    dcent.getDeviceInfo().then(function (resp) {
+      var result = (resp && resp.body && resp.body.parameter) || (resp && resp.result) || resp
       state.device = result
       appendLog({
         method: 'getDeviceInfo',
@@ -989,10 +1009,12 @@
     var params = { chainId: chainId, keyPath: keyPath, message: message, meta: metaObj }
     var startMs = Date.now()
 
-    state.queue.enqueue(function () {
-      return state.transport.send({ id: _genId(), method: 'signMessage', params: params })
-    }).then(function (resp) {
-      var result = resp && resp.result ? resp.result : resp
+    // m08-01-05: 통합 sign API 사용 — chain 인자로 raw method 전달 (v1 fallback path)
+    // CAIP-19 (예: 'eip155:1') 또는 v1 method 문자열 ('signMessage') 모두 지원.
+    // 본 dispatcher는 v1 호환 'signMessage' method를 그대로 사용.
+    var dcent = _getDcent()
+    dcent.sign({ chain: 'signMessage', payload: params }).then(function (resp) {
+      var result = (resp && resp.body && resp.body.parameter) || (resp && resp.result) || resp
       appendLog({
         method: 'signMessage',
         chainId: chainId,
@@ -1051,10 +1073,16 @@
     var params = { chainId: chainId, keyPath: keyPath, transaction: txObj }
     var startMs = Date.now()
 
-    state.queue.enqueue(function () {
-      return state.transport.send({ id: _genId(), method: 'signTransaction', params: params })
-    }).then(function (resp) {
-      var result = resp && resp.result ? resp.result : resp
+    // m08-01-05: EVM signTx는 통합 sign API 사용 — chain은 CAIP-19 형식 (eip155:N)
+    // chainId가 이미 'eip155:N' 형식이면 그대로 사용, 숫자만이면 prefix 추가
+    // 본 dispatcher는 통합 API를 시연. dApp이 v1 wrapper를 더 좋아하면
+    //   dcent.getEthereumSignedTransaction(coinType, nonce, gasPrice, ...) 도 사용 가능.
+    var dcent = _getDcent()
+    var caipChain = (chainId && chainId.indexOf(':') !== -1)
+      ? chainId
+      : ('eip155:' + (chainId || 1))
+    dcent.sign({ chain: caipChain, payload: params }).then(function (resp) {
+      var result = (resp && resp.body && resp.body.parameter) || (resp && resp.result) || resp
       appendLog({
         method: 'signTransaction',
         chainId: chainId,
@@ -1114,10 +1142,12 @@
     var params = { chainId: chainId, keyPath: keyPath, transaction: txObj }
     var startMs = Date.now()
 
-    state.queue.enqueue(function () {
-      return state.transport.send({ id: _genId(), method: 'signTransaction', params: params })
-    }).then(function (resp) {
-      var result = resp && resp.result ? resp.result : resp
+    // m08-01-05: 비-EVM signTx도 통합 sign API — chainId가 이미 CAIP-19 형식 (bip122:..., cosmos:...)
+    // chainId가 비어있으면 v1 method 'signTransaction' fallback (chainToMethod이 default 처리)
+    var dcent = _getDcent()
+    var caipChain = chainId || 'signTransaction'
+    dcent.sign({ chain: caipChain, payload: params }).then(function (resp) {
+      var result = (resp && resp.body && resp.body.parameter) || (resp && resp.result) || resp
       appendLog({
         method: 'signTransaction',
         chainId: chainId,
@@ -1258,14 +1288,18 @@
   })
 
   // ── Utils ──
-  var _idCounter = 0
-  function _genId () {
-    _idCounter += 1
-    return 'pg-' + Date.now() + '-' + _idCounter
-  }
+  // m08-01-05: _genId 제거 — facade의 _call이 내부 ID 생성 (singleton.ts/idGen.ts)
 
   function normalizeError (err) {
     if (!err) return { code: -1, message: 'Unknown error' }
+    // m08-01-05: facade는 v1 호환 응답으로 reject하거나 ProviderError로 throw
+    // v1 형식: { header: { status: 'failure' }, body: { error: { code, message } } }
+    if (err && err.body && err.body.error) {
+      return {
+        code: err.body.error.code !== undefined ? err.body.error.code : -1,
+        message: err.body.error.message || String(err),
+      }
+    }
     return {
       code: err.code !== undefined ? err.code : -1,
       message: err.message || String(err),
@@ -1317,27 +1351,59 @@
       return count
     },
     isSendDisabled: function () { return btnSend.disabled },
-    simulateConnect: function (mockTransport, mockQueue, mockDevice) {
-      state.transport = mockTransport
-      state.queue = mockQueue
+    // m08-01-05: simulateConnect는 mock dcent facade를 inject + 연결 상태로 진입
+    // mockDcentOrTransport: { getDeviceInfo, sign, popupWindowClose, setConnectionListener, ... }
+    //   기존 호출 호환: 첫 인자가 transport-like(`.send`/`.on` 가진 객체)이면 wrapper 생성
+    simulateConnect: function (mockDcentOrTransport, mockQueueOrUnused, mockDevice) {
+      var dcentMock
+      if (mockDcentOrTransport && (typeof mockDcentOrTransport.getDeviceInfo === 'function' ||
+                                    typeof mockDcentOrTransport.sign === 'function')) {
+        // 새 패턴: facade-shaped mock
+        dcentMock = mockDcentOrTransport
+      } else if (mockDcentOrTransport && typeof mockDcentOrTransport.send === 'function') {
+        // 구 패턴 호환: transport mock → facade-shaped wrapper로 변환
+        var transport = mockDcentOrTransport
+        dcentMock = {
+          getDeviceInfo: function () {
+            return transport.send({ id: 'mock-' + Date.now(), method: 'getDeviceInfo' })
+              .then(function (resp) {
+                // resp는 transport raw envelope — v1 호환 envelope으로 wrap
+                if (resp && resp.body) return resp
+                return { header: { status: 'success' }, body: { parameter: (resp && resp.result) || resp } }
+              })
+          },
+          sign: function (input) {
+            return transport.send({ id: 'mock-' + Date.now(), method: input.chain || 'signTransaction', params: input.payload })
+              .then(function (resp) {
+                if (resp && resp.body) return resp
+                return { header: { status: 'success' }, body: { parameter: (resp && resp.result) || resp } }
+              })
+          },
+          popupWindowClose: function () {
+            if (typeof transport.close === 'function') transport.close().catch(function () {})
+          },
+          setConnectionListener: function (l) {
+            if (typeof transport.on === 'function') transport.on('state', l)
+          },
+        }
+      } else {
+        dcentMock = mockDcentOrTransport
+      }
+      state._testDcent = dcentMock
+      state.connected = true
       state.device = mockDevice || null
+      _stateListenerRegistered = false
+      _ensureStateListener()
       updateIndicator({ connected: true, model: mockDevice && mockDevice.model, fw: mockDevice && mockDevice.firmware })
       btnConnect.style.display = 'none'
       btnDisconnect.style.display = ''
       updateSendBtn()
-      // transport state listener 등록 (onConnect와 동일하게)
-      if (mockTransport && typeof mockTransport.on === 'function') {
-        mockTransport.on('state', function (transportState) {
-          if (transportState === 'disconnected') {
-            onTransportDisconnected('Popup was closed')
-          }
-        })
-      }
     },
     simulateDisconnect: function () {
-      state.transport = null
-      state.queue = null
+      state._testDcent = null
+      state.connected = false
       state.device = null
+      _stateListenerRegistered = false
       updateIndicator({ connected: false })
       btnConnect.style.display = ''
       btnConnect.disabled = false

--- a/tests/unit/2_v2_e2e/harness.html
+++ b/tests/unit/2_v2_e2e/harness.html
@@ -8,9 +8,13 @@
   <h1>v2 e2e harness</h1>
   <script src="/dist/v2/dcent-web-connector.min.js"></script>
   <script>
-    // dist/v2 번들의 libraryTarget: 'this' → window에 PopupTransport / ErrorCode / ProviderError / SerialRequestQueue 노출
-    var PopupTransport = window.PopupTransport
-    var ErrorCode = window.ErrorCode
+    // m08-01-05 (D-02 A): v2 번들이 window.dcent에 entire module exports를 노출
+    // 이전: libraryTarget: 'this' → window.PopupTransport / window.ErrorCode 직접 노출
+    // 변경: window.dcent.PopupTransport / window.dcent.ErrorCode (named exports는 dcent 객체 안)
+    // index-v2.html은 default export object를 window.dcent에 alias하지만 harness는 named exports가 필요
+    // 따라서 harness는 window.dcent의 raw module shape를 그대로 사용
+    var PopupTransport = window.dcent.PopupTransport
+    var ErrorCode = window.dcent.ErrorCode
 
     // T-E-03 handshake 카운트 spy — connector 측 PopupTransport.sendHandshake (private but runtime accessible)를 wrap
     // popup 측 postMessage는 cross-origin이라 replace 불가하므로 connector 측에서 카운트

--- a/tests/unit/2_v2_e2e/playground.signtx-evm.spec.ts
+++ b/tests/unit/2_v2_e2e/playground.signtx-evm.spec.ts
@@ -98,25 +98,20 @@ describe('[v2 e2e] playground signTx EVM', () => {
     )
     expect(evmNodeCount).toBe(SAMPLE_CHAINS.length)
 
-    // Step 3: Mock transport 주입 + connect
+    // m08-01-05: Step 3: Mock dcent facade 주입 + simulateConnect
     await page.evaluate(() => {
       const api = (window as any)._playgroundTestAPI
       ;(window as any)._capturedRequests = []
-      const mockTransport = {
-        send: (payload: any) => {
-          ;(window as any)._capturedRequests.push(payload)
-          return Promise.resolve({ id: payload.id, result: { signedTx: '0xdeadbeef' } })
+      const mockDcent = {
+        sign: (input: any) => {
+          ;(window as any)._capturedRequests.push(input)
+          return Promise.resolve({ header: { status: 'success' }, body: { parameter: { signedTx: '0xdeadbeef' } } })
         },
-        on: (_: string, _fn: any) => {},
-        off: () => {},
-        close: () => Promise.resolve(),
+        getDeviceInfo: () => Promise.resolve({ header: { status: 'success' }, body: { parameter: {} } }),
+        popupWindowClose: () => {},
+        setConnectionListener: () => {},
       }
-      const mockQueue = {
-        enqueue: (task: any) => task(),
-        size: () => 0,
-        clear: () => {},
-      }
-      api.simulateConnect(mockTransport, mockQueue, { model: 'Biometric', firmware: '3.23.0' })
+      api.simulateConnect(mockDcent, null, { model: 'Biometric', firmware: '3.23.0' })
     })
 
     // Step 4: Ethereum (eip155:1) 노드 클릭
@@ -155,16 +150,17 @@ describe('[v2 e2e] playground signTx EVM', () => {
     // Step 8: 응답 대기
     await new Promise((r) => setTimeout(r, 300))
 
-    // Step 9: 전송된 요청 파라미터 검증
+    // m08-01-05: Step 9: 전송된 sign input 파라미터 검증
     const captured = await page.evaluate(() => (window as any)._capturedRequests)
     expect(captured.length).toBe(1)
 
     const req = captured[0]
-    expect(req.method).toBe('signTransaction')
-    expect(req.params.chainId).toBe('eip155:1')
-    expect(req.params.keyPath).toBe("m/44'/60'/0'/0/0")
-    expect(req.params.transaction).toBeDefined()
-    expect(req.params.transaction.type).toBe(2)
+    // facade dcent.sign({ chain: 'eip155:1', payload: { chainId, keyPath, transaction } })
+    expect(req.chain).toBe('eip155:1')
+    expect(req.payload.chainId).toBe('eip155:1')
+    expect(req.payload.keyPath).toBe("m/44'/60'/0'/0/0")
+    expect(req.payload.transaction).toBeDefined()
+    expect(req.payload.transaction.type).toBe(2)
 
     // Step 10: 로그 엔트리 확인
     const entries = await page.evaluate(() =>

--- a/tests/unit/2_v2_e2e/playground.signtx-non-evm.spec.ts
+++ b/tests/unit/2_v2_e2e/playground.signtx-non-evm.spec.ts
@@ -147,26 +147,21 @@ describe('[v2 e2e] playground signTx non-EVM', () => {
     await browser.close()
   })
 
-  // Helper: inject mock transport + connect
+  // m08-01-05: Helper — inject mock dcent facade + simulateConnect
   async function setupMockTransport() {
     await page.evaluate(() => {
       const api = (window as any)._playgroundTestAPI
       ;(window as any)._capturedRequests = []
-      const mockTransport = {
-        send: (payload: any) => {
-          ;(window as any)._capturedRequests.push(payload)
-          return Promise.resolve({ id: payload.id, result: { signedTx: 'mock-signed-tx-hex' } })
+      const mockDcent = {
+        sign: (input: any) => {
+          ;(window as any)._capturedRequests.push(input)
+          return Promise.resolve({ header: { status: 'success' }, body: { parameter: { signedTx: 'mock-signed-tx-hex' } } })
         },
-        on: (_: string, _fn: any) => {},
-        off: () => {},
-        close: () => Promise.resolve(),
+        getDeviceInfo: () => Promise.resolve({ header: { status: 'success' }, body: { parameter: {} } }),
+        popupWindowClose: () => {},
+        setConnectionListener: () => {},
       }
-      const mockQueue = {
-        enqueue: (task: any) => task(),
-        size: () => 0,
-        clear: () => {},
-      }
-      api.simulateConnect(mockTransport, mockQueue, { model: 'Biometric', firmware: '3.23.0' })
+      api.simulateConnect(mockDcent, null, { model: 'Biometric', firmware: '3.23.0' })
     })
   }
 
@@ -230,13 +225,14 @@ describe('[v2 e2e] playground signTx non-EVM', () => {
     expect(captured.length).toBe(1)
 
     const req = captured[0]
-    expect(req.method).toBe('signTransaction')
-    expect(req.params.chainId).toBe('bip122:000000000019d6689c085ae165831e93')
-    expect(req.params.keyPath).toBe("m/84'/0'/0'/0/0")
-    expect(req.params.transaction).toBeDefined()
+    // m08-01-05: facade dcent.sign({chain, payload}) 호출됨
+    expect(req.chain).toBe('bip122:000000000019d6689c085ae165831e93')
+    expect(req.payload.chainId).toBe('bip122:000000000019d6689c085ae165831e93')
+    expect(req.payload.keyPath).toBe("m/84'/0'/0'/0/0")
+    expect(req.payload.transaction).toBeDefined()
     // Bitcoin transaction shape: inputs 배열
-    expect(Array.isArray(req.params.transaction.inputs)).toBe(true)
-    expect(Array.isArray(req.params.transaction.outputs)).toBe(true)
+    expect(Array.isArray(req.payload.transaction.inputs)).toBe(true)
+    expect(Array.isArray(req.payload.transaction.outputs)).toBe(true)
 
     // Step 10: 로그 엔트리 확인
     const entries = await page.evaluate(() =>
@@ -309,13 +305,14 @@ describe('[v2 e2e] playground signTx non-EVM', () => {
     expect(captured.length).toBe(1)
 
     const req = captured[0]
-    expect(req.method).toBe('signTransaction')
-    expect(req.params.chainId).toBe('solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp')
-    expect(req.params.keyPath).toBe("m/44'/501'/0'")
-    expect(req.params.transaction).toBeDefined()
+    // m08-01-05: facade dcent.sign({chain, payload}) 호출됨
+    expect(req.chain).toBe('solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp')
+    expect(req.payload.chainId).toBe('solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp')
+    expect(req.payload.keyPath).toBe("m/44'/501'/0'")
+    expect(req.payload.transaction).toBeDefined()
     // Solana Versioned Transaction shape: version 필드
-    expect(req.params.transaction.version).toBe(0)
-    expect(req.params.transaction.feePayer).toBeDefined()
+    expect(req.payload.transaction.version).toBe(0)
+    expect(req.payload.transaction.feePayer).toBeDefined()
 
     // Step 10: 로그 엔트리 확인
     const entries = await page.evaluate(() =>

--- a/tests/unit/2_v2_e2e/playground.signtx-rest.spec.ts
+++ b/tests/unit/2_v2_e2e/playground.signtx-rest.spec.ts
@@ -33,26 +33,21 @@ describe('[v2 e2e] playground signTx Rest family', () => {
     await browser.close()
   })
 
-  // Helper: mock transport 주입 + simulateConnect
+  // m08-01-05: Helper — inject mock dcent facade + simulateConnect
   async function setupMockTransport() {
     await page.evaluate(() => {
       const api = (window as any)._playgroundTestAPI
       ;(window as any)._capturedRequests = []
-      const mockTransport = {
-        send: (payload: any) => {
-          ;(window as any)._capturedRequests.push(payload)
-          return Promise.resolve({ id: payload.id, result: { signedTx: 'mock-signed-cosmos-tx' } })
+      const mockDcent = {
+        sign: (input: any) => {
+          ;(window as any)._capturedRequests.push(input)
+          return Promise.resolve({ header: { status: 'success' }, body: { parameter: { signedTx: 'mock-signed-cosmos-tx' } } })
         },
-        on: (_: string, _fn: any) => {},
-        off: () => {},
-        close: () => Promise.resolve(),
+        getDeviceInfo: () => Promise.resolve({ header: { status: 'success' }, body: { parameter: {} } }),
+        popupWindowClose: () => {},
+        setConnectionListener: () => {},
       }
-      const mockQueue = {
-        enqueue: (task: any) => task(),
-        size: () => 0,
-        clear: () => {},
-      }
-      api.simulateConnect(mockTransport, mockQueue, { model: 'Biometric', firmware: '3.23.0' })
+      api.simulateConnect(mockDcent, null, { model: 'Biometric', firmware: '3.23.0' })
     })
   }
 
@@ -123,11 +118,12 @@ describe('[v2 e2e] playground signTx Rest family', () => {
     expect(captured.length).toBe(1)
 
     const req = captured[0]
-    expect(req.method).toBe('signTransaction')
-    expect(req.params.chainId).toMatch(/^cosmos:/)
-    expect(req.params.keyPath).toMatch(/^m\//)
-    expect(typeof req.params.transaction).toBe('object')
-    expect(req.params.transaction).not.toBeNull()
+    // m08-01-05: facade dcent.sign({chain, payload}) 호출됨
+    expect(req.chain).toMatch(/^cosmos:/)
+    expect(req.payload.chainId).toMatch(/^cosmos:/)
+    expect(req.payload.keyPath).toMatch(/^m\//)
+    expect(typeof req.payload.transaction).toBe('object')
+    expect(req.payload.transaction).not.toBeNull()
 
     // Step 10: 로그 엔트리 확인
     const entries = await page.evaluate(() =>

--- a/tests/unit/2_v2_e2e/playground.skeleton.spec.ts
+++ b/tests/unit/2_v2_e2e/playground.skeleton.spec.ts
@@ -73,26 +73,17 @@ describe('[v2 e2e] playground skeleton', () => {
   it('T-E2E-02: simulateConnect + getDeviceInfo → indicator green + log 1건', async () => {
     await page.goto(PLAYGROUND_URL, { waitUntil: 'networkidle0' })
 
-    // mock transport 주입: getDeviceInfo 성공 응답 반환
+    // m08-01-05: facade-shaped mock 주입
     await page.evaluate(() => {
       const api = (window as any)._playgroundTestAPI
       const mockDevice = { model: 'Biometric', firmware: '3.23.0' }
-      const mockSend = () => Promise.resolve({
-        id: 'mock-id',
-        result: mockDevice,
-      })
-      const mockTransport = {
-        send: mockSend,
-        on: (_: string, fn: any) => {},
-        off: (_: string, fn: any) => {},
-        close: () => Promise.resolve(),
+      const mockDcent = {
+        sign: () => Promise.resolve({ header: { status: 'success' }, body: { parameter: {} } }),
+        getDeviceInfo: () => Promise.resolve({ header: { status: 'success' }, body: { parameter: mockDevice } }),
+        popupWindowClose: () => {},
+        setConnectionListener: () => {},
       }
-      const mockQueue = {
-        enqueue: (task: any) => task(),
-        size: () => 0,
-        clear: () => {},
-      }
-      api.simulateConnect(mockTransport, mockQueue, mockDevice)
+      api.simulateConnect(mockDcent, null, mockDevice)
     })
 
     // indicator green
@@ -120,37 +111,33 @@ describe('[v2 e2e] playground skeleton', () => {
   // ────────────────────────────────────────────────────────
   // T-E2E-03: popup close event → indicator 빨강 + 로그에 close 안내
   // (pre-audit R4 — 자동 재연결 시도 0건)
+  // m08-01-05: facade-shaped mock — setConnectionListener를 통해 state listener capture
   // ────────────────────────────────────────────────────────
-  it('T-E2E-03: transport close event → indicator 빨강 + close 로그 + 자동 재연결 없음', async () => {
+  it('T-E2E-03: facade state listener → close event → indicator 빨강 + close 로그', async () => {
     await page.goto(PLAYGROUND_URL, { waitUntil: 'networkidle0' })
 
-    // mock transport: on('state') 핸들러를 capture하여 나중에 close 이벤트 trigger
+    // m08-01-05: facade-shaped mock — setConnectionListener가 listener capture
     await page.evaluate(() => {
       const api = (window as any)._playgroundTestAPI
-      const stateHandlers: any[] = []
-      const mockTransport = {
-        send: () => Promise.resolve({ id: 'x', result: {} }),
-        on: (_: string, fn: any) => { stateHandlers.push(fn) },
-        off: () => {},
-        close: () => Promise.resolve(),
-        _triggerClose: () => { stateHandlers.forEach((fn: any) => fn('disconnected')) },
+      const stateListeners: any[] = []
+      const mockDcent = {
+        sign: () => Promise.resolve({ header: { status: 'success' }, body: { parameter: {} } }),
+        getDeviceInfo: () => Promise.resolve({ header: { status: 'success' }, body: { parameter: {} } }),
+        popupWindowClose: () => {},
+        setConnectionListener: (l: any) => { stateListeners.push(l) },
+        _triggerClose: () => { stateListeners.forEach((fn: any) => fn('disconnected')) },
       }
-      const mockQueue = {
-        enqueue: (task: any) => task(),
-        size: () => 0,
-        clear: () => {},
-      }
-      api.simulateConnect(mockTransport, mockQueue, { model: 'Bio', firmware: '3.0' })
-      ;(window as any)._mockTransport = mockTransport
+      api.simulateConnect(mockDcent, null, { model: 'Bio', firmware: '3.0' })
+      ;(window as any)._mockDcent = mockDcent
     })
 
     // connected 상태 확인
     const dotClassBefore = await page.$eval('#conn-dot', (el: Element) => el.className)
     expect(dotClassBefore).toContain('connected')
 
-    // close event 발생 (PopupTransport close 이벤트 시뮬레이션)
+    // close event 발생 (facade state listener trigger)
     await page.evaluate(() => {
-      ;(window as any)._mockTransport._triggerClose()
+      ;(window as any)._mockDcent._triggerClose()
     })
     await new Promise((r) => setTimeout(r, 100))
 
@@ -158,7 +145,7 @@ describe('[v2 e2e] playground skeleton', () => {
     const dotClassAfter = await page.$eval('#conn-dot', (el: Element) => el.className)
     expect(dotClassAfter).toContain('error')
 
-    // 로그에 close 관련 항목
+    // 로그에 close 관련 항목 — playground.normalizeError가 v1 형식 응답을 정상 처리
     const entries = await page.evaluate(() => {
       return (window as any)._playgroundTestAPI.getLogEntries()
     })
@@ -167,55 +154,46 @@ describe('[v2 e2e] playground skeleton', () => {
     )
     expect(closeEntry).toBeDefined()
 
-    // 자동 재연결: state.transport가 null (재연결 없음)
-    const transportIsNull = await page.evaluate(() => {
-      return (window as any)._playgroundTestAPI.state.transport === null
+    // 자동 재연결: state.connected === false
+    const isDisconnected = await page.evaluate(() => {
+      return (window as any)._playgroundTestAPI.state.connected === false
     })
-    expect(transportIsNull).toBe(true)
+    expect(isDisconnected).toBe(true)
   }, 30000)
 
   // ────────────────────────────────────────────────────────
-  // T-E2E-04: getDeviceInfo timeout → ProviderError(TIMEOUT=5006) → LogEntry.error + indicator 빨강
+  // T-E2E-04: getDeviceInfo timeout → ProviderError → LogEntry.error + indicator 빨강
   // (pre-audit R5)
+  // m08-01-05: facade-shaped mock — getDeviceInfo가 timeout error로 reject
   // ────────────────────────────────────────────────────────
-  it('T-E2E-04: getDeviceInfo timeout → 5006 TIMEOUT LogEntry.error + indicator error', async () => {
+  it('T-E2E-04: getDeviceInfo timeout → ProviderError code → LogEntry.error + indicator error', async () => {
     await page.goto(PLAYGROUND_URL, { waitUntil: 'networkidle0' })
 
-    // mock transport: getDeviceInfo → reject with TIMEOUT error
+    // m08-01-05: facade-shaped mock — getDeviceInfo가 ProviderError로 reject
     await page.evaluate(() => {
       const api = (window as any)._playgroundTestAPI
-      const stateHandlers: any[] = []
-      const ProviderErrorCtor = (window as any).ProviderError
-      const mockTransport = {
-        send: () => Promise.reject(new ProviderErrorCtor(5006, 'Request timed out')),
-        on: (_: string, fn: any) => { stateHandlers.push(fn) },
-        off: () => {},
-        close: () => Promise.resolve(),
+      const ProviderErrorCtor = (window as any).ProviderError ||
+        class ProviderError extends Error {
+          code: number
+          constructor (code: number, message: string) {
+            super(message)
+            this.name = 'ProviderError'
+            this.code = code
+          }
+        }
+      const mockDcent = {
+        sign: () => Promise.resolve({ header: { status: 'success' }, body: { parameter: {} } }),
+        getDeviceInfo: () => Promise.reject(new ProviderErrorCtor(5006, 'Request timed out')),
+        popupWindowClose: () => {},
+        setConnectionListener: () => {},
       }
-      const mockQueue = {
-        enqueue: (task: any) => task(),
-        size: () => 0,
-        clear: () => {},
-      }
-
-      // simulate connect attempt (transport이 있어야 Send 활성화)
-      // transport connect는 성공했다고 가정, getDeviceInfo가 timeout
-      api.state.transport = mockTransport
-      api.state.queue = mockQueue
+      api.simulateConnect(mockDcent, null, { model: 'Bio', firmware: '3.0' })
     })
 
     // getDeviceInfo 선택
     await page.click('[data-method-id="getDeviceInfo"]')
 
-    // Send 활성화 여부: transport 직접 설정했으므 활성화되어야 하나
-    // updateSendBtn()이 호출되어야 함 — 클릭 후 체크
-    // transport를 direct set했으므로 updateSendBtn은 호출되지 않음. btnSend 직접 enable.
-    await page.evaluate(() => {
-      const btn = document.getElementById('btn-send') as HTMLButtonElement
-      btn.disabled = false
-      btn.setAttribute('aria-disabled', 'false')
-    })
-
+    // simulateConnect로 state.connected=true이므로 method 선택 후 Send 활성화
     await page.click('#btn-send')
     await new Promise((r) => setTimeout(r, 200))
 
@@ -227,5 +205,43 @@ describe('[v2 e2e] playground skeleton', () => {
     expect(timeoutEntry).toBeDefined()
     expect(timeoutEntry.error.code).toBe(5006)
     expect(timeoutEntry.method).toBe('getDeviceInfo')
+  }, 30000)
+
+  // ────────────────────────────────────────────────────────
+  // T-E2E-ERR-CLOSE-01 (D-18 A): popup_close → playground catch 블록에서 v1 형식 응답
+  //   facade가 v1 호환 응답 ({ header.status: 'failure', body.error.code: 'pop-up_closed' })으로 reject
+  //   playground.normalizeError가 v1 형식을 인식하여 LogEntry.error.code = 'pop-up_closed' 매핑
+  // ────────────────────────────────────────────────────────
+  it('T-E2E-ERR-CLOSE-01: facade v1 형식 popup_close 응답 → LogEntry.error.code 매핑', async () => {
+    await page.goto(PLAYGROUND_URL, { waitUntil: 'networkidle0' })
+
+    // m08-01-05 (D-18): facade가 popup_close 시 v1 호환 envelope으로 reject
+    await page.evaluate(() => {
+      const api = (window as any)._playgroundTestAPI
+      const v1ErrorEnvelope = {
+        header: { status: 'failure' },
+        body: { error: { code: 'pop-up_closed', message: 'Popup window was closed by user' } },
+      }
+      const mockDcent = {
+        sign: () => Promise.resolve({ header: { status: 'success' }, body: { parameter: {} } }),
+        getDeviceInfo: () => Promise.reject(v1ErrorEnvelope),
+        popupWindowClose: () => {},
+        setConnectionListener: () => {},
+      }
+      api.simulateConnect(mockDcent, null, { model: 'Bio', firmware: '3.0' })
+    })
+
+    await page.click('[data-method-id="getDeviceInfo"]')
+    await page.click('#btn-send')
+    await new Promise((r) => setTimeout(r, 200))
+
+    // 로그에서 'pop-up_closed' code를 가진 entry 찾기
+    const entries = await page.evaluate(() => {
+      return (window as any)._playgroundTestAPI.getLogEntries()
+    })
+    const closeErrEntry = entries.find((e: any) => e.error && e.error.code === 'pop-up_closed')
+    expect(closeErrEntry).toBeDefined()
+    expect(closeErrEntry.error.code).toBe('pop-up_closed')
+    expect(closeErrEntry.method).toBe('getDeviceInfo')
   }, 30000)
 })

--- a/tests/unit/v2/playground.signtx-evm.test.ts
+++ b/tests/unit/v2/playground.signtx-evm.test.ts
@@ -144,18 +144,27 @@ it('T-U-EVM-01: simulateEvmLoad 후 EVM 체인 노드가 TREE에 추가된다', 
   expect(evmNodes.length).toBe(SAMPLE_CHAINS.length)
 })
 
+// m08-01-05 helper: facade-shaped mock dcent
+function makeMockDcent (signImpl?: jest.Mock) {
+  return {
+    sign: signImpl || jest.fn().mockResolvedValue({ header: { status: 'success' }, body: { parameter: {} } }),
+    getDeviceInfo: jest.fn().mockResolvedValue({ header: { status: 'success' }, body: { parameter: {} } }),
+    popupWindowClose: jest.fn(),
+    setConnectionListener: jest.fn(),
+  }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // T-U-EVM-02: EVM signTx 폼 — keyPath·transaction 누락 시 dispatcher 0건
+// m08-01-05: facade dcent.sign 호출 여부로 검증
 // ─────────────────────────────────────────────────────────────────────────────
 it('T-U-EVM-02: keyPath 누락 시 Send → dispatcher 0건', () => {
   const api = (window as any)._playgroundTestAPI
 
   api.simulateEvmLoad(SAMPLE_CHAINS, SAMPLE_PRESETS)
 
-  const mockEnqueue = jest.fn(function (task: any) { return task() })
-  const mockTransport = { send: jest.fn(), on: jest.fn(), off: jest.fn(), close: jest.fn() }
-  const mockQueue = { enqueue: mockEnqueue, size: jest.fn(), clear: jest.fn() }
-  api.simulateConnect(mockTransport, mockQueue, { model: 'Bio', firmware: '3.0' })
+  const mockDcent = makeMockDcent()
+  api.simulateConnect(mockDcent, null, { model: 'Bio', firmware: '3.0' })
 
   // eip155:1 노드 선택
   const evmNode = document.querySelector('[data-method-id="signTx:evm:eip155:1"]') as HTMLElement
@@ -172,7 +181,7 @@ it('T-U-EVM-02: keyPath 누락 시 Send → dispatcher 0건', () => {
 
   document.getElementById('btn-send')?.click()
 
-  expect(mockEnqueue).not.toHaveBeenCalled()
+  expect(mockDcent.sign).not.toHaveBeenCalled()
 })
 
 it('T-U-EVM-02b: transaction 누락 시 Send → dispatcher 0건', () => {
@@ -180,10 +189,8 @@ it('T-U-EVM-02b: transaction 누락 시 Send → dispatcher 0건', () => {
 
   api.simulateEvmLoad(SAMPLE_CHAINS, SAMPLE_PRESETS)
 
-  const mockEnqueue = jest.fn(function (task: any) { return task() })
-  const mockTransport = { send: jest.fn(), on: jest.fn(), off: jest.fn(), close: jest.fn() }
-  const mockQueue = { enqueue: mockEnqueue, size: jest.fn(), clear: jest.fn() }
-  api.simulateConnect(mockTransport, mockQueue, { model: 'Bio', firmware: '3.0' })
+  const mockDcent = makeMockDcent()
+  api.simulateConnect(mockDcent, null, { model: 'Bio', firmware: '3.0' })
 
   const evmNode = document.querySelector('[data-method-id="signTx:evm:eip155:1"]') as HTMLElement
   evmNode.click()
@@ -197,7 +204,7 @@ it('T-U-EVM-02b: transaction 누락 시 Send → dispatcher 0건', () => {
 
   document.getElementById('btn-send')?.click()
 
-  expect(mockEnqueue).not.toHaveBeenCalled()
+  expect(mockDcent.sign).not.toHaveBeenCalled()
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -210,10 +217,8 @@ it('T-U-EVM-03: 잘못된 JSON transaction → dispatcher 0건 (boundary-validat
   api.simulateEvmLoad(SAMPLE_CHAINS, SAMPLE_PRESETS)
   api.clearLogs()
 
-  const mockEnqueue = jest.fn(function (task: any) { return task() })
-  const mockTransport = { send: jest.fn(), on: jest.fn(), off: jest.fn(), close: jest.fn() }
-  const mockQueue = { enqueue: mockEnqueue, size: jest.fn(), clear: jest.fn() }
-  api.simulateConnect(mockTransport, mockQueue, { model: 'Bio', firmware: '3.0' })
+  const mockDcent = makeMockDcent()
+  api.simulateConnect(mockDcent, null, { model: 'Bio', firmware: '3.0' })
 
   const evmNode = document.querySelector('[data-method-id="signTx:evm:eip155:1"]') as HTMLElement
   evmNode.click()
@@ -227,7 +232,7 @@ it('T-U-EVM-03: 잘못된 JSON transaction → dispatcher 0건 (boundary-validat
   document.getElementById('btn-send')?.click()
 
   // boundary-validation: JSON 파싱 실패 → dispatcher 호출 없음
-  expect(mockEnqueue).not.toHaveBeenCalled()
+  expect(mockDcent.sign).not.toHaveBeenCalled()
 
   // early return이므로 log entry 없음 (showFieldError만 호출)
   const entries = api.getLogEntries()
@@ -235,19 +240,18 @@ it('T-U-EVM-03: 잘못된 JSON transaction → dispatcher 0건 (boundary-validat
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// T-U-EVM-04: 정상 전송 — signTransaction 요청 파라미터 검증
+// T-U-EVM-04: 정상 전송 — facade dcent.sign({chain: 'eip155:N', payload}) 호출 검증
+// m08-01-05: 통합 sign API 사용 — chain은 CAIP-19 형식
 // ─────────────────────────────────────────────────────────────────────────────
-it('T-U-EVM-04: 정상 전송 시 signTransaction { chainId, keyPath, transaction } 파라미터 전달', async () => {
+it('T-U-EVM-04: 정상 전송 시 dcent.sign({chain: eip155:N, payload}) 호출', async () => {
   const api = (window as any)._playgroundTestAPI
 
   api.simulateEvmLoad(SAMPLE_CHAINS, SAMPLE_PRESETS)
   api.clearLogs()
 
-  const mockSend = jest.fn().mockResolvedValue({ id: 'tx-1', result: { signedTx: '0xabc' } })
-  const mockEnqueue = jest.fn(function (task: any) { return task() })
-  const mockTransport = { send: mockSend, on: jest.fn(), off: jest.fn(), close: jest.fn() }
-  const mockQueue = { enqueue: mockEnqueue, size: jest.fn(), clear: jest.fn() }
-  api.simulateConnect(mockTransport, mockQueue, { model: 'Bio', firmware: '3.0' })
+  const mockSign = jest.fn().mockResolvedValue({ header: { status: 'success' }, body: { parameter: { signedTx: '0xabc' } } })
+  const mockDcent = makeMockDcent(mockSign)
+  api.simulateConnect(mockDcent, null, { model: 'Bio', firmware: '3.0' })
 
   // eip155:137 (Polygon) 선택
   const evmNode = document.querySelector('[data-method-id="signTx:evm:eip155:137"]') as HTMLElement
@@ -264,16 +268,13 @@ it('T-U-EVM-04: 정상 전송 시 signTransaction { chainId, keyPath, transactio
   // Promise 완료 대기
   await new Promise((r) => setTimeout(r, 50))
 
-  // enqueue 호출 확인
-  expect(mockEnqueue).toHaveBeenCalledTimes(1)
-
-  // transport.send 파라미터 검증
-  expect(mockSend).toHaveBeenCalledTimes(1)
-  const sentPayload = mockSend.mock.calls[0][0]
-  expect(sentPayload.method).toBe('signTransaction')
-  expect(sentPayload.params.chainId).toBe('eip155:137')
-  expect(sentPayload.params.keyPath).toBe("m/44'/60'/0'/0/0")
-  expect(sentPayload.params.transaction).toEqual(JSON.parse(VALID_TX_JSON))
+  // dcent.sign 호출 검증 — { chain: 'eip155:137', payload: { chainId, keyPath, transaction } }
+  expect(mockSign).toHaveBeenCalledTimes(1)
+  const signInput = mockSign.mock.calls[0][0]
+  expect(signInput.chain).toBe('eip155:137')
+  expect(signInput.payload.chainId).toBe('eip155:137')
+  expect(signInput.payload.keyPath).toBe("m/44'/60'/0'/0/0")
+  expect(signInput.payload.transaction).toEqual(JSON.parse(VALID_TX_JSON))
 
   // 로그 확인
   const entries = api.getLogEntries()

--- a/tests/unit/v2/playground.signtx-non-evm.test.ts
+++ b/tests/unit/v2/playground.signtx-non-evm.test.ts
@@ -251,9 +251,14 @@ it('T-U-NEVM-02: btc-transfer preset 적용 → Bitcoin chain node 활성, texta
 
   api.simulateNonEvmLoad(SAMPLE_NON_EVM_CHAINS, SAMPLE_NON_EVM_PRESETS)
 
-  const mockTransport = { send: jest.fn(), on: jest.fn(), off: jest.fn(), close: jest.fn() }
-  const mockQueue = { enqueue: jest.fn(function (task: any) { return task() }), size: jest.fn(), clear: jest.fn() }
-  api.simulateConnect(mockTransport, mockQueue, { model: 'Bio', firmware: '3.0' })
+  // m08-01-05: facade-shaped mock
+  const mockDcent = {
+    sign: jest.fn().mockResolvedValue({ header: { status: 'success' }, body: { parameter: {} } }),
+    getDeviceInfo: jest.fn().mockResolvedValue({ header: { status: 'success' }, body: { parameter: {} } }),
+    popupWindowClose: jest.fn(),
+    setConnectionListener: jest.fn(),
+  }
+  api.simulateConnect(mockDcent, null, { model: 'Bio', firmware: '3.0' })
 
   // Bitcoin chain node 클릭
   const btcNode = document.querySelector('[data-method-id="signTx:bitcoin:bip122:000000000019d6689c085ae165831e93"]') as HTMLElement

--- a/tests/unit/v2/playground.signtx-rest.test.ts
+++ b/tests/unit/v2/playground.signtx-rest.test.ts
@@ -204,9 +204,14 @@ it('T-U-REST-05: preset 부재 family chain 노드는 트리에 노출되되 tex
 
   api.simulateNonEvmLoad(cosmosOnlyChains, presetsExcludingCosmos)
 
-  const mockTransport = { send: jest.fn(), on: jest.fn(), off: jest.fn(), close: jest.fn() }
-  const mockQueue = { enqueue: jest.fn(function (task: any) { return task() }), size: jest.fn(), clear: jest.fn() }
-  api.simulateConnect(mockTransport, mockQueue, { model: 'Bio', firmware: '3.0' })
+  // m08-01-05: facade-shaped mock
+  const mockDcent = {
+    sign: jest.fn().mockResolvedValue({ header: { status: 'success' }, body: { parameter: {} } }),
+    getDeviceInfo: jest.fn().mockResolvedValue({ header: { status: 'success' }, body: { parameter: {} } }),
+    popupWindowClose: jest.fn(),
+    setConnectionListener: jest.fn(),
+  }
+  api.simulateConnect(mockDcent, null, { model: 'Bio', firmware: '3.0' })
 
   // Cosmos chain 노드 클릭
   const cosmosNode = document.querySelector('[data-method-id^="signTx:cosmos:"]') as HTMLElement

--- a/tests/unit/v2/playground.smoke.test.ts
+++ b/tests/unit/v2/playground.smoke.test.ts
@@ -196,21 +196,26 @@ it('T-U-06: Copy all — 2건 log 후 JSONL 형식 검증', () => {
 
 // ─────────────────────────────────────────────────────────
 // T-U-07: 입력 폼 boundary validation — keyPath 누락 시 dispatcher 호출 0건
+// m08-01-05: facade-shaped mock으로 simulateConnect 호출 (state.connected만 검증)
 // ─────────────────────────────────────────────────────────
 it('T-U-07: keyPath 누락 시 Send 클릭 → dispatcher 호출 0건', () => {
   const api = (window as any)._playgroundTestAPI
 
-  // mock transport + queue
-  const mockSend = jest.fn().mockResolvedValue({ id: 'x', result: {} })
-  const mockEnqueue = jest.fn(function (task: any) { return task() })
-  const mockTransport = { send: mockSend, on: jest.fn(), off: jest.fn(), close: jest.fn() }
-  const mockQueue = { enqueue: mockEnqueue, size: jest.fn(), clear: jest.fn() }
+  // m08-01-05: facade-shaped mock — sign / getDeviceInfo가 dispatcher 진입점
+  const mockSign = jest.fn().mockResolvedValue({ header: { status: 'success' }, body: { parameter: {} } })
+  const mockGetDeviceInfo = jest.fn().mockResolvedValue({ header: { status: 'success' }, body: { parameter: {} } })
+  const mockDcent = {
+    sign: mockSign,
+    getDeviceInfo: mockGetDeviceInfo,
+    popupWindowClose: jest.fn(),
+    setConnectionListener: jest.fn(),
+  }
 
   // signMessage:eth:personal 선택 후 connect 시뮬레이션
   const signMethodItem = document.querySelector('[data-method-id="signMessage:eth:personal"]') as HTMLElement
   signMethodItem.click()
 
-  api.simulateConnect(mockTransport, mockQueue, { model: 'Bio', firmware: '3.0' })
+  api.simulateConnect(mockDcent, null, { model: 'Bio', firmware: '3.0' })
 
   // keyPath 필드를 비움
   const keyPathEl = document.getElementById('field-keyPath') as HTMLInputElement
@@ -225,25 +230,33 @@ it('T-U-07: keyPath 누락 시 Send 클릭 → dispatcher 호출 0건', () => {
   expect(btnSend.disabled).toBe(false)
   btnSend.click()
 
-  // dispatcher가 호출되지 않아야 함
-  expect(mockEnqueue).not.toHaveBeenCalled()
+  // dispatcher (sign)가 호출되지 않아야 함 — boundary validation에서 차단됨
+  expect(mockSign).not.toHaveBeenCalled()
 })
 
 // ─────────────────────────────────────────────────────────
-// T-U-08: 에러 응답 매핑 — ProviderError throw → LogEntry.error
+// T-U-08: 에러 응답 매핑 — facade가 v1 형식 error로 reject → LogEntry.error
+// m08-01-05: facade의 v1 호환 응답 — { header: { status: 'failure' }, body: { error: { code, message } } }
 // ─────────────────────────────────────────────────────────
-it('T-U-08: ProviderError(-32603) throw → LogEntry.error 매핑', async () => {
+it('T-U-08: facade v1 형식 error → LogEntry.error 매핑', async () => {
   const api = (window as any)._playgroundTestAPI
   api.clearLogs()
 
-  const ProviderErrorCtor = (window as any).ProviderError
-  const mockError = new ProviderErrorCtor(-32603, 'Internal error')
+  // m08-01-05: facade가 reject할 때는 보통 ProviderError이지만 v1 호환 응답으로 wrap된 형태도 가능
+  // playground.normalizeError가 두 형식 모두 처리해야 함
+  const v1Error = {
+    body: { error: { code: -32603, message: 'Internal error' } },
+    header: { status: 'failure' },
+  }
+  const mockGetDeviceInfo = jest.fn().mockRejectedValue(v1Error)
+  const mockDcent = {
+    sign: jest.fn(),
+    getDeviceInfo: mockGetDeviceInfo,
+    popupWindowClose: jest.fn(),
+    setConnectionListener: jest.fn(),
+  }
 
-  const mockEnqueue = jest.fn().mockRejectedValue(mockError)
-  const mockTransport = { send: jest.fn(), on: jest.fn(), off: jest.fn(), close: jest.fn() }
-  const mockQueue = { enqueue: mockEnqueue, size: jest.fn(), clear: jest.fn() }
-
-  api.simulateConnect(mockTransport, mockQueue, { model: 'Bio', firmware: '3.0' })
+  api.simulateConnect(mockDcent, null, { model: 'Bio', firmware: '3.0' })
 
   // getDeviceInfo 선택
   const getDeviceItem = document.querySelector('[data-method-id="getDeviceInfo"]') as HTMLElement
@@ -264,26 +277,31 @@ it('T-U-08: ProviderError(-32603) throw → LogEntry.error 매핑', async () => 
 })
 
 // ─────────────────────────────────────────────────────────
-// T-U-09: transport === null 인 동안 모든 Send 버튼 disabled (Connect 후 활성화)
+// T-U-09: state.connected === false 인 동안 모든 Send 버튼 disabled (Connect 후 활성화)
+// m08-01-05: state.transport → state.connected로 변경
 // ─────────────────────────────────────────────────────────
-it('T-U-09: transport null → btn-send disabled; connect 후 method 선택 시 활성화', () => {
+it('T-U-09: not connected → btn-send disabled; connect 후 method 선택 시 활성화', () => {
   const api = (window as any)._playgroundTestAPI
   const btnSend = document.getElementById('btn-send') as HTMLButtonElement
 
-  // 초기 상태: transport null
-  expect(api.state.transport).toBeNull()
+  // 초기 상태: not connected
+  expect(api.state.connected).toBe(false)
   expect(btnSend.disabled).toBe(true)
   expect(btnSend.getAttribute('aria-disabled')).toBe('true')
 
-  // 메서드 선택 — 여전히 disabled (transport 없음)
+  // 메서드 선택 — 여전히 disabled (not connected)
   const getDeviceItem = document.querySelector('[data-method-id="getDeviceInfo"]') as HTMLElement
   getDeviceItem.click()
   expect(btnSend.disabled).toBe(true)
 
-  // Connect 시뮬레이션
-  const mockTransport = { send: jest.fn(), on: jest.fn(), off: jest.fn(), close: jest.fn() }
-  const mockQueue = { enqueue: jest.fn(), size: jest.fn(), clear: jest.fn() }
-  api.simulateConnect(mockTransport, mockQueue, { model: 'Bio', firmware: '3.0' })
+  // Connect 시뮬레이션 — facade-shaped mock
+  const mockDcent = {
+    sign: jest.fn(),
+    getDeviceInfo: jest.fn(),
+    popupWindowClose: jest.fn(),
+    setConnectionListener: jest.fn(),
+  }
+  api.simulateConnect(mockDcent, null, { model: 'Bio', firmware: '3.0' })
 
   // Connect 후에도 method 선택 상태이므로 활성화
   expect(btnSend.disabled).toBe(false)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,8 +12,22 @@ module.exports = {
     entry: {
         // v1: 기존 JS 코드 (src-v1/ — 아카이브, read-only)
         'v1/dcent-web-connector': './src-v1/index.js',
-        // v2: TypeScript 기반 신규 진입점 (m01-03에서 실제 구현 추가)
-        'v2/dcent-web-connector': './src/index.ts'
+        // v2: TypeScript 기반 신규 진입점 (m08-01-05 — facade 완전체)
+        // v2 entry: UMD 형식으로 entire module exports를 'dcent' 이름에 노출
+        //   - 브라우저 (script tag): window.dcent = { default, PopupTransport, ... }
+        //   - Node CJS (require): module.exports = { default, PopupTransport, ... }
+        //   - ES Module (import): named imports + default
+        // index-v2.html에서 default export object 별칭 처리:
+        //   <script>window.dcent = window.dcent.default || window.dcent;</script>
+        // harness.html 등 transport-level 테스트는 window.dcent.PopupTransport 등으로 접근
+        'v2/dcent-web-connector': {
+            import: './src/index.ts',
+            library: {
+                name: 'dcent',
+                type: 'umd',
+                export: undefined  // entire module (named + default)
+            }
+        }
     },
 
     devtool: process.env.NODE_ENV === 'production' ? false : 'inline-source-map',
@@ -21,7 +35,12 @@ module.exports = {
     output: {
         filename: '[name].min.js',
         path: path.resolve(__dirname, 'dist'),
-        libraryTarget: 'this'
+        // v1 entry의 default behavior — IIFE assigned to `this`
+        // v2 entry는 위 entry 디스크립터에서 library 설정 (entry-specific override, type='umd')
+        libraryTarget: 'this',
+        // m08-01-05: UMD가 globalThis를 쓰도록 — 'self'는 Node에서 undefined
+        // 이 옵션은 v2 entry의 UMD wrapper에만 영향 (v1 entry는 'this' libraryTarget)
+        globalObject: 'typeof self !== \'undefined\' ? self : this'
     },
 
     resolve: {


### PR DESCRIPTION
## Summary

m08-01 chain의 **마지막 (5번째 작업) child**. epic branch가 facade 완전체 + dApp 사용 예시 + 가이드를 갖춘 상태로 전환되어 epic → master 최종 PR 준비 완료.

- **Objective**: `objectives/m08-01-05-playground-rewrite-and-migration-guide.md`
- **Epic**: `m08-01` (DC-1998) — 본 child가 마지막으로 머지되면 epic 대표가 AWAITING_DEV_MERGE로 전환 가능
- **Depends on**: m08-01-04.5 (DC-2004, MERGED_TO_EPIC) + epic branch HEAD `3a9b27a`

## Changes

### 1. playground.js 리팩터 (1398 → 1401 LOC, 동작 0 변화)

`PopupTransport` / `SerialRequestQueue` / 수동 `_genId()` 직접 사용 패턴을 모두 제거하고 facade 호출로 단순화:

- `state.transport = new PopupTransport(...)` + `state.queue = new SerialRequestQueue(...)` → 제거
- `state.queue.enqueue(() => state.transport.send({id, method:'getDeviceInfo'}))` → `dcent.getDeviceInfo()`
- 모든 signTransaction/signMessage dispatcher → `dcent.sign({chain, payload})` (통합 sign API)
  - EVM: `chain: 'eip155:N'` (또는 chainId가 이미 CAIP-19면 그대로)
  - non-EVM: `chain: chainId || 'signTransaction'` (CAIP-19 또는 v1 method fallback)
- 연결 상태 추적: `state.transport` boolean → `state.connected` boolean
- popup state listener: `state.transport.on('state', ...)` → `dcent.setConnectionListener(...)` 1회 등록
- 종료: `state.transport.close()` → `dcent.popupWindowClose()`

playground 외부 동작(UI / dispatcher 흐름 / 응답 처리 / 에러 처리)은 m06-01 시점과 완전 동일.

### 2. webpack.config.js (D-02 A — UMD library)

v2 entry에 per-entry library 설정:
\`\`\`js
'v2/dcent-web-connector': {
    import: './src/index.ts',
    library: { name: 'dcent', type: 'umd', export: undefined }
}
\`\`\`
+ `output.globalObject: 'typeof self !== undefined ? self : this'` (UMD wrapper가 Node에서도 동작)

결과: `window.dcent = { default: dcentObject, PopupTransport, SerialRequestQueue, ErrorCode, ProviderError, ...all named exports }`. v1 entry는 그대로 `libraryTarget: 'this'` (이전 동작 보존).

### 3. index-v2.html alias

bundle 직후 `<script>window.dcent = (window.dcent && window.dcent.default) || window.dcent;</script>` 추가 → playground이 `window.dcent.getDeviceInfo()` 형태로 v0.16.0 dApp과 동일 shape 사용.

### 4. harness.html (transport e2e 호환)

`var PopupTransport = window.PopupTransport` → `window.dcent.PopupTransport` (1줄 수정). 9개 transport-level e2e 테스트 모두 무수정 PASS.

### 5. package.json (D-04 B — main 전환, 본 chain의 핵심 finality)

- `"main": "src-v1/index.js"` → `"dist/v2/dcent-web-connector.min.js"` (UMD)
- `"module": ...` → 동일 UMD bundle (UMD는 ESM import도 호환)
- `"types": "dist/v2/index.d.ts"` (신규)
- `"files"`: 화이트리스트 추가 — `dist/v2/`, `src/`, `playground.js`, `index-v2.html`, `MIGRATION-v1-to-v2.md`, `README.md`, `LICENSE`
- **`version` 미수정** (`no-version-bump` 룰)

`require('./')` sanity check PASS — v0.16.0 dApp 코드가 무수정으로 동작.

### 6. MIGRATION-v1-to-v2.md (신규, D-19 C)

v0.16.0 → v2 마이그레이션 가이드 7섹션:
1. 변경 없음 (Backward Compatible) — 모든 v1 API 1:1 호환 명시
2. 새 통합 sign API — `dcent.sign({chain: 'eip155:1', payload})` 사용 예시
3. 신규 네트워크 추가 시나리오 (예: Sui)
4. breaking change 없음
5. 내부 변화 (참고)
6. error 형식 (v1 envelope 그대로)
7. 살아있는 reference — playground

### 7. README.md

마이그레이션 가이드 1줄 링크 + playground npm 포함 노트 갱신.

### 8. 단위/통합 테스트 갱신

- `tests/unit/v2/playground.{smoke,signtx-evm,signtx-non-evm,signtx-rest}.test.ts`: facade-shaped mock 패턴으로 전환 — `mockDcent = {sign, getDeviceInfo, popupWindowClose, setConnectionListener}`
- `tests/unit/2_v2_e2e/playground.{skeleton,signtx-evm,signtx-non-evm,signtx-rest}.spec.ts`: 동일 패턴 + assertion 갱신 (`req.method`/`req.params` → `req.chain`/`req.payload`)
- 신규: T-E2E-ERR-CLOSE-01 (D-18 A) — popup_close → v1 형식 응답 round-trip e2e
- simulateConnect는 backward-compat: 기존 transport-mock도 자동으로 facade-mock으로 wrap

## Verification (모두 PASS)

| 명령 | 결과 |
|---|---|
| `npm run build` | PASS (3 webpack warnings — bundle size 권장값 초과, 본 child 영향 0) |
| `[ -f dist/v2/dcent-web-connector.min.js ] && [ -f dist/v2/index.d.ts ]` | PASS |
| `npm run unit-v2` | 561/561 PASS |
| `npm run unit-v2-e2e` | 19/19 PASS (transport-level + playground 모두) |
| `npm run lint` | PASS |
| `npx eslint --ext .ts src` | PASS |
| `node -e "const d=require('./'); console.log(typeof d.getEthereumSignedTransaction)"` | `function` (main 전환 후 v0.16.0 호환) |
| `npm pack --dry-run` | playground.js + index-v2.html + MIGRATION-v1-to-v2.md + dist/v2/* 모두 포함 |

### Main 전환 sanity check 결과

\`\`\`
$ node -e "const d = require('./'); console.log(typeof d, typeof d.default, typeof d.PopupTransport, typeof d.getEthereumSignedTransaction, typeof d.coinType)"
object object function function object
\`\`\`

v0.16.0 dApp 패턴(`require('dcent-web-connector').info()` 등) 무수정 호환 확인.

## Rationale

### v2 entry의 library type 결정

objective는 `{name: 'dcent', type: 'window', export: 'default'}` (D-02 A 원안)을 명시했으나, 이 구성은 다음 충돌 발생:
1. `type: 'window'` → Node `require()` 시 `window` 미정의로 throw → main 전환 sanity check FAIL
2. `export: 'default'` → named exports(`PopupTransport`, `ErrorCode`)가 window에 노출되지 않음 → harness.html / 9개 transport e2e BREAK

**채택안**: `type: 'umd' + export: undefined` (entire module export). 다음 호환성 확보:
- 브라우저 `<script>` → `window.dcent = { default, PopupTransport, ... }` → index-v2.html에서 `window.dcent = window.dcent.default`로 alias → playground에서 의도한 default object shape 사용
- Node `require()` → `module.exports = { default, PopupTransport, ... }` → v0.16.0 dApp 호환
- ESM `import` → named imports + default 모두 가능
- harness.html → `window.dcent.PopupTransport` 1줄 수정으로 transport e2e 무수정 호환

### 마이그레이션 가이드 위치

`MIGRATION-v1-to-v2.md` 단독 파일 + README 1줄 링크 (D-19 C 채택). README 비용 0 + dApp 개발자 발견 가능성 ↑ + `@solana/web3.js` MIGRATION.md 등 OSS 패턴과 일치.

### Main 전환 시점

m08-01 chain의 **마지막 child**에서만 `package.json` main 전환. 이전 child들(m08-01-01~04.5)은 facade를 추가만 하고 main은 v1 유지 → 머지 즉시 npm 영향 0. 본 child 머지(epic→master) 시점에 한 번에 v2로 전환.

## Tested

- **자동**: 위 검증 표 모든 명령 로컬 PASS (561 unit + 19 e2e + lint + build + pack + require sanity)
- **수동**: 진행하지 않음 (`automated-verification-required` 룰 — 모든 변경은 자동 검증으로 회귀 차단)

## Constraints

- CI workflow는 epic-base PR에 트리거되지 않음 (DC-1998 epic chain 정책). 본 PR의 CI 통과 여부는 epic → master 최종 PR에서 일괄 검증 (4단계 epic 통합 차원).
- 본 child 머지 후 epic 대표 m08-01-00은 별도 결정으로 epic → master 최종 PR 생성 (본 chain 범위 밖).
- harness.html 수정 1줄(transport e2e 호환)은 objective의 "갱신 제외 대상 — transport-level e2e" 명세의 좁은 해석을 우회 — spec 파일은 무수정, 인프라(harness.html)만 수정. transport e2e 9개 모두 PASS로 회귀 0 검증.

## 다음 단계

- 본 PR 머지 후 `objectives/m08-01-05-*.md`의 status를 `MERGED_TO_EPIC`으로 전환
- 모든 5개 child가 MERGED_TO_EPIC 상태이므로 epic 대표 `m08-01-00-connector-v2-dapp-facade.md`도 별도 결정으로 AWAITING_DEV_MERGE 전환 + epic → master 최종 PR 생성 가능