### PR TITLE
[DC-2097] m09-01-01: playground connect 분리 + v1 envelope unwrap helper

### DIFF
--- a/playground.js
+++ b/playground.js
@@ -38,6 +38,37 @@
 ;(function () {
   'use strict'
 
+  // ── b08-01: v1 호환 envelope unwrap helper ──
+  // facade가 resolve로 돌려준 failure 응답을 throw로 변환한다.
+  // src/sign/assert.ts:_assertV1Success와 유사하지만 다른 정책 — playground 인라인 버전은
+  // success path에서 추가로 body.parameter까지 unwrap하고, throw 시 plain Error 사용
+  // (playground는 ProviderError import 회피 — vanilla JS).
+  // v1 특례(transaction.user_cancel)는 throw하지 않고 body를 그대로 반환 (호환 보존).
+  function _unwrapV1Envelope (resp) {
+    // v1 envelope이 아닌 경우(legacy result 형태 / null / primitive)는 그대로 반환
+    if (!resp || typeof resp !== 'object' || !resp.header || typeof resp.header !== 'object') {
+      return resp
+    }
+    var status = resp.header.status
+    if (status === 'success') {
+      // body.parameter가 있으면 그것을, 없으면 envelope 자체 (호출자가 알아서 처리)
+      return (resp.body && resp.body.parameter) || resp.body || resp
+    }
+    // status === 'failure' — v1 특례 보존
+    var cmd = resp.body && resp.body.command
+    var errCode = resp.body && resp.body.error && resp.body.error.code
+    if (cmd === 'transaction' && errCode === 'user_cancel') {
+      // user_cancel은 facade가 resolve로 돌려주는 v1 특례 — playground도 동일하게 resolve 흐름 유지
+      return resp.body.parameter || resp.body || resp
+    }
+    // 그 외 failure → throw (호출자의 .catch가 받아 normalizeError + appendLog error 분기)
+    var msg = (resp.body && resp.body.error && resp.body.error.message) || 'unknown failure'
+    var err = new Error(msg)
+    err.code = errCode || 'internal_error'
+    err.v1Envelope = resp
+    throw err
+  }
+
   // ── EVM chains runtime state (chains.json 로드 후 채워짐) ──
   // chainId → { displayName, defaultKeyPath, family }
   var evmChainsMap = {} // 로드 완료 전: 빈 객체
@@ -819,49 +850,36 @@
   }
 
   function onConnect () {
+    // b08-01: popup-only 진입점.
+    //   - dcent.getDeviceInfo() 호출 + state.device 채우기는 제거.
+    //   - device info fetch는 [getDeviceInfo] 트리 메뉴 + [Send]가 단일 책임자.
+    //   - listener 등록 + state.connected = true + 버튼 토글 + appendLog만 수행.
     btnConnect.disabled = true
     connDot.className = ''
     deviceInfoEl.textContent = 'Connecting...'
 
     var dcent = _getDcent()
-    if (!dcent || typeof dcent.getDeviceInfo !== 'function') {
+    if (!dcent || typeof dcent.setConnectionListener !== 'function') {
       updateIndicator({ connected: false, error: true, msg: 'Init failed: window.dcent not loaded' })
       btnConnect.disabled = false
       return
     }
 
-    // m08-01-05: facade가 transport/queue를 lazy 생성 — listener는 1회만 등록
+    // m08-01-05: facade가 transport/queue를 lazy 생성 — listener는 1회만 등록.
+    // popup은 첫 sign / getDeviceInfo 호출 시 lazy하게 열린다.
     _ensureStateListener()
 
-    var startMs = Date.now()
-    // m08-01-05: dcent.getDeviceInfo()는 v1 호환 응답 ({header, body}) 반환
-    dcent.getDeviceInfo().then(function (resp) {
-      // v1 응답 형식: { header: {status: 'success'}, body: { parameter: {...device fields...} } }
-      var device = (resp && resp.body && resp.body.parameter) || (resp && resp.result) || {}
-      state.device = device
-      state.connected = true
-      var latencyMs = Date.now() - startMs
-      updateIndicator({ connected: true, model: device.model, fw: device.firmware })
-      btnConnect.style.display = 'none'
-      btnDisconnect.style.display = ''
-      updateSendBtn()
-      appendLog({
-        method: 'getDeviceInfo',
-        request: {},
-        response: device,
-        latencyMs: latencyMs,
-        deviceFirmware: device.firmware,
-      })
-    }).catch(function (err) {
-      var errInfo = normalizeError(err)
-      updateIndicator({ connected: false, error: true, msg: errInfo.message })
-      btnConnect.disabled = false
-      appendLog({
-        method: 'getDeviceInfo',
-        request: {},
-        error: errInfo,
-        latencyMs: Date.now() - startMs,
-      })
+    // state.device는 건드리지 않는다 — [getDeviceInfo] 버튼이 단일 책임자.
+    state.connected = true
+    updateIndicator({ connected: true })
+    btnConnect.style.display = 'none'
+    btnDisconnect.style.display = ''
+    updateSendBtn()
+    appendLog({
+      method: '_connect',
+      request: {},
+      response: { msg: 'Ready (popup will open on first call)' },
+      latencyMs: 0,
     })
   }
 
@@ -948,8 +966,8 @@
     var startMs = Date.now()
     var dcent = _getDcent()
     // m08-01-05: facade의 v1 호환 API — 응답은 v1 envelope ({header, body.parameter})
-    dcent.getDeviceInfo().then(function (resp) {
-      var result = (resp && resp.body && resp.body.parameter) || (resp && resp.result) || resp
+    // b08-01: _unwrapV1Envelope이 success → body.parameter unwrap, failure → throw로 변환
+    dcent.getDeviceInfo().then(_unwrapV1Envelope).then(function (result) {
       state.device = result
       appendLog({
         method: 'getDeviceInfo',
@@ -1013,8 +1031,8 @@
     // CAIP-19 (예: 'eip155:1') 또는 v1 method 문자열 ('signMessage') 모두 지원.
     // 본 dispatcher는 v1 호환 'signMessage' method를 그대로 사용.
     var dcent = _getDcent()
-    dcent.sign({ chain: 'signMessage', payload: params }).then(function (resp) {
-      var result = (resp && resp.body && resp.body.parameter) || (resp && resp.result) || resp
+    // b08-01: _unwrapV1Envelope이 success → body.parameter unwrap, failure → throw로 변환
+    dcent.sign({ chain: 'signMessage', payload: params }).then(_unwrapV1Envelope).then(function (result) {
       appendLog({
         method: 'signMessage',
         chainId: chainId,
@@ -1081,8 +1099,8 @@
     var caipChain = (chainId && chainId.indexOf(':') !== -1)
       ? chainId
       : ('eip155:' + (chainId || 1))
-    dcent.sign({ chain: caipChain, payload: params }).then(function (resp) {
-      var result = (resp && resp.body && resp.body.parameter) || (resp && resp.result) || resp
+    // b08-01: _unwrapV1Envelope이 success → body.parameter unwrap, failure → throw로 변환
+    dcent.sign({ chain: caipChain, payload: params }).then(_unwrapV1Envelope).then(function (result) {
       appendLog({
         method: 'signTransaction',
         chainId: chainId,
@@ -1146,8 +1164,8 @@
     // chainId가 비어있으면 v1 method 'signTransaction' fallback (chainToMethod이 default 처리)
     var dcent = _getDcent()
     var caipChain = chainId || 'signTransaction'
-    dcent.sign({ chain: caipChain, payload: params }).then(function (resp) {
-      var result = (resp && resp.body && resp.body.parameter) || (resp && resp.result) || resp
+    // b08-01: _unwrapV1Envelope이 success → body.parameter unwrap, failure → throw로 변환
+    dcent.sign({ chain: caipChain, payload: params }).then(_unwrapV1Envelope).then(function (result) {
       appendLog({
         method: 'signTransaction',
         chainId: chainId,
@@ -1328,6 +1346,9 @@
     validateKeyPath: validateKeyPath,
     state: state,
     appendLog: appendLog,
+    // b08-01: envelope unwrap helper + popup-only onConnect 검증용 노출
+    _unwrapV1Envelope: _unwrapV1Envelope,
+    onConnect: onConnect,
     getLogEntries: function () { return state.logs },
     clearLogs: function () {
       state.logs = []

--- a/tests/unit/v2/playground.envelope.test.ts
+++ b/tests/unit/v2/playground.envelope.test.ts
@@ -1,0 +1,203 @@
+/**
+ * playground.envelope.test.ts — _unwrapV1Envelope helper + onConnect popup-only 회귀 테스트
+ *
+ * b08-01 (DC-2097): facade가 resolve로 돌려준 v1 failure envelope을 throw로 변환하고,
+ * onConnect는 popup-only 진입점이 되어 state.device를 미터치하는 동작을 검증한다.
+ *
+ * 관련 회귀 항목:
+ *   T-R-01: success envelope → body.parameter unwrap
+ *   T-R-02: failure envelope → throw (err.code, err.message 보존)
+ *   T-R-03: v1 특례 (transaction + user_cancel) → throw 안 함
+ *   T-R-04: legacy { result } shape → 입력 그대로 반환 (boundary-validation)
+ *   T-R-05: null / undefined → 입력 그대로 반환 (방어적)
+ *   T-R-07: onConnect 호출 후 state.device === null
+ *   T-R-08: onConnect 호출 후 state.connected === true + 버튼 토글
+ */
+import * as fs from 'fs'
+import * as path from 'path'
+
+// ── Playground 로드 helper ──────────────────────────────────────────────────
+function loadPlayground(): void {
+  const html = fs.readFileSync(
+    path.resolve(__dirname, '../../../index-v2.html'),
+    'utf8'
+  )
+  document.documentElement.innerHTML = html
+
+  ;(window as any).PopupTransport = function (_opts: any) {
+    return {
+      send: jest.fn().mockResolvedValue({ id: 'stub-id', result: {} }),
+      on: jest.fn(),
+      off: jest.fn(),
+      close: jest.fn().mockResolvedValue(undefined),
+    }
+  }
+  ;(window as any).SerialRequestQueue = function (_transport: any) {
+    return {
+      enqueue: jest.fn(function (task: any) { return task() }),
+      size: jest.fn().mockReturnValue(0),
+      clear: jest.fn(),
+    }
+  }
+  ;(window as any).ProviderError = class ProviderError extends Error {
+    code: number
+    constructor(code: number, message: string) {
+      super(message)
+      this.code = code
+    }
+  }
+
+  const playgroundSrc = fs.readFileSync(
+    path.resolve(__dirname, '../../../playground.js'),
+    'utf8'
+  )
+  // eslint-disable-next-line no-new-func
+  new Function(playgroundSrc)()
+}
+
+beforeEach(() => {
+  loadPlayground()
+})
+
+afterEach(() => {
+  document.documentElement.innerHTML = ''
+  delete (window as any)._playgroundTestAPI
+  delete (window as any).PopupTransport
+  delete (window as any).SerialRequestQueue
+  delete (window as any).ProviderError
+  delete (window as any).dcent
+})
+
+// ─────────────────────────────────────────────────────────
+// T-R-01: success envelope → body.parameter unwrap
+// ─────────────────────────────────────────────────────────
+it('T-R-01: _unwrapV1Envelope이 success envelope에서 body.parameter를 반환한다', () => {
+  const api = (window as any)._playgroundTestAPI
+  expect(typeof api._unwrapV1Envelope).toBe('function')
+
+  const envelope = {
+    header: { status: 'success' },
+    body: { parameter: { model: 'Biometric', firmware: '3.0.1' } },
+  }
+  const result = api._unwrapV1Envelope(envelope)
+  expect(result).toEqual({ model: 'Biometric', firmware: '3.0.1' })
+})
+
+// ─────────────────────────────────────────────────────────
+// T-R-02: failure envelope → throw (err.code, err.message 보존)
+// ─────────────────────────────────────────────────────────
+it('T-R-02: _unwrapV1Envelope이 failure envelope을 throw로 변환한다', () => {
+  const api = (window as any)._playgroundTestAPI
+  const envelope = {
+    header: { status: 'failure' },
+    body: { error: { code: 'X', message: 'm' } },
+  }
+  try {
+    api._unwrapV1Envelope(envelope)
+    throw new Error('expected throw')
+  } catch (err: any) {
+    expect(err.message).toBe('m')
+    expect(err.code).toBe('X')
+    expect(err.v1Envelope).toBe(envelope)
+  }
+})
+
+// ─────────────────────────────────────────────────────────
+// T-R-03: v1 특례 — transaction + user_cancel → throw 안 함 (호환 보존)
+// ─────────────────────────────────────────────────────────
+it('T-R-03: _unwrapV1Envelope이 transaction + user_cancel 특례를 보존한다', () => {
+  const api = (window as any)._playgroundTestAPI
+  const envelope = {
+    header: { status: 'failure' },
+    body: {
+      command: 'transaction',
+      error: { code: 'user_cancel', message: 'User cancelled' },
+    },
+  }
+  // throw하지 않아야 함
+  const result = api._unwrapV1Envelope(envelope)
+  // body 자체가 반환됨 (body.parameter 없으므로)
+  expect(result).toBe(envelope.body)
+})
+
+// ─────────────────────────────────────────────────────────
+// T-R-04: legacy { result } shape → 입력 그대로 반환 (boundary-validation)
+// ─────────────────────────────────────────────────────────
+it('T-R-04: _unwrapV1Envelope이 legacy { result } shape을 그대로 반환한다', () => {
+  const api = (window as any)._playgroundTestAPI
+  const legacy = { result: { ok: true } }
+  // header가 없으므로 envelope이 아닌 입력 — pass-through
+  expect(api._unwrapV1Envelope(legacy)).toBe(legacy)
+
+  const plain = { foo: 'bar' }
+  expect(api._unwrapV1Envelope(plain)).toBe(plain)
+})
+
+// ─────────────────────────────────────────────────────────
+// T-R-05: null / undefined → 입력 그대로 반환 (방어적)
+// ─────────────────────────────────────────────────────────
+it('T-R-05: _unwrapV1Envelope이 null / undefined 입력을 그대로 반환한다', () => {
+  const api = (window as any)._playgroundTestAPI
+  expect(api._unwrapV1Envelope(null)).toBeNull()
+  expect(api._unwrapV1Envelope(undefined)).toBeUndefined()
+  // primitive도 안전하게 pass-through
+  expect(api._unwrapV1Envelope('hello')).toBe('hello')
+  expect(api._unwrapV1Envelope(123)).toBe(123)
+})
+
+// ─────────────────────────────────────────────────────────
+// T-R-07: onConnect 호출 후 state.device === null (popup-only)
+// ─────────────────────────────────────────────────────────
+it('T-R-07: onConnect 호출 후 state.device === null (popup-only — device info 미fetch)', () => {
+  const api = (window as any)._playgroundTestAPI
+  expect(typeof api.onConnect).toBe('function')
+
+  // facade-shaped mock — getDeviceInfo는 호출되지 않아야 함을 검증
+  const mockGetDeviceInfo = jest.fn()
+  const mockDcent = {
+    sign: jest.fn(),
+    getDeviceInfo: mockGetDeviceInfo,
+    popupWindowClose: jest.fn(),
+    setConnectionListener: jest.fn(),
+  }
+  ;(window as any).dcent = mockDcent
+
+  // 초기 상태
+  expect(api.state.device).toBeNull()
+  expect(api.state.connected).toBe(false)
+
+  api.onConnect()
+
+  // device는 미터치
+  expect(api.state.device).toBeNull()
+  // getDeviceInfo도 호출되지 않음 (popup-only)
+  expect(mockGetDeviceInfo).not.toHaveBeenCalled()
+})
+
+// ─────────────────────────────────────────────────────────
+// T-R-08: onConnect 호출 후 state.connected === true + 버튼 토글 (UX 회귀 0)
+// ─────────────────────────────────────────────────────────
+it('T-R-08: onConnect 호출 후 state.connected === true + 버튼 토글 (UX 회귀 0)', () => {
+  const api = (window as any)._playgroundTestAPI
+
+  const mockDcent = {
+    sign: jest.fn(),
+    getDeviceInfo: jest.fn(),
+    popupWindowClose: jest.fn(),
+    setConnectionListener: jest.fn(),
+  }
+  ;(window as any).dcent = mockDcent
+
+  const btnConnect = document.getElementById('btn-connect') as HTMLButtonElement
+  const btnDisconnect = document.getElementById('btn-disconnect') as HTMLButtonElement
+  // 초기: connect 보임, disconnect 숨김
+  expect(btnConnect.style.display).not.toBe('none')
+
+  api.onConnect()
+
+  expect(api.state.connected).toBe(true)
+  expect(btnConnect.style.display).toBe('none')
+  expect(btnDisconnect.style.display).toBe('')
+  // setConnectionListener는 1회 등록되었어야 함
+  expect(mockDcent.setConnectionListener).toHaveBeenCalledTimes(1)
+})

--- a/tests/unit/v2/playground.smoke.test.ts
+++ b/tests/unit/v2/playground.smoke.test.ts
@@ -277,6 +277,90 @@ it('T-U-08: facade v1 형식 error → LogEntry.error 매핑', async () => {
 })
 
 // ─────────────────────────────────────────────────────────
+// T-R-06 (b08-01): facade가 failure envelope을 resolve로 돌려주는 시나리오에서
+// sendGetDeviceInfo 호출 → appendLog의 error 필드가 설정되고 state.device는 미오염
+// ─────────────────────────────────────────────────────────
+it('T-R-06: failure envelope resolve 시 error로 기록되고 state.device 미오염', async () => {
+  const api = (window as any)._playgroundTestAPI
+  api.clearLogs()
+
+  // facade가 v1 failure envelope을 resolve로 돌려주는 mock (silent success 흡수 시나리오)
+  const v1Failure = {
+    header: { status: 'failure' },
+    body: { error: { code: 'X', message: 'device is not connected' } },
+  }
+  const mockGetDeviceInfo = jest.fn().mockResolvedValue(v1Failure)
+  const mockDcent = {
+    sign: jest.fn(),
+    getDeviceInfo: mockGetDeviceInfo,
+    popupWindowClose: jest.fn(),
+    setConnectionListener: jest.fn(),
+  }
+
+  // 사전: state.device를 깨끗한 상태로 만들고 connected만 true (popup-only 모델)
+  api.simulateConnect(mockDcent, null, null)
+  // simulateConnect 직후 device는 null
+  expect(api.state.device).toBeNull()
+
+  // getDeviceInfo 선택 후 Send
+  const getDeviceItem = document.querySelector('[data-method-id="getDeviceInfo"]') as HTMLElement
+  getDeviceItem.click()
+  document.getElementById('btn-send')?.click()
+
+  // Promise resolve 대기
+  await new Promise((r) => setTimeout(r, 50))
+
+  const entries = api.getLogEntries()
+  expect(entries.length).toBeGreaterThan(0)
+  const lastEntry = entries[entries.length - 1]
+  // failure envelope이 silent success로 흡수되지 않고 error로 기록되어야 함
+  expect(lastEntry.error).toBeDefined()
+  expect(lastEntry.error.message).toBe('device is not connected')
+  // state.device는 오염되지 않아야 함
+  expect(api.state.device).toBeNull()
+})
+
+// ─────────────────────────────────────────────────────────
+// T-R-09 (b08-01): onConnect → tree에서 getDeviceInfo 선택 → [Send]로 state.device가 채워짐
+// E2E-style 단위 합 — onConnect는 popup-only, getDeviceInfo는 Send 경로의 단일 책임자
+// ─────────────────────────────────────────────────────────
+it('T-R-09: onConnect → getDeviceInfo Send 흐름에서 state.device가 채워진다', async () => {
+  const api = (window as any)._playgroundTestAPI
+
+  const deviceInfo = { model: 'Biometric', firmware: '3.0.1' }
+  const mockGetDeviceInfo = jest.fn().mockResolvedValue({
+    header: { status: 'success' },
+    body: { parameter: deviceInfo },
+  })
+  const mockDcent = {
+    sign: jest.fn(),
+    getDeviceInfo: mockGetDeviceInfo,
+    popupWindowClose: jest.fn(),
+    setConnectionListener: jest.fn(),
+  }
+  ;(window as any).dcent = mockDcent
+
+  // onConnect — popup-only (device 미터치)
+  api.onConnect()
+  expect(api.state.connected).toBe(true)
+  expect(api.state.device).toBeNull()
+  expect(mockGetDeviceInfo).not.toHaveBeenCalled()
+
+  // 트리에서 getDeviceInfo 선택 → Send
+  const getDeviceItem = document.querySelector('[data-method-id="getDeviceInfo"]') as HTMLElement
+  getDeviceItem.click()
+  document.getElementById('btn-send')?.click()
+
+  // Promise resolve 대기
+  await new Promise((r) => setTimeout(r, 50))
+
+  // getDeviceInfo 단일 책임자 — Send 시점에 호출됨
+  expect(mockGetDeviceInfo).toHaveBeenCalledTimes(1)
+  // state.device가 채워짐
+  expect(api.state.device).toEqual(deviceInfo)
+})
+
+// ─────────────────────────────────────────────────────────
 // T-U-09: state.connected === false 인 동안 모든 Send 버튼 disabled (Connect 후 활성화)
 // m08-01-05: state.transport → state.connected로 변경
 // ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

connector v2 playground의 **UX 책임 분리** ([Connect] popup-only로 + [getDeviceInfo] 단일 책임자) + **failure envelope을 throw로 변환하는 `_unwrapV1Envelope` helper 도입**. m09-01 epic의 첫 번째 child로서 m09-01-02 (sign API 마이그레이션) 작업의 base 정리 역할.

## Objective

- **ID**: `m09-01-01-playground-connect-and-envelope-unwrap`
- **Jira**: [DC-2097](https://iotrust.atlassian.net/browse/DC-2097) (parent: [DC-2133 epic](https://iotrust.atlassian.net/browse/DC-2133))
- **Epic**: `m09-01-00-connector-playground-v2-finalization` (epic branch: `epic/DC-2133_m09-01-connector-playground-v2-finalization`)
- **File**: `objectives/m09-01-01-playground-connect-and-envelope-unwrap.md` (dcent-web-sdk-uap 부모 리포 — 본문 하단 `<details>`에 전문 embed)

## Scope

- `_unwrapV1Envelope(resp)` helper를 `playground.js` 상단에 도입 (failure envelope → throw, v1 특례 `transaction + user_cancel`은 보존)
- 4개 함수 (`sendGetDeviceInfo`, `sendSignMessage`, `sendSignTxEvm`, `sendSignTxNonEvm`)에 `.then(_unwrapV1Envelope)` chain 적용
- `onConnect` 본문 단순화 (popup-only — `dcent.getDeviceInfo()` 호출 + `state.device` 채우기 제거)
- mock 모드 호환 유지 (`simulateConnect`)

## Non-scope

- v2 통합 sign API 1번 경로 마이그레이션 → m09-01-02
- chains.evm.json / presets.*.json 갱신 → m09-01-02
- chainToMethod 제거 → m09-04-01
- v1 wrapper 제거 → m09-04-01

## Background — b08-01 흡수

이 PR은 원래 brief objective `b08-01-playground-connect-vs-getdeviceinfo-separation`(Jira DC-2097)으로 작업됐다. pre-audit 결과 m09-01 epic에 자연스럽게 흡수되어야 한다는 결론으로 epic child `m09-01-01`로 승격됐고, **PR의 base를 master에서 epic branch로 retarget**(`gh pr edit 143 --base epic/...`)했다. 코드 변경은 그대로 유지된다:

- `331199f` [DC-2097] fix(playground): v1 failure envelope을 throw로 변환 + onConnect popup-only 분리
- `7e3882a` [DC-2097] test(playground): _unwrapV1Envelope + onConnect popup-only 회귀 가드

## Automated Verification

### 요약

- 총 명령: 6
- 통과: 6
- 실패: 0
- 타임아웃: 0

### 명령별 결과

| # | Command | T-XX | Status | Exit |
|---|---|---|---|---|
| 1 | `npm run unit-v2 -- tests/unit/v2/playground.envelope.test.ts` | T-R-01~05, T-R-07, T-R-08 | ✅ PASS | 0 |
| 2 | `npm run unit-v2 -- tests/unit/v2/playground.smoke.test.ts` | T-R-06, T-R-09 + 기존 T-U-01~09 | ✅ PASS | 0 |
| 3 | `npm run lint` | T-LINT-01 | ✅ PASS | 0 |
| 4 | `npm run tsc` | T-TSC-01 | ✅ PASS | 0 |
| 5 | `npm run build` | T-BUILD-01 | ✅ PASS | 0 |
| 6 | `grep -cE '\.then\(_unwrapV1Envelope\)' playground.js` | T-GREP-01 | ✅ PASS (= 4) | 0 |

### Baseline Checks (CI workflow와 동일)

- ✓ `yarn lint` (1s)
- ✓ `yarn build` (2s)
- ✓ `yarn unit-mock` (51s, 11 suites / 69 tests passed)
- ✓ `yarn unit-v2` (3s, 54 suites / 570 tests passed)

## T-XX Coverage

**총 13개 T-XX** — PASS 13, FAIL 0, BLOCKED 0, UNCOVERED 0

| T-XX | Description |
|---|---|
| T-R-01 | `_unwrapV1Envelope` success envelope → body.parameter |
| T-R-02 | failure envelope → throw (err.code/message 보존) |
| T-R-03 | transaction + user_cancel 특례 보존 |
| T-R-04 | legacy `{result}` 그대로 반환 |
| T-R-05 | null/undefined 그대로 반환 |
| T-R-06 | failure envelope resolve 시 error 기록 + state.device 미오염 |
| T-R-07 | onConnect 후 state.device === null (popup-only) |
| T-R-08 | onConnect 후 state.connected === true + 버튼 토글 |
| T-R-09 | onConnect → getDeviceInfo Send → state.device 채워짐 |
| T-LINT-01 | lint 통과 |
| T-TSC-01 | tsc 통과 |
| T-BUILD-01 | build 통과 |
| T-GREP-01 | `.then(_unwrapV1Envelope)` count === 4 |

## AST 기반 검증 (uap-verify-objective Step 7d)

- **Optional Parameter Wiring**: ✅ PASS (변경된 .ts/.tsx 파일 없음 — playground.js는 vanilla JS)
- **Forbidden Test Patterns**: ✅ PASS (0 findings, 2 files scanned)

## Checklist

- [x] Automated verification (`uap-verify-objective` PASS — 13/13 T-XX)
- [x] Baseline checks PASS (lint / build / unit-mock / unit-v2)
- [x] AST 기반 검증 PASS
- [x] CI 모든 체크 통과 (생성 시점 `lint-build-unit (22.x)` SUCCESS — 머지 전 재확인 필요)
- [ ] 사람 코드 리뷰
- [ ] 머지 (epic branch로)

---

## 상세 자료 (전문)

_`pr-body-embed-objective` 룰에 따라 objective 문서와 verification report 전문을 리뷰어 접근성을 위해 PR 본문에 embed합니다._

<details>
<summary><b>📄 Full Objective Specification</b> — <code>objectives/m09-01-01-playground-connect-and-envelope-unwrap.md</code></summary>

```yaml
---
id: m09-01-01-playground-connect-and-envelope-unwrap
status: IN_PROGRESS
type: feature
target-repo: dcent-web-connector
cycle: 09
epic: m09-01
base-branch: epic/DC-2133_m09-01-connector-playground-v2-finalization
depends-on: []
depends-on-shipped: []
related: [m08-01-05-playground-rewrite-and-migration-guide, m08-01-02-generic-sign-core, b08-01-playground-connect-vs-getdeviceinfo-separation]
source: ['m09-01-00 epic 대표 문서', '흡수: b08-01 (Jira DC-2097, PR #143 base를 epic branch로 retarget 완료)']
jira: DC-2097
branch: DC-2097_b08-01-playground-connect-vs-getdeviceinfo-separation
reviewers: [kekim-iotrust, hyochulan-iotrust]
---
```

### 1. 목적
connector v2 playground의 UX 책임 분리 + failure envelope unwrap helper 도입.

### 2. 스코프
- `_unwrapV1Envelope(resp)` helper 도입
- 4개 함수에 `.then(_unwrapV1Envelope)` chain
- `onConnect` popup-only 단순화
- mock 모드 호환 유지

### 4. 상세 설계 (요약)

```javascript
// playground.js 상단
function _unwrapV1Envelope (resp) {
  if (!resp || typeof resp !== 'object' || !resp.header || typeof resp.header !== 'object') {
    return resp
  }
  var status = resp.header.status
  if (status === 'success') {
    return (resp.body && resp.body.parameter) || resp.body || resp
  }
  // status === 'failure' — v1 특례 보존
  var cmd = resp.body && resp.body.command
  var errCode = resp.body && resp.body.error && resp.body.error.code
  if (cmd === 'transaction' && errCode === 'user_cancel') {
    return resp.body.parameter || resp.body || resp
  }
  var msg = (resp.body && resp.body.error && resp.body.error.message) || 'unknown failure'
  var err = new Error(msg)
  err.code = errCode || 'internal_error'
  err.v1Envelope = resp
  throw err
}
```

### 적용 룰
- `objectives-doc-format`
- `automated-verification-required`
- `objective-pr-granularity`
- `objective-no-auto-merge`
- `boundary-validation` (`_unwrapV1Envelope`이 응답 boundary 검증)
- `error-handling-consistency` (failure envelope → throw 통일)

</details>

<details>
<summary><b>🔍 Full Verification Report</b> — <code>objectives/.prepare/m09-01-01-playground-connect-and-envelope-unwrap/verification-report.md</code></summary>

**Verdict**: PASS ✅
**Jira**: DC-2097 (parent=DC-2133 epic)
**Branch**: DC-2097_b08-01-playground-connect-vs-getdeviceinfo-separation
**Target Repo**: dcent-web-connector

### 요약
- 총 명령: 6
- 통과: 6
- 실패: 0
- 실행 소요 시간: ~30s

### T-XX Coverage
**총 13개 T-XX** — PASS 13, FAIL 0, BLOCKED 0, UNCOVERED 0

### Protocol Drift Pre-Check
SKIP (no interface signal — 변경 파일은 playground.js + 테스트 2개만)

### 명령별 결과
1. `npx jest --config jest.v2.config.js --runInBand tests/unit/v2/playground.envelope.test.ts` → ✅ PASS (7/7 tests)
2. `npx jest --config jest.v2.config.js --runInBand tests/unit/v2/playground.smoke.test.ts` → ✅ PASS (11/11 tests)
3. `npm run lint` → ✅ PASS
4. `npm run tsc` → ✅ PASS
5. `npm run build` → ✅ PASS (webpack 3 warnings, bundle size only)
6. `grep -cE '\.then\(_unwrapV1Envelope\)' playground.js` → ✅ PASS (GREP_COUNT=4)

### AST 기반 검증
- **Optional Parameter Wiring**: PASS (0 findings, skipped: 변경된 .ts/.tsx 파일 없음)
- **Forbidden Test Patterns**: PASS (0 findings, 2 files scanned)

### Guide Gap
스킵 (target-repo=dcent-web-connector, not dcent-hybrid-webview-v2)

### Scope Coherence Check
스킵 (source: epic 대표 문서 + HANDOFF — Jira/CS 티켓 아님)

</details>

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/uap-autopilot-objective m09-01-01-playground-connect-and-envelope-unwrap`
