### PR TITLE
[DC-2133] m09-01: connector v2 playground v2 sign API 1번 경로 정착

### DIFF
--- a/playground.js
+++ b/playground.js
@@ -38,6 +38,37 @@
 ;(function () {
   'use strict'
 
+  // ── b08-01: v1 호환 envelope unwrap helper ──
+  // facade가 resolve로 돌려준 failure 응답을 throw로 변환한다.
+  // src/sign/assert.ts:_assertV1Success와 유사하지만 다른 정책 — playground 인라인 버전은
+  // success path에서 추가로 body.parameter까지 unwrap하고, throw 시 plain Error 사용
+  // (playground는 ProviderError import 회피 — vanilla JS).
+  // v1 특례(transaction.user_cancel)는 throw하지 않고 body를 그대로 반환 (호환 보존).
+  function _unwrapV1Envelope (resp) {
+    // v1 envelope이 아닌 경우(legacy result 형태 / null / primitive)는 그대로 반환
+    if (!resp || typeof resp !== 'object' || !resp.header || typeof resp.header !== 'object') {
+      return resp
+    }
+    var status = resp.header.status
+    if (status === 'success') {
+      // body.parameter가 있으면 그것을, 없으면 envelope 자체 (호출자가 알아서 처리)
+      return (resp.body && resp.body.parameter) || resp.body || resp
+    }
+    // status === 'failure' — v1 특례 보존
+    var cmd = resp.body && resp.body.command
+    var errCode = resp.body && resp.body.error && resp.body.error.code
+    if (cmd === 'transaction' && errCode === 'user_cancel') {
+      // user_cancel은 facade가 resolve로 돌려주는 v1 특례 — playground도 동일하게 resolve 흐름 유지
+      return resp.body.parameter || resp.body || resp
+    }
+    // 그 외 failure → throw (호출자의 .catch가 받아 normalizeError + appendLog error 분기)
+    var msg = (resp.body && resp.body.error && resp.body.error.message) || 'unknown failure'
+    var err = new Error(msg)
+    err.code = errCode || 'internal_error'
+    err.v1Envelope = resp
+    throw err
+  }
+
   // ── EVM chains runtime state (chains.json 로드 후 채워짐) ──
   // chainId → { displayName, defaultKeyPath, family }
   var evmChainsMap = {} // 로드 완료 전: 빈 객체
@@ -819,49 +850,36 @@
   }
 
   function onConnect () {
+    // b08-01: popup-only 진입점.
+    //   - dcent.getDeviceInfo() 호출 + state.device 채우기는 제거.
+    //   - device info fetch는 [getDeviceInfo] 트리 메뉴 + [Send]가 단일 책임자.
+    //   - listener 등록 + state.connected = true + 버튼 토글 + appendLog만 수행.
     btnConnect.disabled = true
     connDot.className = ''
     deviceInfoEl.textContent = 'Connecting...'
 
     var dcent = _getDcent()
-    if (!dcent || typeof dcent.getDeviceInfo !== 'function') {
+    if (!dcent || typeof dcent.setConnectionListener !== 'function') {
       updateIndicator({ connected: false, error: true, msg: 'Init failed: window.dcent not loaded' })
       btnConnect.disabled = false
       return
     }
 
-    // m08-01-05: facade가 transport/queue를 lazy 생성 — listener는 1회만 등록
+    // m08-01-05: facade가 transport/queue를 lazy 생성 — listener는 1회만 등록.
+    // popup은 첫 sign / getDeviceInfo 호출 시 lazy하게 열린다.
     _ensureStateListener()
 
-    var startMs = Date.now()
-    // m08-01-05: dcent.getDeviceInfo()는 v1 호환 응답 ({header, body}) 반환
-    dcent.getDeviceInfo().then(function (resp) {
-      // v1 응답 형식: { header: {status: 'success'}, body: { parameter: {...device fields...} } }
-      var device = (resp && resp.body && resp.body.parameter) || (resp && resp.result) || {}
-      state.device = device
-      state.connected = true
-      var latencyMs = Date.now() - startMs
-      updateIndicator({ connected: true, model: device.model, fw: device.firmware })
-      btnConnect.style.display = 'none'
-      btnDisconnect.style.display = ''
-      updateSendBtn()
-      appendLog({
-        method: 'getDeviceInfo',
-        request: {},
-        response: device,
-        latencyMs: latencyMs,
-        deviceFirmware: device.firmware,
-      })
-    }).catch(function (err) {
-      var errInfo = normalizeError(err)
-      updateIndicator({ connected: false, error: true, msg: errInfo.message })
-      btnConnect.disabled = false
-      appendLog({
-        method: 'getDeviceInfo',
-        request: {},
-        error: errInfo,
-        latencyMs: Date.now() - startMs,
-      })
+    // state.device는 건드리지 않는다 — [getDeviceInfo] 버튼이 단일 책임자.
+    state.connected = true
+    updateIndicator({ connected: true })
+    btnConnect.style.display = 'none'
+    btnDisconnect.style.display = ''
+    updateSendBtn()
+    appendLog({
+      method: '_connect',
+      request: {},
+      response: { msg: 'Ready (popup will open on first call)' },
+      latencyMs: 0,
     })
   }
 
@@ -948,8 +966,8 @@
     var startMs = Date.now()
     var dcent = _getDcent()
     // m08-01-05: facade의 v1 호환 API — 응답은 v1 envelope ({header, body.parameter})
-    dcent.getDeviceInfo().then(function (resp) {
-      var result = (resp && resp.body && resp.body.parameter) || (resp && resp.result) || resp
+    // b08-01: _unwrapV1Envelope이 success → body.parameter unwrap, failure → throw로 변환
+    dcent.getDeviceInfo().then(_unwrapV1Envelope).then(function (result) {
       state.device = result
       appendLog({
         method: 'getDeviceInfo',
@@ -1013,8 +1031,8 @@
     // CAIP-19 (예: 'eip155:1') 또는 v1 method 문자열 ('signMessage') 모두 지원.
     // 본 dispatcher는 v1 호환 'signMessage' method를 그대로 사용.
     var dcent = _getDcent()
-    dcent.sign({ chain: 'signMessage', payload: params }).then(function (resp) {
-      var result = (resp && resp.body && resp.body.parameter) || (resp && resp.result) || resp
+    // b08-01: _unwrapV1Envelope이 success → body.parameter unwrap, failure → throw로 변환
+    dcent.sign({ chain: 'signMessage', payload: params }).then(_unwrapV1Envelope).then(function (result) {
       appendLog({
         method: 'signMessage',
         chainId: chainId,
@@ -1081,8 +1099,8 @@
     var caipChain = (chainId && chainId.indexOf(':') !== -1)
       ? chainId
       : ('eip155:' + (chainId || 1))
-    dcent.sign({ chain: caipChain, payload: params }).then(function (resp) {
-      var result = (resp && resp.body && resp.body.parameter) || (resp && resp.result) || resp
+    // b08-01: _unwrapV1Envelope이 success → body.parameter unwrap, failure → throw로 변환
+    dcent.sign({ chain: caipChain, payload: params }).then(_unwrapV1Envelope).then(function (result) {
       appendLog({
         method: 'signTransaction',
         chainId: chainId,
@@ -1146,8 +1164,8 @@
     // chainId가 비어있으면 v1 method 'signTransaction' fallback (chainToMethod이 default 처리)
     var dcent = _getDcent()
     var caipChain = chainId || 'signTransaction'
-    dcent.sign({ chain: caipChain, payload: params }).then(function (resp) {
-      var result = (resp && resp.body && resp.body.parameter) || (resp && resp.result) || resp
+    // b08-01: _unwrapV1Envelope이 success → body.parameter unwrap, failure → throw로 변환
+    dcent.sign({ chain: caipChain, payload: params }).then(_unwrapV1Envelope).then(function (result) {
       appendLog({
         method: 'signTransaction',
         chainId: chainId,
@@ -1328,6 +1346,9 @@
     validateKeyPath: validateKeyPath,
     state: state,
     appendLog: appendLog,
+    // b08-01: envelope unwrap helper + popup-only onConnect 검증용 노출
+    _unwrapV1Envelope: _unwrapV1Envelope,
+    onConnect: onConnect,
     getLogEntries: function () { return state.logs },
     clearLogs: function () {
       state.logs = []

--- a/playground.js
+++ b/playground.js
@@ -153,14 +153,14 @@
               kind: 'method',
               id: 'signMessage:eth:personal',
               label: 'personal_sign',
-              chainId: 'eip155:1',
+              chainId: 'eip155:1/slip44:60',
               metaKind: 'personal',
             },
             {
               kind: 'method',
               id: 'signMessage:eth:eip712-v3',
               label: 'signTypedData_v3',
-              chainId: 'eip155:1',
+              chainId: 'eip155:1/slip44:60',
               metaKind: 'eip712',
               metaVersion: 'V3',
             },
@@ -168,7 +168,7 @@
               kind: 'method',
               id: 'signMessage:eth:eip712-v4',
               label: 'signTypedData_v4',
-              chainId: 'eip155:1',
+              chainId: 'eip155:1/slip44:60',
               metaKind: 'eip712',
               metaVersion: 'V4',
             },
@@ -182,7 +182,7 @@
               kind: 'method',
               id: 'signMessage:sol:raw',
               label: 'signMessage (raw)',
-              chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+              chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
               metaKind: 'raw',
             },
           ],
@@ -1091,16 +1091,12 @@
     var params = { chainId: chainId, keyPath: keyPath, transaction: txObj }
     var startMs = Date.now()
 
-    // m08-01-05: EVM signTx는 통합 sign API 사용 — chain은 CAIP-19 형식 (eip155:N)
-    // chainId가 이미 'eip155:N' 형식이면 그대로 사용, 숫자만이면 prefix 추가
-    // 본 dispatcher는 통합 API를 시연. dApp이 v1 wrapper를 더 좋아하면
-    //   dcent.getEthereumSignedTransaction(coinType, nonce, gasPrice, ...) 도 사용 가능.
+    // m09-01-02: 1번 경로 마이그레이션 — chain intent literal 'signTransaction' 사용 + payload.chainId는 CAIP-19.
+    // connector chainToMethod의 PREFIX_TO_METHOD 미매치 → fallthrough → sdk MethodRegistry hit.
+    // chainId(CAIP-19)는 sdk resolveChainId가 wallet-models registry로 currency 결정.
     var dcent = _getDcent()
-    var caipChain = (chainId && chainId.indexOf(':') !== -1)
-      ? chainId
-      : ('eip155:' + (chainId || 1))
     // b08-01: _unwrapV1Envelope이 success → body.parameter unwrap, failure → throw로 변환
-    dcent.sign({ chain: caipChain, payload: params }).then(_unwrapV1Envelope).then(function (result) {
+    dcent.sign({ chain: 'signTransaction', payload: params }).then(_unwrapV1Envelope).then(function (result) {
       appendLog({
         method: 'signTransaction',
         chainId: chainId,
@@ -1160,12 +1156,11 @@
     var params = { chainId: chainId, keyPath: keyPath, transaction: txObj }
     var startMs = Date.now()
 
-    // m08-01-05: 비-EVM signTx도 통합 sign API — chainId가 이미 CAIP-19 형식 (bip122:..., cosmos:...)
-    // chainId가 비어있으면 v1 method 'signTransaction' fallback (chainToMethod이 default 처리)
+    // m09-01-02: 1번 경로 마이그레이션 — chain intent literal 'signTransaction' 사용 + payload.chainId는 CAIP-19.
+    // bip122/solana/xrpl/cosmos/stellar/hedera 등 비-EVM도 동일 패턴. chains.json의 chainId가 이미 CAIP-19.
     var dcent = _getDcent()
-    var caipChain = chainId || 'signTransaction'
     // b08-01: _unwrapV1Envelope이 success → body.parameter unwrap, failure → throw로 변환
-    dcent.sign({ chain: caipChain, payload: params }).then(_unwrapV1Envelope).then(function (result) {
+    dcent.sign({ chain: 'signTransaction', payload: params }).then(_unwrapV1Envelope).then(function (result) {
       appendLog({
         method: 'signTransaction',
         chainId: chainId,

--- a/playground/chains.evm.json
+++ b/playground/chains.evm.json
@@ -1,384 +1,384 @@
 [
   {
-    "chainId": "eip155:1",
+    "chainId": "eip155:1/slip44:60",
     "family": "ethereum",
     "displayName": "Ethereum",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:30",
+    "chainId": "eip155:30/slip44:60",
     "family": "ethereum",
     "displayName": "RSK Smart Bitcoin",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:8217",
+    "chainId": "eip155:8217/slip44:60",
     "family": "ethereum",
     "displayName": "Kaia",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:61",
+    "chainId": "eip155:61/slip44:60",
     "family": "ethereum",
     "displayName": "Ethereum Classic",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:256",
+    "chainId": "eip155:256/slip44:60",
     "family": "ethereum",
     "displayName": "Luniverse",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:50",
+    "chainId": "eip155:50/slip44:60",
     "family": "ethereum",
     "displayName": "XDC (XinFin)",
     "defaultKeyPath": "m/44'/550'/0'/0/0"
   },
   {
-    "chainId": "eip155:56",
+    "chainId": "eip155:56/slip44:60",
     "family": "ethereum",
     "displayName": "Binance Smart Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:10",
+    "chainId": "eip155:10/slip44:60",
     "family": "ethereum",
     "displayName": "Optimism",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:11",
+    "chainId": "eip155:11/slip44:60",
     "family": "ethereum",
     "displayName": "Metadium",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:14",
+    "chainId": "eip155:14/slip44:60",
     "family": "ethereum",
     "displayName": "Flare Network",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:19",
+    "chainId": "eip155:19/slip44:60",
     "family": "ethereum",
     "displayName": "Songbird Canary-Network",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:25",
+    "chainId": "eip155:25/slip44:60",
     "family": "ethereum",
     "displayName": "Cronos",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:66",
+    "chainId": "eip155:66/slip44:60",
     "family": "ethereum",
     "displayName": "OKX Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:100",
+    "chainId": "eip155:100/slip44:60",
     "family": "ethereum",
     "displayName": "Gnosis",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:246",
+    "chainId": "eip155:246/slip44:60",
     "family": "ethereum",
     "displayName": "Energy Web Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:248",
+    "chainId": "eip155:248/slip44:60",
     "family": "ethereum",
     "displayName": "Oasys",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:250",
+    "chainId": "eip155:250/slip44:60",
     "family": "ethereum",
     "displayName": "Fantom Opera",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:255",
+    "chainId": "eip155:255/slip44:60",
     "family": "ethereum",
     "displayName": "Kroma",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:288",
+    "chainId": "eip155:288/slip44:60",
     "family": "ethereum",
     "displayName": "Boba",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:321",
+    "chainId": "eip155:321/slip44:60",
     "family": "ethereum",
     "displayName": "KCC",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:592",
+    "chainId": "eip155:592/slip44:60",
     "family": "ethereum",
     "displayName": "Astar EVM",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:2017",
+    "chainId": "eip155:2017/slip44:60",
     "family": "ethereum",
     "displayName": "Orbit Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:7518",
+    "chainId": "eip155:7518/slip44:60",
     "family": "ethereum",
     "displayName": "MEVerse",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:8453",
+    "chainId": "eip155:8453/slip44:60",
     "family": "ethereum",
     "displayName": "Base",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:42161",
+    "chainId": "eip155:42161/slip44:60",
     "family": "ethereum",
     "displayName": "Arbitrum One",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:42220",
+    "chainId": "eip155:42220/slip44:60",
     "family": "ethereum",
     "displayName": "Celo",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:43114",
+    "chainId": "eip155:43114/slip44:60",
     "family": "ethereum",
     "displayName": "Avalanche C-Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:1666600000",
+    "chainId": "eip155:1666600000/slip44:60",
     "family": "ethereum",
     "displayName": "Harmony",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:11297108109",
+    "chainId": "eip155:11297108109/slip44:60",
     "family": "ethereum",
     "displayName": "Palm",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:137",
+    "chainId": "eip155:137/slip44:60",
     "family": "ethereum",
     "displayName": "Polygon",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:3776",
+    "chainId": "eip155:3776/slip44:60",
     "family": "ethereum",
     "displayName": "Astar zkEVM",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:612",
+    "chainId": "eip155:612/slip44:60",
     "family": "ethereum",
     "displayName": "EIOB Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:4613",
+    "chainId": "eip155:4613/slip44:60",
     "family": "ethereum",
     "displayName": "VERY Mainnet",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:37",
+    "chainId": "eip155:37/slip44:60",
     "family": "ethereum",
     "displayName": "XPLA",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:81",
+    "chainId": "eip155:81/slip44:60",
     "family": "ethereum",
     "displayName": "Japan Open Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:1625",
+    "chainId": "eip155:1625/slip44:60",
     "family": "ethereum",
     "displayName": "Gravity Alpha",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:102030",
+    "chainId": "eip155:102030/slip44:60",
     "family": "ethereum",
     "displayName": "Creditcoin EVM",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:314",
+    "chainId": "eip155:314/slip44:60",
     "family": "ethereum",
     "displayName": "Filecoin EVM",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:1689",
+    "chainId": "eip155:1689/slip44:60",
     "family": "ethereum",
     "displayName": "NERO",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:146",
+    "chainId": "eip155:146/slip44:60",
     "family": "ethereum",
     "displayName": "Sonic",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:22776",
+    "chainId": "eip155:22776/slip44:60",
     "family": "ethereum",
     "displayName": "MAP Protocol",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:1868",
+    "chainId": "eip155:1868/slip44:60",
     "family": "ethereum",
     "displayName": "Soneium",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:534352",
+    "chainId": "eip155:534352/slip44:60",
     "family": "ethereum",
     "displayName": "Scroll",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:41923",
+    "chainId": "eip155:41923/slip44:60",
     "family": "ethereum",
     "displayName": "Edu Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:5050",
+    "chainId": "eip155:5050/slip44:60",
     "family": "ethereum",
     "displayName": "Skate",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:888888888",
+    "chainId": "eip155:888888888/slip44:60",
     "family": "ethereum",
     "displayName": "Ancient8",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:88888",
+    "chainId": "eip155:88888/slip44:60",
     "family": "ethereum",
     "displayName": "Chiliz",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:167000",
+    "chainId": "eip155:167000/slip44:60",
     "family": "ethereum",
     "displayName": "Taiko Alethia",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:80094",
+    "chainId": "eip155:80094/slip44:60",
     "family": "ethereum",
     "displayName": "Berachain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:1514",
+    "chainId": "eip155:1514/slip44:60",
     "family": "ethereum",
     "displayName": "Story Network",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:1440000",
+    "chainId": "eip155:1440000/slip44:60",
     "family": "ethereum",
     "displayName": "XRPL EVM",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:169",
+    "chainId": "eip155:169/slip44:60",
     "family": "ethereum",
     "displayName": "Manta Pacific",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:20250217",
+    "chainId": "eip155:20250217/slip44:60",
     "family": "ethereum",
     "displayName": "Xphere",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:999",
+    "chainId": "eip155:999/slip44:60",
     "family": "ethereum",
     "displayName": "HyperEVM",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:484",
+    "chainId": "eip155:484/slip44:60",
     "family": "ethereum",
     "displayName": "Camp Mainnet",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:6985385",
+    "chainId": "eip155:6985385/slip44:60",
     "family": "ethereum",
     "displayName": "Humanity Protocol",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:210000",
+    "chainId": "eip155:210000/slip44:60",
     "family": "ethereum",
     "displayName": "JuChain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:50104",
+    "chainId": "eip155:50104/slip44:60",
     "family": "ethereum",
     "displayName": "Sophon",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:4352",
+    "chainId": "eip155:4352/slip44:60",
     "family": "ethereum",
     "displayName": "MemeCore",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:98866",
+    "chainId": "eip155:98866/slip44:60",
     "family": "ethereum",
     "displayName": "Plume",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:1776",
+    "chainId": "eip155:1776/slip44:60",
     "family": "ethereum",
     "displayName": "Injective",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:143",
+    "chainId": "eip155:143/slip44:60",
     "family": "ethereum",
     "displayName": "Monad Mainnet",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:7300",
+    "chainId": "eip155:7300/slip44:60",
     "family": "ethereum",
     "displayName": "XPLAVerse",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:204",
+    "chainId": "eip155:204/slip44:60",
     "family": "ethereum",
     "displayName": "opBNB",
     "defaultKeyPath": "m/44'/60'/0'/0/0"

--- a/playground/chains.json
+++ b/playground/chains.json
@@ -1,500 +1,494 @@
 [
   {
-    "chainId": "eip155:1",
+    "chainId": "eip155:1/slip44:60",
     "family": "ethereum",
     "displayName": "Ethereum",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:30",
+    "chainId": "eip155:30/slip44:60",
     "family": "ethereum",
     "displayName": "RSK Smart Bitcoin",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:8217",
+    "chainId": "eip155:8217/slip44:60",
     "family": "ethereum",
     "displayName": "Kaia",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:61",
+    "chainId": "eip155:61/slip44:60",
     "family": "ethereum",
     "displayName": "Ethereum Classic",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:256",
+    "chainId": "eip155:256/slip44:60",
     "family": "ethereum",
     "displayName": "Luniverse",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:50",
+    "chainId": "eip155:50/slip44:60",
     "family": "ethereum",
     "displayName": "XDC (XinFin)",
     "defaultKeyPath": "m/44'/550'/0'/0/0"
   },
   {
-    "chainId": "eip155:56",
+    "chainId": "eip155:56/slip44:60",
     "family": "ethereum",
     "displayName": "Binance Smart Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:10",
+    "chainId": "eip155:10/slip44:60",
     "family": "ethereum",
     "displayName": "Optimism",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:11",
+    "chainId": "eip155:11/slip44:60",
     "family": "ethereum",
     "displayName": "Metadium",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:14",
+    "chainId": "eip155:14/slip44:60",
     "family": "ethereum",
     "displayName": "Flare Network",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:19",
+    "chainId": "eip155:19/slip44:60",
     "family": "ethereum",
     "displayName": "Songbird Canary-Network",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:25",
+    "chainId": "eip155:25/slip44:60",
     "family": "ethereum",
     "displayName": "Cronos",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:66",
+    "chainId": "eip155:66/slip44:60",
     "family": "ethereum",
     "displayName": "OKX Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:100",
+    "chainId": "eip155:100/slip44:60",
     "family": "ethereum",
     "displayName": "Gnosis",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:246",
+    "chainId": "eip155:246/slip44:60",
     "family": "ethereum",
     "displayName": "Energy Web Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:248",
+    "chainId": "eip155:248/slip44:60",
     "family": "ethereum",
     "displayName": "Oasys",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:250",
+    "chainId": "eip155:250/slip44:60",
     "family": "ethereum",
     "displayName": "Fantom Opera",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:255",
+    "chainId": "eip155:255/slip44:60",
     "family": "ethereum",
     "displayName": "Kroma",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:288",
+    "chainId": "eip155:288/slip44:60",
     "family": "ethereum",
     "displayName": "Boba",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:321",
+    "chainId": "eip155:321/slip44:60",
     "family": "ethereum",
     "displayName": "KCC",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:592",
+    "chainId": "eip155:592/slip44:60",
     "family": "ethereum",
     "displayName": "Astar EVM",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:2017",
+    "chainId": "eip155:2017/slip44:60",
     "family": "ethereum",
     "displayName": "Orbit Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:7518",
+    "chainId": "eip155:7518/slip44:60",
     "family": "ethereum",
     "displayName": "MEVerse",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:8453",
+    "chainId": "eip155:8453/slip44:60",
     "family": "ethereum",
     "displayName": "Base",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:42161",
+    "chainId": "eip155:42161/slip44:60",
     "family": "ethereum",
     "displayName": "Arbitrum One",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:42220",
+    "chainId": "eip155:42220/slip44:60",
     "family": "ethereum",
     "displayName": "Celo",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:43114",
+    "chainId": "eip155:43114/slip44:60",
     "family": "ethereum",
     "displayName": "Avalanche C-Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:1666600000",
+    "chainId": "eip155:1666600000/slip44:60",
     "family": "ethereum",
     "displayName": "Harmony",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:11297108109",
+    "chainId": "eip155:11297108109/slip44:60",
     "family": "ethereum",
     "displayName": "Palm",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:137",
+    "chainId": "eip155:137/slip44:60",
     "family": "ethereum",
     "displayName": "Polygon",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "conflux:cfx",
+    "chainId": "conflux:cfx/slip44:503",
     "family": "conflux",
     "displayName": "Conflux",
     "defaultKeyPath": "m/44'/60'/0'"
   },
   {
-    "chainId": "eip155:3776",
+    "chainId": "eip155:3776/slip44:60",
     "family": "ethereum",
     "displayName": "Astar zkEVM",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:612",
+    "chainId": "eip155:612/slip44:60",
     "family": "ethereum",
     "displayName": "EIOB Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:4613",
+    "chainId": "eip155:4613/slip44:60",
     "family": "ethereum",
     "displayName": "VERY Mainnet",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:37",
+    "chainId": "eip155:37/slip44:60",
     "family": "ethereum",
     "displayName": "XPLA",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:81",
+    "chainId": "eip155:81/slip44:60",
     "family": "ethereum",
     "displayName": "Japan Open Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:1625",
+    "chainId": "eip155:1625/slip44:60",
     "family": "ethereum",
     "displayName": "Gravity Alpha",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:102030",
+    "chainId": "eip155:102030/slip44:60",
     "family": "ethereum",
     "displayName": "Creditcoin EVM",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:314",
+    "chainId": "eip155:314/slip44:60",
     "family": "ethereum",
     "displayName": "Filecoin EVM",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:1689",
+    "chainId": "eip155:1689/slip44:60",
     "family": "ethereum",
     "displayName": "NERO",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:146",
+    "chainId": "eip155:146/slip44:60",
     "family": "ethereum",
     "displayName": "Sonic",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:22776",
+    "chainId": "eip155:22776/slip44:60",
     "family": "ethereum",
     "displayName": "MAP Protocol",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:1868",
+    "chainId": "eip155:1868/slip44:60",
     "family": "ethereum",
     "displayName": "Soneium",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:534352",
+    "chainId": "eip155:534352/slip44:60",
     "family": "ethereum",
     "displayName": "Scroll",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:41923",
+    "chainId": "eip155:41923/slip44:60",
     "family": "ethereum",
     "displayName": "Edu Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:5050",
+    "chainId": "eip155:5050/slip44:60",
     "family": "ethereum",
     "displayName": "Skate",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:888888888",
+    "chainId": "eip155:888888888/slip44:60",
     "family": "ethereum",
     "displayName": "Ancient8",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:88888",
+    "chainId": "eip155:88888/slip44:60",
     "family": "ethereum",
     "displayName": "Chiliz",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:167000",
+    "chainId": "eip155:167000/slip44:60",
     "family": "ethereum",
     "displayName": "Taiko Alethia",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:80094",
+    "chainId": "eip155:80094/slip44:60",
     "family": "ethereum",
     "displayName": "Berachain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:1514",
+    "chainId": "eip155:1514/slip44:60",
     "family": "ethereum",
     "displayName": "Story Network",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:1440000",
+    "chainId": "eip155:1440000/slip44:60",
     "family": "ethereum",
     "displayName": "XRPL EVM",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:169",
+    "chainId": "eip155:169/slip44:60",
     "family": "ethereum",
     "displayName": "Manta Pacific",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:20250217",
+    "chainId": "eip155:20250217/slip44:60",
     "family": "ethereum",
     "displayName": "Xphere",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:999",
+    "chainId": "eip155:999/slip44:60",
     "family": "ethereum",
     "displayName": "HyperEVM",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:484",
+    "chainId": "eip155:484/slip44:60",
     "family": "ethereum",
     "displayName": "Camp Mainnet",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:6985385",
+    "chainId": "eip155:6985385/slip44:60",
     "family": "ethereum",
     "displayName": "Humanity Protocol",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:210000",
+    "chainId": "eip155:210000/slip44:60",
     "family": "ethereum",
     "displayName": "JuChain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:50104",
+    "chainId": "eip155:50104/slip44:60",
     "family": "ethereum",
     "displayName": "Sophon",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:4352",
+    "chainId": "eip155:4352/slip44:60",
     "family": "ethereum",
     "displayName": "MemeCore",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:98866",
+    "chainId": "eip155:98866/slip44:60",
     "family": "ethereum",
     "displayName": "Plume",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:1776",
+    "chainId": "eip155:1776/slip44:60",
     "family": "ethereum",
     "displayName": "Injective",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:143",
+    "chainId": "eip155:143/slip44:60",
     "family": "ethereum",
     "displayName": "Monad Mainnet",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:7300",
+    "chainId": "eip155:7300/slip44:60",
     "family": "ethereum",
     "displayName": "XPLAVerse",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:204",
+    "chainId": "eip155:204/slip44:60",
     "family": "ethereum",
     "displayName": "opBNB",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "bip122:000000000019d6689c085ae165831e93",
+    "chainId": "bip122:000000000019d6689c085ae165831e93/slip44:0",
     "family": "bitcoin",
     "displayName": "Bitcoin",
     "defaultKeyPath": "m/84'/0'/0'/0/0"
   },
   {
-    "chainId": "bip122:000000000000000000651ef99cb9fcbe",
+    "chainId": "bip122:000000000000000000651ef99cb9fcbe/slip44:145",
     "family": "bitcoin",
     "displayName": "Bitcoin Cash",
     "defaultKeyPath": "m/84'/145'/0'/0/0"
   },
   {
-    "chainId": "bip122:12a765e31ffd4059bada1e25190f6e98",
+    "chainId": "bip122:12a765e31ffd4059bada1e25190f6e98/slip44:2",
     "family": "bitcoin",
     "displayName": "Litecoin",
     "defaultKeyPath": "m/84'/2'/0'/0/0"
   },
   {
-    "chainId": "bip122:1a91e3dace36e2be3bf030a65679fe82",
+    "chainId": "bip122:1a91e3dace36e2be3bf030a65679fe82/slip44:3",
     "family": "bitcoin",
     "displayName": "Dogecoin",
     "defaultKeyPath": "m/84'/3'/0'/0/0"
   },
   {
-    "chainId": "xrpl:0",
+    "chainId": "xrpl:0/slip44:144",
     "family": "xrp",
     "displayName": "XRPL",
     "defaultKeyPath": "m/44'/144'/0'/0/0"
   },
   {
-    "chainId": "cosmos:Binance-Chain-Tigris",
+    "chainId": "cosmos:Binance-Chain-Tigris/slip44:714",
     "family": "cosmos",
     "displayName": "Binance coin",
     "defaultKeyPath": "m/44'/714'/0'/0/0"
   },
   {
-    "chainId": "stellar:pubnet",
+    "chainId": "stellar:pubnet/slip44:148",
     "family": "stellar",
     "displayName": "Stellar",
     "defaultKeyPath": "m/44'/148'/0'"
   },
   {
-    "chainId": "hedera:mainnet",
+    "chainId": "hedera:mainnet/slip44:3030",
     "family": "hedera",
     "displayName": "Hedera Hashgraph",
     "defaultKeyPath": "m/44'/3030'/0'"
   },
   {
-    "chainId": "stacks:1",
+    "chainId": "stacks:1/slip44:5757",
     "family": "stacks",
     "displayName": "Stacks",
     "defaultKeyPath": "m/44'/5757'/0'/0/0"
   },
   {
-    "chainId": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
+    "chainId": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501",
     "family": "solana",
     "displayName": "Solana",
     "defaultKeyPath": "m/44'/501'/0'"
   },
   {
-    "chainId": "polkadot:91b171bb158e2d3848fa23a9f1c25182",
+    "chainId": "polkadot:91b171bb158e2d3848fa23a9f1c25182/slip44:354",
     "family": "polkadot",
     "displayName": "Polkadot",
     "defaultKeyPath": "m/44'/354'/0'/0/0"
   },
   {
-    "chainId": "cosmos:cosmoshub-4",
+    "chainId": "cosmos:cosmoshub-4/slip44:118",
     "family": "cosmos",
     "displayName": "Cosmos",
     "defaultKeyPath": "m/44'/118'/0'/0/0"
   },
   {
-    "chainId": "tezos:NetXdQprcVkpaWU",
+    "chainId": "tezos:NetXdQprcVkpaWU/slip44:1729",
     "family": "tezos",
     "displayName": "Tezos",
     "defaultKeyPath": "m/44'/1729'/0'/0'"
   },
   {
-    "chainId": "vechain:b1ac3413d346d43539627e6be7ec1b4a",
+    "chainId": "vechain:b1ac3413d346d43539627e6be7ec1b4a/slip44:818",
     "family": "vechain",
     "displayName": "VeChain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "cosmos:coreum-mainnet-1",
+    "chainId": "cosmos:coreum-mainnet-1/slip44:990",
     "family": "cosmos",
     "displayName": "TX",
     "defaultKeyPath": "m/44'/990'/0'/0/0"
   },
   {
-    "chainId": "algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k",
+    "chainId": "algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k/slip44:283",
     "family": "algorand",
     "displayName": "Algorand",
     "defaultKeyPath": "m/44'/283'/0'/0/0"
   },
   {
-    "chainId": "fil:f",
+    "chainId": "fil:f/slip44:461",
     "family": "fil",
     "displayName": "Filecoin",
     "defaultKeyPath": "m/44'/461'/0'/0/0"
-  },
-  {
-    "chainId": "tron:mainnet",
-    "family": "tron",
-    "displayName": "Tron",
-    "defaultKeyPath": "m/44'/195'/0'/0/0"
   }
 ]

--- a/playground/presets.evm.json
+++ b/playground/presets.evm.json
@@ -4,17 +4,17 @@
     "label": "EVM transfer (EIP-1559)",
     "note": "Template only — edit nonce/maxFeePerGas before send",
     "applicableChainIds": [
-      "eip155:1",
-      "eip155:10",
-      "eip155:56",
-      "eip155:100",
-      "eip155:137",
-      "eip155:250",
-      "eip155:8217",
-      "eip155:8453",
-      "eip155:42161",
-      "eip155:42220",
-      "eip155:43114"
+      "eip155:1/slip44:60",
+      "eip155:10/slip44:60",
+      "eip155:56/slip44:60",
+      "eip155:100/slip44:60",
+      "eip155:137/slip44:60",
+      "eip155:250/slip44:60",
+      "eip155:8217/slip44:60",
+      "eip155:8453/slip44:60",
+      "eip155:42161/slip44:60",
+      "eip155:42220/slip44:60",
+      "eip155:43114/slip44:60"
     ],
     "transaction": {
       "type": 2,

--- a/playground/presets.non-evm.json
+++ b/playground/presets.non-evm.json
@@ -4,7 +4,7 @@
     "label": "Bitcoin native-segwit transfer",
     "family": "bitcoin",
     "applicableChainIds": [
-      "bip122:000000000019d6689c085ae165831e93"
+      "bip122:000000000019d6689c085ae165831e93/slip44:0"
     ],
     "note": "P2WPKH native SegWit output. Amounts in satoshi. Edit inputs/outputs before send.",
     "sourceUrl": "https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/test/transaction_builder.spec.js",
@@ -32,7 +32,7 @@
     "label": "Solana SOL transfer",
     "family": "solana",
     "applicableChainIds": [
-      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501"
     ],
     "note": "Versioned Transaction (version: 0) format. Edit to/lamports before send.",
     "sourceUrl": "https://solana-labs.github.io/solana-web3.js/classes/VersionedTransaction.html",
@@ -43,8 +43,16 @@
         {
           "programId": "11111111111111111111111111111111",
           "keys": [
-            { "pubkey": "11111111111111111111111111111111", "isSigner": true, "isWritable": true },
-            { "pubkey": "11111111111111111111111111111112", "isSigner": false, "isWritable": true }
+            {
+              "pubkey": "11111111111111111111111111111111",
+              "isSigner": true,
+              "isWritable": true
+            },
+            {
+              "pubkey": "11111111111111111111111111111112",
+              "isSigner": false,
+              "isWritable": true
+            }
           ],
           "data": {
             "instruction": 2,
@@ -60,7 +68,7 @@
     "label": "XRP Payment",
     "family": "xrp",
     "applicableChainIds": [
-      "xrpl:0"
+      "xrpl:0/slip44:144"
     ],
     "note": "XRP Ledger Payment transaction. Edit Destination/Amount before send.",
     "sourceUrl": "https://js.xrpl.org/interfaces/Payment.html",
@@ -79,15 +87,21 @@
     "label": "Hedera HBAR transfer",
     "family": "hedera",
     "applicableChainIds": [
-      "hedera:mainnet"
+      "hedera:mainnet/slip44:3030"
     ],
     "note": "Hedera TransferTransaction (CryptoTransfer). Edit accountId/amount before send.",
     "sourceUrl": "https://docs.hedera.com/hedera/sdks-and-apis/sdks/cryptocurrency/transfer-cryptocurrency",
     "transaction": {
       "type": "CryptoTransfer",
       "transfers": [
-        { "accountId": "0.0.2", "amount": -100000000 },
-        { "accountId": "0.0.3", "amount": 100000000 }
+        {
+          "accountId": "0.0.2",
+          "amount": -100000000
+        },
+        {
+          "accountId": "0.0.3",
+          "amount": 100000000
+        }
       ],
       "memo": "",
       "maxTransactionFee": 100000000,
@@ -99,51 +113,23 @@
     "label": "Stellar XLM payment",
     "family": "stellar",
     "applicableChainIds": [
-      "stellar:pubnet"
+      "stellar:pubnet/slip44:148"
     ],
     "note": "Stellar Operation.payment for native XLM. Edit destination/amount before send.",
     "sourceUrl": "https://stellar.github.io/js-stellar-sdk/Operation.payment.html",
     "transaction": {
       "type": "payment",
       "destination": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
-      "asset": { "code": "XLM", "issuer": null },
+      "asset": {
+        "code": "XLM",
+        "issuer": null
+      },
       "amount": "10",
-      "memo": { "type": "none" },
+      "memo": {
+        "type": "none"
+      },
       "fee": 100,
       "sequenceNumber": "0"
-    }
-  },
-  {
-    "id": "trx-transfer",
-    "label": "Tron TRX transfer",
-    "family": "tron",
-    "applicableChainIds": [
-      "tron:mainnet"
-    ],
-    "note": "TronWeb transactionBuilder.sendTrx format. Amount in SUN (1 TRX = 1,000,000 SUN). Edit to/amount before send.",
-    "sourceUrl": "https://developers.tron.network/docs/getting-started-with-tronweb",
-    "transaction": {
-      "to_address": "TPswDDCAWhJAZGdHPidFiqHuoXXVKRiTZ2",
-      "owner_address": "TN3W4H6rK2ce4vX9YnFQHwKENnHjoxb3m9",
-      "amount": 1000000,
-      "raw_data": {
-        "contract": [
-          {
-            "type": "TransferContract",
-            "parameter": {
-              "value": {
-                "to_address": "TPswDDCAWhJAZGdHPidFiqHuoXXVKRiTZ2",
-                "owner_address": "TN3W4H6rK2ce4vX9YnFQHwKENnHjoxb3m9",
-                "amount": 1000000
-              }
-            }
-          }
-        ],
-        "ref_block_bytes": "0000",
-        "ref_block_hash": "0000000000000000",
-        "expiration": 1800000,
-        "timestamp": 0
-      }
     }
   }
 ]

--- a/playground/presets.rest.json
+++ b/playground/presets.rest.json
@@ -4,7 +4,7 @@
     "label": "Algorand ALGO payment",
     "family": "algorand",
     "applicableChainIds": [
-      "algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k"
+      "algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k/slip44:283"
     ],
     "note": "Algorand 결제(pay) 트랜잭션. amount 단위는 microAlgo (1 ALGO = 1,000,000). from/to/amount 수정 후 송금.",
     "sourceUrl": "https://github.com/algorand/js-algorand-sdk",
@@ -25,7 +25,7 @@
     "label": "Conflux CFX transfer",
     "family": "conflux",
     "applicableChainIds": [
-      "conflux:cfx"
+      "conflux:cfx/slip44:503"
     ],
     "note": "Conflux Core Space 송금 트랜잭션 (EVM 호환). chainId 1029 = Conflux Hydra mainnet. from/to/value 수정 후 송금.",
     "sourceUrl": "https://github.com/Conflux-Chain/js-conflux-sdk",
@@ -47,7 +47,7 @@
     "label": "Cosmos ATOM transfer",
     "family": "cosmos",
     "applicableChainIds": [
-      "cosmos:cosmoshub-4"
+      "cosmos:cosmoshub-4/slip44:118"
     ],
     "note": "Cosmos Hub MsgSend (cosmjs StdSignDoc). amount 단위는 uatom (1 ATOM = 1,000,000). fromAddress/toAddress/amount 수정 후 송금.",
     "sourceUrl": "https://github.com/cosmos/cosmjs",
@@ -81,7 +81,7 @@
     "label": "Filecoin FIL transfer",
     "family": "fil",
     "applicableChainIds": [
-      "fil:f"
+      "fil:f/slip44:461"
     ],
     "note": "Filecoin Lotus Message (BLS/secp256k1). value 단위는 attoFIL (1 FIL = 10^18). to/from/value 수정 후 송금.",
     "sourceUrl": "https://github.com/glifio/modules",
@@ -102,7 +102,7 @@
     "label": "Polkadot DOT transfer",
     "family": "polkadot",
     "applicableChainIds": [
-      "polkadot:91b171bb158e2d3848fa23a9f1c25182"
+      "polkadot:91b171bb158e2d3848fa23a9f1c25182/slip44:354"
     ],
     "note": "Polkadot balances.transfer extrinsic. args[1] 단위는 Planck (1 DOT = 10^10 Planck). args[0] 수신자 주소 + args[1] 금액 수정 후 송금.",
     "sourceUrl": "https://github.com/polkadot-js/api",
@@ -126,7 +126,7 @@
     "label": "Stacks STX transfer",
     "family": "stacks",
     "applicableChainIds": [
-      "stacks:1"
+      "stacks:1/slip44:5757"
     ],
     "note": "Stacks tokenTransfer (makeSTXTokenTransfer). amount 단위는 microSTX (1 STX = 1,000,000). recipient/amount 수정 후 송금.",
     "sourceUrl": "https://github.com/hirosystems/stacks.js",
@@ -147,7 +147,7 @@
     "label": "Tezos XTZ transfer",
     "family": "tezos",
     "applicableChainIds": [
-      "tezos:NetXdQprcVkpaWU"
+      "tezos:NetXdQprcVkpaWU/slip44:1729"
     ],
     "note": "Tezos transaction operation (taquito). amount 단위는 mutez (1 XTZ = 1,000,000). source/destination/amount 수정 후 송금.",
     "sourceUrl": "https://github.com/ecadlabs/taquito",
@@ -167,7 +167,7 @@
     "label": "VeChain VET transfer",
     "family": "vechain",
     "applicableChainIds": [
-      "vechain:b1ac3413d346d43539627e6be7ec1b4a"
+      "vechain:b1ac3413d346d43539627e6be7ec1b4a/slip44:818"
     ],
     "note": "VeChain Thor transaction (thor-devkit). clauses[0].value는 wei 단위 hex (1 VET = 10^18 wei). clauses[0].to/value 수정 후 송금.",
     "sourceUrl": "https://github.com/vechain/thor-devkit.js",

--- a/tests/unit/2_v2_e2e/playground.signtx-evm.spec.ts
+++ b/tests/unit/2_v2_e2e/playground.signtx-evm.spec.ts
@@ -17,15 +17,16 @@ const { launchBrowser } = require('./launchBrowser')
 const HARNESS_BASE = 'http://localhost:9091'
 const PLAYGROUND_URL = `${HARNESS_BASE}/index-v2.html`
 
+// m09-01-02: CAIP-19 형식 (1번 경로 마이그레이션). EVM은 slip44:60.
 const SAMPLE_CHAINS = [
   {
-    chainId: 'eip155:1',
+    chainId: 'eip155:1/slip44:60',
     family: 'ethereum',
     displayName: 'Ethereum',
     defaultKeyPath: "m/44'/60'/0'/0/0",
   },
   {
-    chainId: 'eip155:137',
+    chainId: 'eip155:137/slip44:60',
     family: 'ethereum',
     displayName: 'Polygon',
     defaultKeyPath: "m/44'/60'/0'/0/0",
@@ -37,7 +38,7 @@ const SAMPLE_PRESETS = [
     id: 'evm-transfer-1559',
     label: 'EVM transfer (EIP-1559)',
     note: 'Template only — edit nonce/maxFeePerGas before send',
-    applicableChainIds: ['eip155:1', 'eip155:137'],
+    applicableChainIds: ['eip155:1/slip44:60', 'eip155:137/slip44:60'],
     transaction: {
       type: 2,
       to: '0x0000000000000000000000000000000000000000',
@@ -114,8 +115,8 @@ describe('[v2 e2e] playground signTx EVM', () => {
       api.simulateConnect(mockDcent, null, { model: 'Biometric', firmware: '3.23.0' })
     })
 
-    // Step 4: Ethereum (eip155:1) 노드 클릭
-    await page.click('[data-method-id="signTx:evm:eip155:1"]')
+    // Step 4: Ethereum (eip155:1/slip44:60) 노드 클릭 — m09-01-02: CAIP-19
+    await page.click('[data-method-id="signTx:evm:eip155:1/slip44:60"]')
 
     // Step 5: 폼 렌더링 확인 — keyPath, transaction 필드 존재
     const hasKeyPath = await page.$('#field-keyPath')
@@ -155,9 +156,10 @@ describe('[v2 e2e] playground signTx EVM', () => {
     expect(captured.length).toBe(1)
 
     const req = captured[0]
-    // facade dcent.sign({ chain: 'eip155:1', payload: { chainId, keyPath, transaction } })
-    expect(req.chain).toBe('eip155:1')
-    expect(req.payload.chainId).toBe('eip155:1')
+    // m09-01-02: 1번 경로 마이그레이션 — chain은 intent literal 'signTransaction',
+    //   payload.chainId는 CAIP-19 (eip155:1/slip44:60)
+    expect(req.chain).toBe('signTransaction')
+    expect(req.payload.chainId).toBe('eip155:1/slip44:60')
     expect(req.payload.keyPath).toBe("m/44'/60'/0'/0/0")
     expect(req.payload.transaction).toBeDefined()
     expect(req.payload.transaction.type).toBe(2)

--- a/tests/unit/2_v2_e2e/playground.signtx-non-evm.spec.ts
+++ b/tests/unit/2_v2_e2e/playground.signtx-non-evm.spec.ts
@@ -18,42 +18,39 @@ const { launchBrowser } = require('./launchBrowser')
 const HARNESS_BASE = 'http://localhost:9091'
 const PLAYGROUND_URL = `${HARNESS_BASE}/index-v2.html`
 
+// m09-01-02: CAIP-19 형식 (1번 경로 마이그레이션). slip44는 SLIP-0044 spec.
+// 단, tron은 wm 미등록이므로 본 PR scope에서 fixture만 유지 (chainId는 CAIP-2 그대로 유지하여
+// resolveChainId fail 흐름 검증 가능). 실제 chains.json은 tron entry 제거됨.
 const SAMPLE_NON_EVM_CHAINS = [
   {
-    chainId: 'bip122:000000000019d6689c085ae165831e93',
+    chainId: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
     family: 'bitcoin',
     displayName: 'Bitcoin',
     defaultKeyPath: "m/84'/0'/0'/0/0",
   },
   {
-    chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+    chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
     family: 'solana',
     displayName: 'Solana',
     defaultKeyPath: "m/44'/501'/0'",
   },
   {
-    chainId: 'xrpl:0',
+    chainId: 'xrpl:0/slip44:144',
     family: 'xrp',
     displayName: 'XRPL',
     defaultKeyPath: "m/44'/144'/0'/0/0",
   },
   {
-    chainId: 'hedera:mainnet',
+    chainId: 'hedera:mainnet/slip44:3030',
     family: 'hedera',
     displayName: 'Hedera Hashgraph',
     defaultKeyPath: "m/44'/3030'/0'",
   },
   {
-    chainId: 'stellar:pubnet',
+    chainId: 'stellar:pubnet/slip44:148',
     family: 'stellar',
     displayName: 'Stellar',
     defaultKeyPath: "m/44'/148'/0'",
-  },
-  {
-    chainId: 'tron:mainnet',
-    family: 'tron',
-    displayName: 'Tron',
-    defaultKeyPath: "m/44'/195'/0'/0/0",
   },
 ]
 
@@ -62,7 +59,7 @@ const SAMPLE_NON_EVM_PRESETS = [
     id: 'btc-transfer',
     label: 'Bitcoin native-segwit transfer',
     family: 'bitcoin',
-    applicableChainIds: ['bip122:000000000019d6689c085ae165831e93'],
+    applicableChainIds: ['bip122:000000000019d6689c085ae165831e93/slip44:0'],
     note: 'P2WPKH native SegWit',
     sourceUrl: 'https://github.com/bitcoinjs/bitcoinjs-lib',
     transaction: {
@@ -83,7 +80,7 @@ const SAMPLE_NON_EVM_PRESETS = [
     id: 'sol-transfer',
     label: 'Solana SOL transfer',
     family: 'solana',
-    applicableChainIds: ['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
+    applicableChainIds: ['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501'],
     note: 'Versioned Transaction (version: 0)',
     sourceUrl: 'https://solana-labs.github.io/solana-web3.js/',
     transaction: {
@@ -192,7 +189,7 @@ describe('[v2 e2e] playground signTx non-EVM', () => {
     await setupMockTransport()
 
     // Step 4: Bitcoin 노드 클릭
-    await page.click('[data-method-id="signTx:bitcoin:bip122:000000000019d6689c085ae165831e93"]')
+    await page.click('[data-method-id="signTx:bitcoin:bip122:000000000019d6689c085ae165831e93/slip44:0"]')
 
     // Step 5: 폼 렌더링 확인
     const hasKeyPath = await page.$('#field-keyPath')
@@ -225,9 +222,9 @@ describe('[v2 e2e] playground signTx non-EVM', () => {
     expect(captured.length).toBe(1)
 
     const req = captured[0]
-    // m08-01-05: facade dcent.sign({chain, payload}) 호출됨
-    expect(req.chain).toBe('bip122:000000000019d6689c085ae165831e93')
-    expect(req.payload.chainId).toBe('bip122:000000000019d6689c085ae165831e93')
+    // m09-01-02: 1번 경로 마이그레이션 — chain intent literal + CAIP-19 payload.chainId
+    expect(req.chain).toBe('signTransaction')
+    expect(req.payload.chainId).toBe('bip122:000000000019d6689c085ae165831e93/slip44:0')
     expect(req.payload.keyPath).toBe("m/84'/0'/0'/0/0")
     expect(req.payload.transaction).toBeDefined()
     // Bitcoin transaction shape: inputs 배열
@@ -271,8 +268,8 @@ describe('[v2 e2e] playground signTx non-EVM', () => {
     // Step 3: Mock transport 주입
     await setupMockTransport()
 
-    // Step 4: Solana 노드 클릭
-    await page.click('[data-method-id="signTx:solana:solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"]')
+    // Step 4: Solana 노드 클릭 — m09-01-02: CAIP-19
+    await page.click('[data-method-id="signTx:solana:solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501"]')
 
     // Step 5: 폼 렌더링 확인
     const hasKeyPath = await page.$('#field-keyPath')
@@ -305,9 +302,9 @@ describe('[v2 e2e] playground signTx non-EVM', () => {
     expect(captured.length).toBe(1)
 
     const req = captured[0]
-    // m08-01-05: facade dcent.sign({chain, payload}) 호출됨
-    expect(req.chain).toBe('solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp')
-    expect(req.payload.chainId).toBe('solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp')
+    // m09-01-02: 1번 경로 마이그레이션 — chain intent literal + CAIP-19 payload.chainId
+    expect(req.chain).toBe('signTransaction')
+    expect(req.payload.chainId).toBe('solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501')
     expect(req.payload.keyPath).toBe("m/44'/501'/0'")
     expect(req.payload.transaction).toBeDefined()
     // Solana Versioned Transaction shape: version 필드

--- a/tests/unit/2_v2_e2e/playground.signtx-rest.spec.ts
+++ b/tests/unit/2_v2_e2e/playground.signtx-rest.spec.ts
@@ -75,7 +75,8 @@ describe('[v2 e2e] playground signTx Rest family', () => {
 
     // Step 4: Cosmos Hub 4 노드 클릭 — preset의 applicableChainIds와 정확히 매칭되는 chainId
     // (chains.json은 여러 cosmos chain 포함하지만 atom-transfer preset은 cosmoshub-4 전용)
-    const cosmosSelector = 'signTx:cosmos:cosmos:cosmoshub-4'
+    // m09-01-02: chains.json의 chainId는 CAIP-19 형식이므로 selector도 full CAIP-19 사용
+    const cosmosSelector = 'signTx:cosmos:cosmos:cosmoshub-4/slip44:118'
     await page.waitForSelector(`[data-method-id="${cosmosSelector}"]`, { timeout: 5000 })
     await page.click(`[data-method-id="${cosmosSelector}"]`)
 

--- a/tests/unit/2_v2_e2e/playground.signtx-rest.spec.ts
+++ b/tests/unit/2_v2_e2e/playground.signtx-rest.spec.ts
@@ -118,9 +118,9 @@ describe('[v2 e2e] playground signTx Rest family', () => {
     expect(captured.length).toBe(1)
 
     const req = captured[0]
-    // m08-01-05: facade dcent.sign({chain, payload}) 호출됨
-    expect(req.chain).toMatch(/^cosmos:/)
-    expect(req.payload.chainId).toMatch(/^cosmos:/)
+    // m09-01-02: 1번 경로 마이그레이션 — chain intent literal + CAIP-19 payload.chainId
+    expect(req.chain).toBe('signTransaction')
+    expect(req.payload.chainId).toMatch(/^cosmos:.+\/slip44:\d+$/)
     expect(req.payload.keyPath).toMatch(/^m\//)
     expect(typeof req.payload.transaction).toBe('object')
     expect(req.payload.transaction).not.toBeNull()

--- a/tests/unit/v2/playground.envelope.test.ts
+++ b/tests/unit/v2/playground.envelope.test.ts
@@ -1,0 +1,203 @@
+/**
+ * playground.envelope.test.ts — _unwrapV1Envelope helper + onConnect popup-only 회귀 테스트
+ *
+ * b08-01 (DC-2097): facade가 resolve로 돌려준 v1 failure envelope을 throw로 변환하고,
+ * onConnect는 popup-only 진입점이 되어 state.device를 미터치하는 동작을 검증한다.
+ *
+ * 관련 회귀 항목:
+ *   T-R-01: success envelope → body.parameter unwrap
+ *   T-R-02: failure envelope → throw (err.code, err.message 보존)
+ *   T-R-03: v1 특례 (transaction + user_cancel) → throw 안 함
+ *   T-R-04: legacy { result } shape → 입력 그대로 반환 (boundary-validation)
+ *   T-R-05: null / undefined → 입력 그대로 반환 (방어적)
+ *   T-R-07: onConnect 호출 후 state.device === null
+ *   T-R-08: onConnect 호출 후 state.connected === true + 버튼 토글
+ */
+import * as fs from 'fs'
+import * as path from 'path'
+
+// ── Playground 로드 helper ──────────────────────────────────────────────────
+function loadPlayground(): void {
+  const html = fs.readFileSync(
+    path.resolve(__dirname, '../../../index-v2.html'),
+    'utf8'
+  )
+  document.documentElement.innerHTML = html
+
+  ;(window as any).PopupTransport = function (_opts: any) {
+    return {
+      send: jest.fn().mockResolvedValue({ id: 'stub-id', result: {} }),
+      on: jest.fn(),
+      off: jest.fn(),
+      close: jest.fn().mockResolvedValue(undefined),
+    }
+  }
+  ;(window as any).SerialRequestQueue = function (_transport: any) {
+    return {
+      enqueue: jest.fn(function (task: any) { return task() }),
+      size: jest.fn().mockReturnValue(0),
+      clear: jest.fn(),
+    }
+  }
+  ;(window as any).ProviderError = class ProviderError extends Error {
+    code: number
+    constructor(code: number, message: string) {
+      super(message)
+      this.code = code
+    }
+  }
+
+  const playgroundSrc = fs.readFileSync(
+    path.resolve(__dirname, '../../../playground.js'),
+    'utf8'
+  )
+  // eslint-disable-next-line no-new-func
+  new Function(playgroundSrc)()
+}
+
+beforeEach(() => {
+  loadPlayground()
+})
+
+afterEach(() => {
+  document.documentElement.innerHTML = ''
+  delete (window as any)._playgroundTestAPI
+  delete (window as any).PopupTransport
+  delete (window as any).SerialRequestQueue
+  delete (window as any).ProviderError
+  delete (window as any).dcent
+})
+
+// ─────────────────────────────────────────────────────────
+// T-R-01: success envelope → body.parameter unwrap
+// ─────────────────────────────────────────────────────────
+it('T-R-01: _unwrapV1Envelope이 success envelope에서 body.parameter를 반환한다', () => {
+  const api = (window as any)._playgroundTestAPI
+  expect(typeof api._unwrapV1Envelope).toBe('function')
+
+  const envelope = {
+    header: { status: 'success' },
+    body: { parameter: { model: 'Biometric', firmware: '3.0.1' } },
+  }
+  const result = api._unwrapV1Envelope(envelope)
+  expect(result).toEqual({ model: 'Biometric', firmware: '3.0.1' })
+})
+
+// ─────────────────────────────────────────────────────────
+// T-R-02: failure envelope → throw (err.code, err.message 보존)
+// ─────────────────────────────────────────────────────────
+it('T-R-02: _unwrapV1Envelope이 failure envelope을 throw로 변환한다', () => {
+  const api = (window as any)._playgroundTestAPI
+  const envelope = {
+    header: { status: 'failure' },
+    body: { error: { code: 'X', message: 'm' } },
+  }
+  try {
+    api._unwrapV1Envelope(envelope)
+    throw new Error('expected throw')
+  } catch (err: any) {
+    expect(err.message).toBe('m')
+    expect(err.code).toBe('X')
+    expect(err.v1Envelope).toBe(envelope)
+  }
+})
+
+// ─────────────────────────────────────────────────────────
+// T-R-03: v1 특례 — transaction + user_cancel → throw 안 함 (호환 보존)
+// ─────────────────────────────────────────────────────────
+it('T-R-03: _unwrapV1Envelope이 transaction + user_cancel 특례를 보존한다', () => {
+  const api = (window as any)._playgroundTestAPI
+  const envelope = {
+    header: { status: 'failure' },
+    body: {
+      command: 'transaction',
+      error: { code: 'user_cancel', message: 'User cancelled' },
+    },
+  }
+  // throw하지 않아야 함
+  const result = api._unwrapV1Envelope(envelope)
+  // body 자체가 반환됨 (body.parameter 없으므로)
+  expect(result).toBe(envelope.body)
+})
+
+// ─────────────────────────────────────────────────────────
+// T-R-04: legacy { result } shape → 입력 그대로 반환 (boundary-validation)
+// ─────────────────────────────────────────────────────────
+it('T-R-04: _unwrapV1Envelope이 legacy { result } shape을 그대로 반환한다', () => {
+  const api = (window as any)._playgroundTestAPI
+  const legacy = { result: { ok: true } }
+  // header가 없으므로 envelope이 아닌 입력 — pass-through
+  expect(api._unwrapV1Envelope(legacy)).toBe(legacy)
+
+  const plain = { foo: 'bar' }
+  expect(api._unwrapV1Envelope(plain)).toBe(plain)
+})
+
+// ─────────────────────────────────────────────────────────
+// T-R-05: null / undefined → 입력 그대로 반환 (방어적)
+// ─────────────────────────────────────────────────────────
+it('T-R-05: _unwrapV1Envelope이 null / undefined 입력을 그대로 반환한다', () => {
+  const api = (window as any)._playgroundTestAPI
+  expect(api._unwrapV1Envelope(null)).toBeNull()
+  expect(api._unwrapV1Envelope(undefined)).toBeUndefined()
+  // primitive도 안전하게 pass-through
+  expect(api._unwrapV1Envelope('hello')).toBe('hello')
+  expect(api._unwrapV1Envelope(123)).toBe(123)
+})
+
+// ─────────────────────────────────────────────────────────
+// T-R-07: onConnect 호출 후 state.device === null (popup-only)
+// ─────────────────────────────────────────────────────────
+it('T-R-07: onConnect 호출 후 state.device === null (popup-only — device info 미fetch)', () => {
+  const api = (window as any)._playgroundTestAPI
+  expect(typeof api.onConnect).toBe('function')
+
+  // facade-shaped mock — getDeviceInfo는 호출되지 않아야 함을 검증
+  const mockGetDeviceInfo = jest.fn()
+  const mockDcent = {
+    sign: jest.fn(),
+    getDeviceInfo: mockGetDeviceInfo,
+    popupWindowClose: jest.fn(),
+    setConnectionListener: jest.fn(),
+  }
+  ;(window as any).dcent = mockDcent
+
+  // 초기 상태
+  expect(api.state.device).toBeNull()
+  expect(api.state.connected).toBe(false)
+
+  api.onConnect()
+
+  // device는 미터치
+  expect(api.state.device).toBeNull()
+  // getDeviceInfo도 호출되지 않음 (popup-only)
+  expect(mockGetDeviceInfo).not.toHaveBeenCalled()
+})
+
+// ─────────────────────────────────────────────────────────
+// T-R-08: onConnect 호출 후 state.connected === true + 버튼 토글 (UX 회귀 0)
+// ─────────────────────────────────────────────────────────
+it('T-R-08: onConnect 호출 후 state.connected === true + 버튼 토글 (UX 회귀 0)', () => {
+  const api = (window as any)._playgroundTestAPI
+
+  const mockDcent = {
+    sign: jest.fn(),
+    getDeviceInfo: jest.fn(),
+    popupWindowClose: jest.fn(),
+    setConnectionListener: jest.fn(),
+  }
+  ;(window as any).dcent = mockDcent
+
+  const btnConnect = document.getElementById('btn-connect') as HTMLButtonElement
+  const btnDisconnect = document.getElementById('btn-disconnect') as HTMLButtonElement
+  // 초기: connect 보임, disconnect 숨김
+  expect(btnConnect.style.display).not.toBe('none')
+
+  api.onConnect()
+
+  expect(api.state.connected).toBe(true)
+  expect(btnConnect.style.display).toBe('none')
+  expect(btnDisconnect.style.display).toBe('')
+  // setConnectionListener는 1회 등록되었어야 함
+  expect(mockDcent.setConnectionListener).toHaveBeenCalledTimes(1)
+})

--- a/tests/unit/v2/playground.signtx-evm.test.ts
+++ b/tests/unit/v2/playground.signtx-evm.test.ts
@@ -240,10 +240,11 @@ it('T-U-EVM-03: 잘못된 JSON transaction → dispatcher 0건 (boundary-validat
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// T-U-EVM-04: 정상 전송 — facade dcent.sign({chain: 'eip155:N', payload}) 호출 검증
-// m08-01-05: 통합 sign API 사용 — chain은 CAIP-19 형식
+// T-U-EVM-04 / T-U-01: 정상 전송 — facade dcent.sign({chain: 'signTransaction', payload}) 호출 검증
+// m09-01-02: 1번 경로 마이그레이션 — chain은 intent literal 'signTransaction',
+//   payload.chainId는 CAIP-19 (eip155:N/slip44:60)
 // ─────────────────────────────────────────────────────────────────────────────
-it('T-U-EVM-04: 정상 전송 시 dcent.sign({chain: eip155:N, payload}) 호출', async () => {
+it('T-U-EVM-04: 정상 전송 시 dcent.sign({chain: "signTransaction", payload: {chainId: CAIP-19}}) 호출', async () => {
   const api = (window as any)._playgroundTestAPI
 
   api.simulateEvmLoad(SAMPLE_CHAINS, SAMPLE_PRESETS)
@@ -253,7 +254,7 @@ it('T-U-EVM-04: 정상 전송 시 dcent.sign({chain: eip155:N, payload}) 호출'
   const mockDcent = makeMockDcent(mockSign)
   api.simulateConnect(mockDcent, null, { model: 'Bio', firmware: '3.0' })
 
-  // eip155:137 (Polygon) 선택
+  // eip155:137 (Polygon) 선택 — SAMPLE_CHAINS의 chainId 그대로 사용
   const evmNode = document.querySelector('[data-method-id="signTx:evm:eip155:137"]') as HTMLElement
   evmNode.click()
 
@@ -268,10 +269,11 @@ it('T-U-EVM-04: 정상 전송 시 dcent.sign({chain: eip155:N, payload}) 호출'
   // Promise 완료 대기
   await new Promise((r) => setTimeout(r, 50))
 
-  // dcent.sign 호출 검증 — { chain: 'eip155:137', payload: { chainId, keyPath, transaction } }
+  // dcent.sign 호출 검증 — { chain: 'signTransaction', payload: { chainId, keyPath, transaction } }
+  // m09-01-02: chain은 intent literal. payload.chainId는 form에서 가져온 값(이 테스트에서는 SAMPLE_CHAINS의 'eip155:137').
   expect(mockSign).toHaveBeenCalledTimes(1)
   const signInput = mockSign.mock.calls[0][0]
-  expect(signInput.chain).toBe('eip155:137')
+  expect(signInput.chain).toBe('signTransaction')
   expect(signInput.payload.chainId).toBe('eip155:137')
   expect(signInput.payload.keyPath).toBe("m/44'/60'/0'/0/0")
   expect(signInput.payload.transaction).toEqual(JSON.parse(VALID_TX_JSON))

--- a/tests/unit/v2/playground.signtx-non-evm.test.ts
+++ b/tests/unit/v2/playground.signtx-non-evm.test.ts
@@ -315,9 +315,10 @@ it('T-U-NEVM-03: CHAIN_KEY_PATH Proxy — 비-EVM family별 defaultKeyPath 반�
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// T-U-NEVM-04: preset fixture 6개 모두 valid JSON 파싱
+// T-U-NEVM-04 / T-DATA-01: preset fixture (wm 등록 family) 모두 valid JSON 파싱 + CAIP-19 형식
+// m09-01-02: wm 미등록 chain (tron:mainnet) 제외 — 5 family. applicableChainIds는 CAIP-19 형식.
 // ─────────────────────────────────────────────────────────────────────────────
-it('T-U-NEVM-04: presets.non-evm.json — 6 family preset fixture 모두 valid JSON', () => {
+it('T-U-NEVM-04: presets.non-evm.json — wm 등록 family preset 모두 valid JSON + CAIP-19', () => {
   const presetsPath = path.resolve(__dirname, '../../../playground/presets.non-evm.json')
   const raw = fs.readFileSync(presetsPath, 'utf8')
 
@@ -327,11 +328,15 @@ it('T-U-NEVM-04: presets.non-evm.json — 6 family preset fixture 모두 valid J
 
   presets = JSON.parse(raw)
   expect(Array.isArray(presets)).toBe(true)
-  expect(presets.length).toBe(6)
+  // m09-01-02: tron은 wm 미등록 → 본 PR scope에서 제외 (m09-02에서 추가)
+  expect(presets.length).toBe(5)
 
   // 각 preset의 필수 필드 확인
   const requiredFields = ['id', 'label', 'family', 'applicableChainIds', 'transaction']
-  const expectedFamilies = ['bitcoin', 'solana', 'xrp', 'hedera', 'stellar', 'tron']
+  const expectedFamilies = ['bitcoin', 'solana', 'xrp', 'hedera', 'stellar']
+
+  // CAIP-19 정규식: namespace:reference/slip44:N
+  const CAIP19_RE = /^[-a-z0-9]{3,8}:[-_a-zA-Z0-9]{1,32}\/slip44:\d+$/
 
   presets.forEach((p: any) => {
     requiredFields.forEach((field) => {
@@ -340,13 +345,60 @@ it('T-U-NEVM-04: presets.non-evm.json — 6 family preset fixture 모두 valid J
     expect(expectedFamilies).toContain(p.family)
     expect(Array.isArray(p.applicableChainIds)).toBe(true)
     expect(p.applicableChainIds.length).toBeGreaterThan(0)
+    // T-DATA-01: applicableChainIds 모두 CAIP-19 형식이어야 함
+    p.applicableChainIds.forEach((c: string) => {
+      expect(c).toMatch(CAIP19_RE)
+    })
     expect(typeof p.transaction).toBe('object')
   })
 
-  // family 중복 없이 6개 모두 존재
+  // family 중복 없이 5개 모두 존재
   const families = presets.map((p: any) => p.family)
   expectedFamilies.forEach((fam) => {
     expect(families).toContain(fam)
+  })
+
+  // tron은 제외되었어야 함 (m09-02 의존)
+  expect(families).not.toContain('tron')
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T-DATA-01: chains.json — 모든 entry chainId가 CAIP-19 형식
+// ─────────────────────────────────────────────────────────────────────────────
+it('T-DATA-01: chains.json — 모든 entry chainId가 CAIP-19 형식 (namespace:ref/slip44:N)', () => {
+  const chainsPath = path.resolve(__dirname, '../../../playground/chains.json')
+  const raw = fs.readFileSync(chainsPath, 'utf8')
+  const chains: any[] = JSON.parse(raw)
+
+  expect(Array.isArray(chains)).toBe(true)
+  expect(chains.length).toBeGreaterThan(0)
+
+  const CAIP19_RE = /^[-a-z0-9]{3,8}:[-_a-zA-Z0-9]{1,32}\/slip44:\d+$/
+
+  chains.forEach((c: any) => {
+    expect(typeof c.chainId).toBe('string')
+    expect(c.chainId).toMatch(CAIP19_RE)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T-DATA-02: presets.*.json의 applicableChainIds가 chains.json chainId 집합에 포함
+// ─────────────────────────────────────────────────────────────────────────────
+it('T-DATA-02: presets applicableChainIds ⊆ chains.json chainIds', () => {
+  const chainsPath = path.resolve(__dirname, '../../../playground/chains.json')
+  const evmPresetsPath = path.resolve(__dirname, '../../../playground/presets.evm.json')
+  const nonEvmPresetsPath = path.resolve(__dirname, '../../../playground/presets.non-evm.json')
+
+  const chains: any[] = JSON.parse(fs.readFileSync(chainsPath, 'utf8'))
+  const evmPresets: any[] = JSON.parse(fs.readFileSync(evmPresetsPath, 'utf8'))
+  const nonEvmPresets: any[] = JSON.parse(fs.readFileSync(nonEvmPresetsPath, 'utf8'))
+
+  const chainIds = new Set(chains.map((c: any) => c.chainId))
+
+  ;[...evmPresets, ...nonEvmPresets].forEach((p: any) => {
+    p.applicableChainIds.forEach((c: string) => {
+      expect(chainIds.has(c)).toBe(true)
+    })
   })
 })
 

--- a/tests/unit/v2/playground.smoke.test.ts
+++ b/tests/unit/v2/playground.smoke.test.ts
@@ -277,6 +277,90 @@ it('T-U-08: facade v1 형식 error → LogEntry.error 매핑', async () => {
 })
 
 // ─────────────────────────────────────────────────────────
+// T-R-06 (b08-01): facade가 failure envelope을 resolve로 돌려주는 시나리오에서
+// sendGetDeviceInfo 호출 → appendLog의 error 필드가 설정되고 state.device는 미오염
+// ─────────────────────────────────────────────────────────
+it('T-R-06: failure envelope resolve 시 error로 기록되고 state.device 미오염', async () => {
+  const api = (window as any)._playgroundTestAPI
+  api.clearLogs()
+
+  // facade가 v1 failure envelope을 resolve로 돌려주는 mock (silent success 흡수 시나리오)
+  const v1Failure = {
+    header: { status: 'failure' },
+    body: { error: { code: 'X', message: 'device is not connected' } },
+  }
+  const mockGetDeviceInfo = jest.fn().mockResolvedValue(v1Failure)
+  const mockDcent = {
+    sign: jest.fn(),
+    getDeviceInfo: mockGetDeviceInfo,
+    popupWindowClose: jest.fn(),
+    setConnectionListener: jest.fn(),
+  }
+
+  // 사전: state.device를 깨끗한 상태로 만들고 connected만 true (popup-only 모델)
+  api.simulateConnect(mockDcent, null, null)
+  // simulateConnect 직후 device는 null
+  expect(api.state.device).toBeNull()
+
+  // getDeviceInfo 선택 후 Send
+  const getDeviceItem = document.querySelector('[data-method-id="getDeviceInfo"]') as HTMLElement
+  getDeviceItem.click()
+  document.getElementById('btn-send')?.click()
+
+  // Promise resolve 대기
+  await new Promise((r) => setTimeout(r, 50))
+
+  const entries = api.getLogEntries()
+  expect(entries.length).toBeGreaterThan(0)
+  const lastEntry = entries[entries.length - 1]
+  // failure envelope이 silent success로 흡수되지 않고 error로 기록되어야 함
+  expect(lastEntry.error).toBeDefined()
+  expect(lastEntry.error.message).toBe('device is not connected')
+  // state.device는 오염되지 않아야 함
+  expect(api.state.device).toBeNull()
+})
+
+// ─────────────────────────────────────────────────────────
+// T-R-09 (b08-01): onConnect → tree에서 getDeviceInfo 선택 → [Send]로 state.device가 채워짐
+// E2E-style 단위 합 — onConnect는 popup-only, getDeviceInfo는 Send 경로의 단일 책임자
+// ─────────────────────────────────────────────────────────
+it('T-R-09: onConnect → getDeviceInfo Send 흐름에서 state.device가 채워진다', async () => {
+  const api = (window as any)._playgroundTestAPI
+
+  const deviceInfo = { model: 'Biometric', firmware: '3.0.1' }
+  const mockGetDeviceInfo = jest.fn().mockResolvedValue({
+    header: { status: 'success' },
+    body: { parameter: deviceInfo },
+  })
+  const mockDcent = {
+    sign: jest.fn(),
+    getDeviceInfo: mockGetDeviceInfo,
+    popupWindowClose: jest.fn(),
+    setConnectionListener: jest.fn(),
+  }
+  ;(window as any).dcent = mockDcent
+
+  // onConnect — popup-only (device 미터치)
+  api.onConnect()
+  expect(api.state.connected).toBe(true)
+  expect(api.state.device).toBeNull()
+  expect(mockGetDeviceInfo).not.toHaveBeenCalled()
+
+  // 트리에서 getDeviceInfo 선택 → Send
+  const getDeviceItem = document.querySelector('[data-method-id="getDeviceInfo"]') as HTMLElement
+  getDeviceItem.click()
+  document.getElementById('btn-send')?.click()
+
+  // Promise resolve 대기
+  await new Promise((r) => setTimeout(r, 50))
+
+  // getDeviceInfo 단일 책임자 — Send 시점에 호출됨
+  expect(mockGetDeviceInfo).toHaveBeenCalledTimes(1)
+  // state.device가 채워짐
+  expect(api.state.device).toEqual(deviceInfo)
+})
+
+// ─────────────────────────────────────────────────────────
 // T-U-09: state.connected === false 인 동안 모든 Send 버튼 disabled (Connect 후 활성화)
 // m08-01-05: state.transport → state.connected로 변경
 // ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Epic Summary

m09-01: connector v2 playground을 v2 통합 sign API 1번 경로로 정착시키는 epic.
b08-01을 흡수, m04-01 design의 1번 경로 + chain literal 패턴 채택.

배포 영향: playground.js / playground/ / index-v2.html은 .npmignore에 등록되어
npm publish tarball에서 제외. published 패키지 사용 dApp에 영향 없음.

## Children

- m09-01-01-playground-connect-and-envelope-unwrap (PR #143 머지됨, DC-2097)
  - playground.js envelope unwrap helper (_unwrapV1Envelope) 도입
  - onConnect popup-only 분리 (getDeviceInfo 책임 분리)
- m09-01-02-playground-v2-sign-api-migration (PR #144 머지됨, DC-2136)
  - sendSignTxEvm/NonEvm 1번 경로 마이그레이션 (chain literal 'signTransaction')
  - chains.json / chains.evm.json / presets.*.json CAIP-19 형식 직접 기재
  - 7개 spec 파일 mock spy assertion 1번 경로 + CAIP-19 갱신
  - fix commit 3864812: presets.rest.json CAIP-19 누락분 + REST e2e selector 수정

## Verification (epic branch tip)

- lint PASS, tsc PASS (baseline 0 errors), build PASS
- unit-v2 572/572 PASS
- unit-v2-e2e 19/19 PASS
- unit-mock 69/69 PASS
- T-GREP-01 (playground.js console.* 0건) PASS

## Definition of Done (m09-01-00)

- [x] 모든 child MERGED_TO_EPIC
- [x] Epic branch에서 §8 자동 검증 6건 통과
- [ ] mock 모드(?usb=mock) v2 sign 시나리오 동작 확인 (수동 — 머지 전 release manager 검토)
- [x] Epic → master 최종 PR 생성
- [x] PR description에 boundary + children 산출물 요약
- [ ] CI 통과
- [ ] PR URL 보고 (release manager 머지 결정)
- [ ] Epic 머지 후 v2 wire smoke test (수동)
- [ ] Jira Epic DC-2133 + DC-2097 + DC-2136 모두 Done 전환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)