### PR TITLE
[DC-2235] chore(playground): sign 호출 NEW schema 마이그레이션 ({method, chainId, payload})

### DIFF
--- a/playground.js
+++ b/playground.js
@@ -1027,12 +1027,11 @@
     var params = { chainId: chainId, keyPath: keyPath, message: message, meta: metaObj }
     var startMs = Date.now()
 
-    // m08-01-05: 통합 sign API 사용 — chain 인자로 raw method 전달 (v1 fallback path)
-    // CAIP-19 (예: 'eip155:1') 또는 v1 method 문자열 ('signMessage') 모두 지원.
-    // 본 dispatcher는 v1 호환 'signMessage' method를 그대로 사용.
+    // m09-04-01.5: NEW schema 마이그레이션 — { method, chainId, payload }.
+    // method는 intent literal ('signMessage'), chainId(CAIP-19)는 top-level, payload에는 chainId 제거.
     var dcent = _getDcent()
     // b08-01: _unwrapV1Envelope이 success → body.parameter unwrap, failure → throw로 변환
-    dcent.sign({ chain: 'signMessage', payload: params }).then(_unwrapV1Envelope).then(function (result) {
+    dcent.sign({ method: 'signMessage', chainId: chainId, payload: { keyPath: keyPath, message: message, meta: metaObj } }).then(_unwrapV1Envelope).then(function (result) {
       appendLog({
         method: 'signMessage',
         chainId: chainId,
@@ -1091,12 +1090,12 @@
     var params = { chainId: chainId, keyPath: keyPath, transaction: txObj }
     var startMs = Date.now()
 
-    // m09-01-02: 1번 경로 마이그레이션 — chain intent literal 'signTransaction' 사용 + payload.chainId는 CAIP-19.
-    // connector chainToMethod의 PREFIX_TO_METHOD 미매치 → fallthrough → sdk MethodRegistry hit.
-    // chainId(CAIP-19)는 sdk resolveChainId가 wallet-models registry로 currency 결정.
+    // m09-04-01.5: NEW schema 마이그레이션 — { method, chainId, payload }.
+    // method='signTransaction' (intent literal), chainId(CAIP-19) top-level, payload에서 chainId 제거.
+    // sdk resolveChainId가 wallet-models registry로 currency 결정.
     var dcent = _getDcent()
     // b08-01: _unwrapV1Envelope이 success → body.parameter unwrap, failure → throw로 변환
-    dcent.sign({ chain: 'signTransaction', payload: params }).then(_unwrapV1Envelope).then(function (result) {
+    dcent.sign({ method: 'signTransaction', chainId: chainId, payload: { keyPath: keyPath, transaction: txObj } }).then(_unwrapV1Envelope).then(function (result) {
       appendLog({
         method: 'signTransaction',
         chainId: chainId,
@@ -1156,11 +1155,11 @@
     var params = { chainId: chainId, keyPath: keyPath, transaction: txObj }
     var startMs = Date.now()
 
-    // m09-01-02: 1번 경로 마이그레이션 — chain intent literal 'signTransaction' 사용 + payload.chainId는 CAIP-19.
+    // m09-04-01.5: NEW schema 마이그레이션 — { method, chainId, payload }.
     // bip122/solana/xrpl/cosmos/stellar/hedera 등 비-EVM도 동일 패턴. chains.json의 chainId가 이미 CAIP-19.
     var dcent = _getDcent()
     // b08-01: _unwrapV1Envelope이 success → body.parameter unwrap, failure → throw로 변환
-    dcent.sign({ chain: 'signTransaction', payload: params }).then(_unwrapV1Envelope).then(function (result) {
+    dcent.sign({ method: 'signTransaction', chainId: chainId, payload: { keyPath: keyPath, transaction: txObj } }).then(_unwrapV1Envelope).then(function (result) {
       appendLog({
         method: 'signTransaction',
         chainId: chainId,

--- a/tests/unit/v2/playground.signtx-evm.test.ts
+++ b/tests/unit/v2/playground.signtx-evm.test.ts
@@ -240,11 +240,11 @@ it('T-U-EVM-03: 잘못된 JSON transaction → dispatcher 0건 (boundary-validat
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
-// T-U-EVM-04 / T-U-01: 정상 전송 — facade dcent.sign({chain: 'signTransaction', payload}) 호출 검증
-// m09-01-02: 1번 경로 마이그레이션 — chain은 intent literal 'signTransaction',
-//   payload.chainId는 CAIP-19 (eip155:N/slip44:60)
+// T-U-EVM-04 / T-U-01: 정상 전송 — facade dcent.sign({method, chainId, payload}) 호출 검증
+// m09-04-01.5: NEW schema 마이그레이션 — method='signTransaction' (intent literal),
+//   chainId(CAIP-19)는 top-level, payload는 { keyPath, transaction }만 포함
 // ─────────────────────────────────────────────────────────────────────────────
-it('T-U-EVM-04: 정상 전송 시 dcent.sign({chain: "signTransaction", payload: {chainId: CAIP-19}}) 호출', async () => {
+it('T-U-EVM-04: 정상 전송 시 dcent.sign({method: "signTransaction", chainId: CAIP-19, payload}) 호출', async () => {
   const api = (window as any)._playgroundTestAPI
 
   api.simulateEvmLoad(SAMPLE_CHAINS, SAMPLE_PRESETS)
@@ -269,14 +269,17 @@ it('T-U-EVM-04: 정상 전송 시 dcent.sign({chain: "signTransaction", payload:
   // Promise 완료 대기
   await new Promise((r) => setTimeout(r, 50))
 
-  // dcent.sign 호출 검증 — { chain: 'signTransaction', payload: { chainId, keyPath, transaction } }
-  // m09-01-02: chain은 intent literal. payload.chainId는 form에서 가져온 값(이 테스트에서는 SAMPLE_CHAINS의 'eip155:137').
+  // dcent.sign 호출 검증 — { method: 'signTransaction', chainId, payload: { keyPath, transaction } }
+  // m09-04-01.5: NEW schema — method는 intent literal, chainId(CAIP-19)는 top-level,
+  //   payload는 { keyPath, transaction }만 포함 (chainId 제거).
   expect(mockSign).toHaveBeenCalledTimes(1)
   const signInput = mockSign.mock.calls[0][0]
-  expect(signInput.chain).toBe('signTransaction')
-  expect(signInput.payload.chainId).toBe('eip155:137')
+  expect(signInput.method).toBe('signTransaction')
+  expect(signInput.chainId).toBe('eip155:137')
   expect(signInput.payload.keyPath).toBe("m/44'/60'/0'/0/0")
   expect(signInput.payload.transaction).toEqual(JSON.parse(VALID_TX_JSON))
+  // payload에 chainId 키가 없어야 함 (top-level로 이동)
+  expect(signInput.payload.chainId).toBeUndefined()
 
   // 로그 확인
   const entries = api.getLogEntries()


### PR DESCRIPTION
## Objective

**m09-04-01.5-playground-new-schema** — connector playground 자산(`playground.js` 3 호출 + `tests/unit/v2/playground.signtx-evm.test.ts` assertion)을 m09-04-01의 NEW sign schema `{method, chainId, payload}`로 선행 마이그레이션.

- Jira: [DC-2235](https://iotrust.atlassian.net/browse/DC-2235) (Subtask of [DC-2223](https://iotrust.atlassian.net/browse/DC-2223) Epic)
- Objective file: `objectives/m09-04-01.5-playground-new-schema.md`
- Epic: m09-04 connector v2.0 cleanup
- Base: `epic/DC-2223_m09-04-connector-v2-cleanup`

## 변경 사항

### `playground.js` (3 호출)
| Line | Function | Before | After |
|---|---|---|---|
| 1034 | `sendSignMessage` | `{ chain: 'signMessage', payload: params }` | `{ method: 'signMessage', chainId, payload: { keyPath, message, meta } }` |
| 1098 | `sendSignTxEvm` | `{ chain: 'signTransaction', payload: params }` | `{ method: 'signTransaction', chainId, payload: { keyPath, transaction } }` |
| 1162 | `sendSignTxNonEvm` | 동일 패턴 | 동일 패턴 |

`chainId`(CAIP-19)는 `payload.chainId`에서 **top-level**로 이동. `payload`는 `{keyPath, message/transaction, [meta]}` 만 포함.

### `tests/unit/v2/playground.signtx-evm.test.ts` (T-U-EVM-04)
- 라인 243-247: 주석 + `it(...)` 제목을 NEW schema 표기로 갱신
- 라인 272-282: assertion이 `signInput.method` / `signInput.chainId` (top-level) 사용. `payload.chainId` is undefined 가드 추가.

### 나머지 4개 test 파일
- `signtx-non-evm.test.ts`, `signtx-rest.test.ts`, `envelope.test.ts`, `smoke.test.ts`: 변경 불필요. OLD-shape sign assertion 부재 (grep 0건 확인).

## 자동 검증

| ID | Command | Result |
|---|---|---|
| T-LINT-01 | `yarn lint` | ✅ exit 0 |
| T-BUILD-01 | `yarn build` | ✅ exit 0 (asset size warnings 기존 동일) |
| T-GREP-01 | playground.js OLD shape 0건 | ✅ |
| T-GREP-02 | tests OLD shape 0건 | ✅ |
| T-GREP-03 | playground.js NEW shape sign() 3건 | ✅ |

## verification-exemption: protocol-bilateral

**Jest unit-mock test (T-U-01~05)는 본 PR에서 일시 FAIL이 의도된 회귀입니다.**

- 이유: m09-04-01.5 단독 머지 시 connector `sign.ts`는 아직 OLD shape `{chain, payload}`를 받기 때문에, NEW shape 호출이 unhandled로 떨어져 test가 FAIL.
- 해소: m09-04-01 PR(`sign()` 시그니처 변경 + v1 path 제거) 머지 후 epic branch 전체 baseline-checks에서 일괄 PASS 예상.

## 머지 순서

```
1. (이 PR)  m09-04-01.5 → epic branch (먼저 머지 — playground/test 선행 정렬)
2.          m09-04-01    → epic branch (sign() 시그니처 변경 + v1 path 제거)
3.          epic branch  → master (m09-04 epic 전체 머지)
```

본 PR이 먼저 들어가야 m09-04-01의 schema 변경이 안전하게 진행됩니다.

## Sibling impact

- [m09-04-01-remove-v1-paths](../../../../objectives/m09-04-01-remove-v1-paths.md) (DC-2221, PLANNED): sign() 시그니처를 `{chain, payload}` → `{method, chainId, payload}`로 변경. 본 PR의 호출 측 마이그레이션이 선행됨.

## 적용 룰

- `objectives-doc-format`
- `automated-verification-required` — `verification-exemption: protocol-bilateral`
- `objective-pr-granularity` — 200-400 LOC 예상, 실제 20/18 LOC (작음, exemption 불필요)
- `release-unit-versioning` — epic child, MERGED_TO_EPIC lifecycle
- `no-version-bump` — package.json version 미수정 ✓
- `commit-message-format` — `[DC-2235] chore(playground): ...` ✓
- `epic-branch-workflow` — base = epic branch
- `objective-no-auto-merge` — AI는 PR 생성까지만

🤖 Generated with [Claude Code](https://claude.com/claude-code)