### PR TITLE
[DC-2237] feat(sign): family-agnostic payload validation — m09-04-05

### DIFF
--- a/src/sign/_validateSignPayload.ts
+++ b/src/sign/_validateSignPayload.ts
@@ -1,0 +1,123 @@
+/**
+ * v2 sign — `payload` 인자 family-agnostic light validation (m09-04-05)
+ *
+ * dApp이 `sign({method, chainId, payload})`로 전달하는 payload가 sdk handleRequest에 도달하기 전,
+ * connector facade에서 **family-agnostic shape** 만 검증한다.
+ *
+ * 적용 룰:
+ *   - dapp-input-sanitization: dApp 입력 객체 직접 pass-through 금지. 프로토타입 키 차단 + DoS 가드
+ *   - provider-security-checklist C3: dApp-controllable payload를 known-fields whitelist로 추출하지는 않지만
+ *     (family-specific 필드는 sdk가 처리), connector 경계의 universal shape contract를 강제한다
+ *   - connector-chain-addition-isolation: payload 검증에 chain enum / family-specific 분기 절대 부재.
+ *     chainId 문자열은 helpful error 메시지의 echo 용도로만 사용 (분기 로직 X)
+ *   - error-handling-consistency: 검증 실패 시 항상 ProviderError(INVALID_PARAMS) throw — silent return 금지
+ *
+ * 검증 단계:
+ *   1. payload가 plain object인지 (`typeof === 'object'`, `!Array.isArray`, `!== null`)
+ *   2. payload.keyPath가 non-empty string인지 (sdk handleRequest `_extractKeyPath`의 contract)
+ *   3. payload에 프로토타입 키 (`__proto__` / `constructor` / `prototype`) 부재
+ *   4. payload 직렬화 크기 ≤ 64KB (DoS 방어)
+ *
+ * 통과 후: sdk handleRequest가 chainId 기반 family-specific 검증을 수행한다.
+ */
+
+import { ProviderError } from '../error/ProviderError'
+import { ErrorCode } from '../error/ErrorCode'
+
+/** payload 직렬화 최대 크기 — DoS 방어 (64KB). */
+const MAX_PAYLOAD_BYTES = 64 * 1024
+
+/** 프로토타입 오염 차단 키 (own-property로 존재하면 거부). */
+const FORBIDDEN_PROTO_KEYS = ['__proto__', 'constructor', 'prototype'] as const
+
+/**
+ * v2 sign API payload shape validation (family-agnostic).
+ *
+ * @param chainId CAIP-19 chain identifier — 에러 메시지의 echo 용도만 (분기 로직 부재)
+ * @param payload dApp이 보낸 payload 후보 — 검증 후 sdk로 forward
+ * @throws ProviderError(INVALID_PARAMS) — 검증 실패 시
+ */
+export function _validateSignPayload (chainId: string, payload: unknown): void {
+  // (1) plain object 검증
+  if (payload === null || payload === undefined) {
+    throw new ProviderError(
+      ErrorCode.INVALID_PARAMS,
+      `Invalid sign payload for chainId '${chainId}': expected object, got ${payload === null ? 'null' : 'undefined'}`,
+    )
+  }
+  if (typeof payload !== 'object') {
+    throw new ProviderError(
+      ErrorCode.INVALID_PARAMS,
+      `Invalid sign payload for chainId '${chainId}': expected object, got ${typeof payload}`,
+    )
+  }
+  if (Array.isArray(payload)) {
+    throw new ProviderError(
+      ErrorCode.INVALID_PARAMS,
+      `Invalid sign payload for chainId '${chainId}': expected object, got array`,
+    )
+  }
+
+  const p = payload as Record<string, unknown>
+
+  // (2) keyPath 필수 (sdk handleRequest 계약)
+  if (typeof p.keyPath !== 'string') {
+    throw new ProviderError(
+      ErrorCode.INVALID_PARAMS,
+      `Invalid sign payload for chainId '${chainId}': 'keyPath' field required (BIP44 path string). ` +
+      `Example: sign({ method: '...', chainId: '${chainId}', payload: { keyPath: "m/44'/60'/0'/0/0", ... } })`,
+    )
+  }
+  if (p.keyPath.length === 0) {
+    throw new ProviderError(
+      ErrorCode.INVALID_PARAMS,
+      `Invalid sign payload for chainId '${chainId}': 'keyPath' must not be empty`,
+    )
+  }
+
+  // (3) 프로토타입 키 차단 — own-property로 존재하면 거부
+  for (const key of FORBIDDEN_PROTO_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(p, key)) {
+      throw new ProviderError(
+        ErrorCode.INVALID_PARAMS,
+        `Invalid sign payload: prototype key '${key}' not allowed`,
+      )
+    }
+  }
+
+  // (4) DoS 방어 — 직렬화 크기 ≤ 64KB
+  let serialized: string
+  try {
+    serialized = JSON.stringify(p)
+  } catch (err) {
+    // 순환 참조 등으로 JSON.stringify 실패
+    throw new ProviderError(
+      ErrorCode.INVALID_PARAMS,
+      `Invalid sign payload for chainId '${chainId}': not JSON-serializable (${(err as Error).message})`,
+    )
+  }
+  if (serialized.length > MAX_PAYLOAD_BYTES) {
+    throw new ProviderError(
+      ErrorCode.INVALID_PARAMS,
+      `Sign payload exceeds ${MAX_PAYLOAD_BYTES}-byte limit (got ${serialized.length} bytes)`,
+    )
+  }
+
+  // family-specific shape는 sdk 책임 — connector는 여기서 종료
+}
+
+/**
+ * v2 sign API payload contract — family-agnostic 필수 필드 + dApp-controllable extras.
+ *
+ * connector 경계에서 보장되는 contract:
+ *   - keyPath: non-empty string (BIP44 path) — `_validateSignPayload`가 강제
+ *
+ * sdk가 chainId 기반으로 family-specific 필드를 별도 검증한다 (예: EVM personal_sign의 address).
+ * 본 인터페이스는 documentation 용도이며 dApp에 export된다 (`src/index.ts` 참조).
+ */
+export interface SignPayload {
+  /** BIP44 derivation path — sdk가 wallet-models proxy에 forward. */
+  keyPath: string
+  /** family-specific 필드 — sdk가 검증. */
+  [key: string]: unknown
+}

--- a/src/sign/sign.ts
+++ b/src/sign/sign.ts
@@ -1,5 +1,5 @@
 /**
- * v2 sign — public 통합 sign API (m09-04-01 NEW schema)
+ * v2 sign — public 통합 sign API (m09-04-01 NEW schema, m09-04-05 payload contract)
  *
  * dApp이 호출하는 단일 진입점.
  *
@@ -9,23 +9,27 @@
  *
  * 동작:
  *   1. method / chainId 값을 각각 sanitize (type/length/whitelist/prototype 키)
- *   2. _call({method, chainId, params: payload})로 위임
+ *   2. payload를 family-agnostic light validation (m09-04-05) — keyPath 강제, 프로토타입 차단, DoS 가드
+ *   3. _call({method, chainId, params: payload})로 위임
  *
  * connector-chain-addition-isolation 룰: chain enum / 정적 매핑 부재.
  * connector는 chain-agnostic transport이며, chain 식별자 → method dispatch 책임은
  * bridge sdk 측이 `resolveChainId(chainId)` + wallet-models registry로 처리한다.
  *
  * 룰 준수:
- *   - dapp-input-sanitization: method / chainId 검증 (C3). payload는 bridge sdk 책임
- *   - error-handling-consistency: V1Response를 그대로 반환 (throw는 sanitize에서만)
- *   - provider-security-checklist C3: method / chainId는 dApp-controllable, sanitize가 origin-fixed가 아닌
- *     항목에 대한 whitelist 적용
- *   - connector-chain-addition-isolation: chain enum / 정적 매핑 부재
+ *   - dapp-input-sanitization: method / chainId / payload 검증 (C3). family-specific 필드는 bridge sdk 책임
+ *   - error-handling-consistency: V1Response를 그대로 반환 (throw는 sanitize / validatePayload에서만)
+ *   - provider-security-checklist C3: method / chainId / payload는 dApp-controllable.
+ *     connector 경계에서 universal shape contract를 강제하고, family-specific 필드는 sdk가 처리.
+ *   - connector-chain-addition-isolation: chain enum / 정적 매핑 부재. _validateSignPayload는 family-agnostic.
  */
 
 import { _call } from './call'
 import { _sanitizeMethod, _sanitizeChainId } from './sanitize'
+import { _validateSignPayload } from './_validateSignPayload'
 import type { V1Response } from './types'
+
+export type { SignPayload } from './_validateSignPayload'
 
 /** sign 입력 — method intent + chainId(CAIP-19) + payload (bridge로 그대로 전달). */
 export interface SignInput {
@@ -39,19 +43,55 @@ export interface SignInput {
    * sdk가 본 값을 wallet-models registry로 dispatch에 사용.
    */
   chainId: string
-  /** bridge sdk가 받을 payload (transaction body, account info, etc.) */
+  /**
+   * bridge sdk가 받을 payload — `keyPath: string` 필수, family-specific 필드는 sdk가 처리.
+   * connector 경계에서 보장되는 contract는 `_validateSignPayload` 참조.
+   */
   payload: Record<string, unknown>
 }
 
 /**
  * 통합 sign API — dApp이 method + chainId + payload만 알면 호출 가능.
  *
+ * @example EVM personal_sign (signMessage)
+ *   await dcent.sign({
+ *     method: 'signMessage',
+ *     chainId: 'eip155:1',
+ *     payload: {
+ *       keyPath: "m/44'/60'/0'/0/0",
+ *       message: '0x48656c6c6f',
+ *       // EVM family는 sdk가 wallet-models proxy에 address를 자동 inject (m09-03-05).
+ *       // dApp이 address를 보내도 sdk가 무시 (family-specific은 sdk 책임).
+ *     },
+ *   })
+ *
+ * @example EVM signTransaction (EIP-1559)
+ *   await dcent.sign({
+ *     method: 'signTransaction',
+ *     chainId: 'eip155:1',
+ *     payload: {
+ *       keyPath: "m/44'/60'/0'/0/0",
+ *       transaction: { from: '0xabc...', to: '0xdef...', value: '0x...', type: '0x2' },
+ *     },
+ *   })
+ *
+ * @example Bitcoin signTransaction
+ *   await dcent.sign({
+ *     method: 'signTransaction',
+ *     chainId: 'bip122:000000000019d6689c085ae165831e93',
+ *     payload: {
+ *       keyPath: "m/44'/0'/0'/0/0",
+ *       transaction: { inputs: [...], outputs: [...] },
+ *     },
+ *   })
+ *
  * @param input { method, chainId, payload }
  * @returns V1Response (v1 호환 응답 shape)
- * @throws ProviderError(INVALID_PARAMS) — method / chainId 검증 실패 시
+ * @throws ProviderError(INVALID_PARAMS) — method / chainId / payload 검증 실패 시
  */
 export async function sign (input: SignInput): Promise<V1Response> {
   const safeMethod = _sanitizeMethod(input.method)
   const safeChainId = _sanitizeChainId(input.chainId)
+  _validateSignPayload(safeChainId, input.payload)
   return _call({ method: safeMethod, chainId: safeChainId, params: input.payload })
 }

--- a/tests/unit/v2/sign/sign.test.ts
+++ b/tests/unit/v2/sign/sign.test.ts
@@ -85,7 +85,7 @@ describe('sign — NEW schema {method, chainId, payload}', () => {
     await sign({
       method: 'signTransaction',
       chainId: 'eip155:1',
-      payload: { tx: { to: '0xdef' } },
+      payload: { keyPath: "m/44'/60'/0'/0/0", tx: { to: '0xdef' } },
     })
 
     expect(sendSpy.mock.calls[0][0].method).toBe('signTransaction')
@@ -99,7 +99,7 @@ describe('sign — NEW schema {method, chainId, payload}', () => {
     await sign({
       method: 'signTransaction',
       chainId: 'bip122:000000000019d6689c085ae165831e93',
-      payload: {},
+      payload: { keyPath: "m/44'/0'/0'/0/0" },
     })
 
     expect(sendSpy.mock.calls[0][0].chainId).toBe('bip122:000000000019d6689c085ae165831e93')
@@ -112,7 +112,7 @@ describe('sign — NEW schema {method, chainId, payload}', () => {
     await sign({
       method: 'signTransaction',
       chainId: 'xrpl:0',
-      payload: {},
+      payload: { keyPath: "m/44'/144'/0'/0/0" },
     })
 
     expect(sendSpy.mock.calls[0][0].chainId).toBe('xrpl:0')
@@ -125,7 +125,7 @@ describe('sign — NEW schema {method, chainId, payload}', () => {
     await sign({
       method: 'signTransaction',
       chainId: 'cosmos:cosmoshub-4',
-      payload: {},
+      payload: { keyPath: "m/44'/118'/0'/0/0" },
     })
 
     expect(sendSpy.mock.calls[0][0].chainId).toBe('cosmos:cosmoshub-4')
@@ -141,7 +141,7 @@ describe('sign — NEW schema {method, chainId, payload}', () => {
     const resp = await sign({
       method: 'customSignSui',
       chainId: 'sui:mainnet',
-      payload: { tx: 'serialized' },
+      payload: { keyPath: "m/44'/784'/0'/0'/0'", tx: 'serialized' },
     })
 
     expect(sendSpy.mock.calls[0][0].method).toBe('customSignSui')

--- a/tests/unit/v2/sign/validateSignPayload.test.ts
+++ b/tests/unit/v2/sign/validateSignPayload.test.ts
@@ -1,0 +1,216 @@
+/**
+ * _validateSignPayload 단위 테스트 (m09-04-05)
+ *
+ * v2 sign API의 family-agnostic payload shape validation 회귀 테스트.
+ *
+ * T-PV-01: payload = undefined → throw INVALID_PARAMS "expected object, got undefined"
+ * T-PV-02: payload = null → throw "got null"
+ * T-PV-03: payload = [] → throw "got array"
+ * T-PV-04: payload = 'string' (typeof !== 'object') → throw
+ * T-PV-04b: payload = number / boolean → throw
+ * T-PV-05: payload = {} (no keyPath) → throw "'keyPath' field required"
+ * T-PV-06: payload = {keyPath: ''} → throw "must not be empty"
+ * T-PV-07: payload = {keyPath: 123} (non-string) → throw "'keyPath' field required"
+ * T-PV-08: minimal valid payload → no throw
+ * T-PV-09: payload with __proto__ (own-property) → throw "prototype key"
+ * T-PV-10: payload with constructor (own-property) → throw
+ * T-PV-10b: payload with prototype (own-property) → throw
+ * T-PV-11: payload size > 64KB → throw "exceeds 65536-byte limit"
+ * T-PV-12: payload with circular reference → throw "not JSON-serializable"
+ * T-PV-13: chainId echo in error message (family-agnostic — chainId는 echo만)
+ *
+ * connector-chain-addition-isolation 룰 회귀: helper에 chain-specific 분기 부재.
+ * dapp-input-sanitization 룰 회귀: 프로토타입 키 + DoS 가드.
+ */
+
+import { _validateSignPayload } from '../../../../src/sign/_validateSignPayload'
+import { ProviderError } from '../../../../src/error/ProviderError'
+import { ErrorCode } from '../../../../src/error/ErrorCode'
+
+describe('_validateSignPayload — type 검증', () => {
+  test('T-PV-01: payload = undefined → throw INVALID_PARAMS', () => {
+    expect(() => _validateSignPayload('eip155:1', undefined)).toThrow(ProviderError)
+    try {
+      _validateSignPayload('eip155:1', undefined)
+    } catch (e) {
+      expect((e as ProviderError).code).toBe(ErrorCode.INVALID_PARAMS)
+      expect((e as ProviderError).message).toMatch(/expected object/)
+      expect((e as ProviderError).message).toMatch(/undefined/)
+    }
+  })
+
+  test('T-PV-02: payload = null → throw "got null"', () => {
+    expect(() => _validateSignPayload('eip155:1', null)).toThrow(ProviderError)
+    try {
+      _validateSignPayload('eip155:1', null)
+    } catch (e) {
+      expect((e as ProviderError).message).toMatch(/null/)
+    }
+  })
+
+  test('T-PV-03: payload = [] (array) → throw "got array"', () => {
+    expect(() => _validateSignPayload('eip155:1', [])).toThrow(ProviderError)
+    try {
+      _validateSignPayload('eip155:1', [])
+    } catch (e) {
+      expect((e as ProviderError).message).toMatch(/array/)
+    }
+  })
+
+  test('T-PV-04: payload = string → throw "expected object"', () => {
+    expect(() => _validateSignPayload('eip155:1', 'oops' as unknown as object)).toThrow(ProviderError)
+    try {
+      _validateSignPayload('eip155:1', 'oops' as unknown as object)
+    } catch (e) {
+      expect((e as ProviderError).message).toMatch(/expected object/)
+      expect((e as ProviderError).message).toMatch(/string/)
+    }
+  })
+
+  test('T-PV-04b: payload = number / boolean → throw', () => {
+    expect(() => _validateSignPayload('eip155:1', 42 as unknown as object)).toThrow(ProviderError)
+    expect(() => _validateSignPayload('eip155:1', true as unknown as object)).toThrow(ProviderError)
+  })
+})
+
+describe('_validateSignPayload — keyPath 필수', () => {
+  test('T-PV-05: payload = {} (no keyPath) → helpful error with example', () => {
+    expect(() => _validateSignPayload('eip155:1', {})).toThrow(ProviderError)
+    try {
+      _validateSignPayload('eip155:1', {})
+    } catch (e) {
+      expect((e as ProviderError).code).toBe(ErrorCode.INVALID_PARAMS)
+      expect((e as ProviderError).message).toMatch(/'keyPath' field required/)
+      expect((e as ProviderError).message).toMatch(/BIP44/)
+      // 예시 포함
+      expect((e as ProviderError).message).toMatch(/Example/)
+    }
+  })
+
+  test('T-PV-06: payload.keyPath = "" (empty string) → throw "must not be empty"', () => {
+    expect(() => _validateSignPayload('eip155:1', { keyPath: '' })).toThrow(ProviderError)
+    try {
+      _validateSignPayload('eip155:1', { keyPath: '' })
+    } catch (e) {
+      expect((e as ProviderError).message).toMatch(/must not be empty/)
+    }
+  })
+
+  test('T-PV-07: payload.keyPath = 123 (non-string) → throw "field required"', () => {
+    expect(() => _validateSignPayload('eip155:1', { keyPath: 123 })).toThrow(ProviderError)
+    try {
+      _validateSignPayload('eip155:1', { keyPath: 123 })
+    } catch (e) {
+      expect((e as ProviderError).message).toMatch(/'keyPath' field required/)
+    }
+  })
+
+  test('T-PV-08: minimal valid payload (keyPath only) → no throw', () => {
+    expect(() => _validateSignPayload('eip155:1', { keyPath: "m/44'/60'/0'/0/0" })).not.toThrow()
+  })
+
+  test('T-PV-08b: valid payload with family-specific extras → no throw (family은 sdk 책임)', () => {
+    expect(() =>
+      _validateSignPayload('eip155:1', {
+        keyPath: "m/44'/60'/0'/0/0",
+        message: '0xdeadbeef',
+        address: '0xabc',
+      }),
+    ).not.toThrow()
+  })
+})
+
+describe('_validateSignPayload — 프로토타입 오염 차단', () => {
+  test('T-PV-09: payload with own-property __proto__ → throw "prototype key"', () => {
+    // Object.defineProperty로 own-property로 설정 (객체 리터럴의 __proto__는 prototype을 set하므로)
+    const payload = { keyPath: "m/44'/60'/0'/0/0" }
+    Object.defineProperty(payload, '__proto__', {
+      value: { evil: true },
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    })
+    expect(() => _validateSignPayload('eip155:1', payload)).toThrow(ProviderError)
+    try {
+      _validateSignPayload('eip155:1', payload)
+    } catch (e) {
+      expect((e as ProviderError).message).toMatch(/prototype key/)
+      expect((e as ProviderError).message).toMatch(/__proto__/)
+    }
+  })
+
+  test('T-PV-10: payload with own-property "constructor" → throw', () => {
+    const payload: Record<string, unknown> = { keyPath: "m/44'/60'/0'/0/0", constructor: 'evil' }
+    expect(() => _validateSignPayload('eip155:1', payload)).toThrow(ProviderError)
+    try {
+      _validateSignPayload('eip155:1', payload)
+    } catch (e) {
+      expect((e as ProviderError).message).toMatch(/constructor/)
+    }
+  })
+
+  test('T-PV-10b: payload with own-property "prototype" → throw', () => {
+    const payload: Record<string, unknown> = { keyPath: "m/44'/60'/0'/0/0", prototype: 'evil' }
+    expect(() => _validateSignPayload('eip155:1', payload)).toThrow(ProviderError)
+  })
+
+  test('T-PV-10c: inherited "constructor" (no own-property) → 통과 (chain prototype은 모든 객체가 가짐)', () => {
+    // 일반 object 리터럴은 constructor를 inherited로 갖지만 own-property는 아님 → 통과해야 함
+    expect(() =>
+      _validateSignPayload('eip155:1', { keyPath: "m/44'/60'/0'/0/0", message: 'hi' }),
+    ).not.toThrow()
+  })
+})
+
+describe('_validateSignPayload — DoS 가드', () => {
+  test('T-PV-11: payload size > 64KB → throw "exceeds 65536-byte limit"', () => {
+    const bigString = 'x'.repeat(70 * 1024) // 70KB
+    expect(() =>
+      _validateSignPayload('eip155:1', { keyPath: "m/44'/60'/0'/0/0", bigBlob: bigString }),
+    ).toThrow(ProviderError)
+    try {
+      _validateSignPayload('eip155:1', { keyPath: "m/44'/60'/0'/0/0", bigBlob: bigString })
+    } catch (e) {
+      expect((e as ProviderError).message).toMatch(/exceeds/)
+      expect((e as ProviderError).message).toMatch(/65536/)
+    }
+  })
+
+  test('T-PV-12: payload with circular reference → throw "not JSON-serializable"', () => {
+    const payload: Record<string, unknown> = { keyPath: "m/44'/60'/0'/0/0" }
+    payload.self = payload // circular
+    expect(() => _validateSignPayload('eip155:1', payload)).toThrow(ProviderError)
+    try {
+      _validateSignPayload('eip155:1', payload)
+    } catch (e) {
+      expect((e as ProviderError).message).toMatch(/not JSON-serializable/)
+    }
+  })
+
+  test('T-PV-11b: payload size at boundary (just under 64KB) → 통과', () => {
+    // 64KB - 200 byte overhead → 안전 영역
+    const safeString = 'x'.repeat(60 * 1024)
+    expect(() =>
+      _validateSignPayload('eip155:1', { keyPath: "m/44'/60'/0'/0/0", blob: safeString }),
+    ).not.toThrow()
+  })
+})
+
+describe('_validateSignPayload — chainId echo (family-agnostic 회귀)', () => {
+  test('T-PV-13: 에러 메시지에 chainId가 echo되지만 분기 로직은 부재', () => {
+    // 다양한 chainId로 호출해도 동일한 에러 패턴이 발생 (family-specific 분기 X)
+    const chainIds = ['eip155:1', 'bip122:000', 'solana:mainnet', 'cosmos:cosmoshub-4']
+    for (const chainId of chainIds) {
+      try {
+        _validateSignPayload(chainId, undefined)
+        fail(`Expected throw for chainId ${chainId}`)
+      } catch (e) {
+        expect((e as ProviderError).code).toBe(ErrorCode.INVALID_PARAMS)
+        // chainId는 에러 메시지에 echo만 됨 (분기 로직 부재)
+        expect((e as ProviderError).message).toContain(chainId)
+        // 동일한 에러 패턴 — chain별 다른 메시지가 아님
+        expect((e as ProviderError).message).toMatch(/expected object/)
+      }
+    }
+  })
+})


### PR DESCRIPTION
## Objective

- **ID**: `m09-04-05-connector-sign-payload-contract`
- **Jira**: [DC-2237](https://iotrust.atlassian.net/browse/DC-2237) (Epic: [DC-2223](https://iotrust.atlassian.net/browse/DC-2223))
- **Epic branch**: `epic/DC-2223_m09-04-connector-v2-cleanup`
- **Base ref**: `62c8f24` (m09-04-01 + m09-04-01.5 머지 후)

## 변경 사항

v2 통합 sign API (`dcent.sign({method, chainId, payload})`)의 **payload shape contract**를 명문화. dApp이 잘못된 payload를 보낼 때 wm 도달 전 connector level에서 helpful error로 차단한다.

### Family-agnostic light validation (`_validateSignPayload`)

`connector-chain-addition-isolation` 룰 준수 — chain enum / 정적 매핑 / family-specific 분기 절대 부재:

| 검증 항목 | 룰 |
|---|---|
| `payload`가 plain object (null/array/primitive 거부) | `dapp-input-sanitization` |
| `payload.keyPath`가 non-empty string (sdk handleRequest 필수) | `boundary-validation` |
| 프로토타입 키 own-property 차단 (`__proto__`/`constructor`/`prototype`) | `dapp-input-sanitization` (C3) |
| 직렬화 크기 ≤ 64KB + 순환 참조 거부 | DoS 방어 |

family-specific 검증 (EVM personal_sign의 address 등)은 sdk handleRequest 책임 (m09-03-05 ceremony).

## 신규 / 수정

### 신규
- `src/sign/_validateSignPayload.ts` (123 LOC) — family-agnostic helper + `SignPayload` interface
- `tests/unit/v2/sign/validateSignPayload.test.ts` (216 LOC) — T-PV-01~13

### 수정
- `src/sign/sign.ts` (+44 LOC) — `sign()` 진입점에 `_validateSignPayload(safeChainId, input.payload)` 호출 추가 + JSDoc family별 example
- `tests/unit/v2/sign/sign.test.ts` (10 LOC 조정) — happy-path 테스트에 `keyPath` 추가 (NEW contract 준수)

**Total**: ~393 LOC net (600 한계 안전, `pr-size-exception` 미사용)

## 자동 검증 결과

| 명령 | 결과 |
|---|---|
| `yarn unit-v2` | **462 PASS** (29 suites, validateSignPayload.test.ts 포함) |
| `yarn unit-mock` | **69 PASS** (v0.16.0 호환성 회귀 0) |
| `yarn lint` | PASS |
| `yarn tsc` (`--noEmit`) | PASS |
| `yarn build` | PASS (webpack v1+v2 entrypoints) |
| **T-GREP-01**: `_validateSignPayload\(` in `src/sign/sign.ts` | PASS (sign.ts:95) |
| **T-GREP-02**: chain-specific 코드 분기 부재 | PASS (`connector-chain-addition-isolation` 룰) |

## Sign 한바퀴 완성 chain

```
m09-03-05 (sdk ceremony)  →  ★ m09-04-05 (본 PR)  →  m09-04-06 (docs+playground+e2e)
                                  ↓
                          dApp UX 개선 + 회귀 종료
```

본 PR이 머지되면 **connector 측 payload contract** 가 명문화되어 sdk의 ceremony patch (m09-03-05) 와 짝을 이룬다.

## 적용 룰

- `connector-chain-addition-isolation` — `_validateSignPayload`는 family-agnostic, chain-specific 분기 부재
- `dapp-input-sanitization` — 프로토타입 키 차단 + DoS 가드
- `provider-security-checklist` C3 — dApp options whitelist
- `error-handling-consistency` — INVALID_PARAMS 일관 throw 패턴
- `automated-verification-required` — Jest 단위 + lint + tsc + build 필수 조합 PASS
- `no-version-bump` — package.json version 미수정
- `release-unit-versioning` — epic m09-04 child, base=epic branch

## 머지 순서

본 PR은 `epic/DC-2223_m09-04-connector-v2-cleanup`로 머지된다 (epic child). Epic 최종 PR (epic → dev)은 m09-04-04 + m09-04-06 머지 후 별도로 생성.

🤖 Generated by `/uap-autopilot-objective` (`uap-autopilot-chain` orchestrator)