### PR TITLE
[DC-2297] feat(playground): account/device API 8개 노출 + 그룹 재구성

### DIFF
--- a/playground.js
+++ b/playground.js
@@ -85,6 +85,11 @@
   var nonEvmPresetsMap = {} // presetId → preset object
   var nonEvmPresetsList = [] // 전체 비-EVM preset 배열
 
+  // ── account preset runtime state (m11-01-01) ──
+  // presets.account.json 로드 후 채워진다. syncAccount form의 preset selector에서 사용.
+  var accountPresetsList = [] // 전체 account preset 배열
+  var accountPresetsMap = {} // presetId → preset object
+
   // ── FAMILY_LABELS: family → 트리 표시명 ──
   // m06-01-03 추가, m06-01-04 신규 8 family 표시명 추가
   var FAMILY_LABELS = {
@@ -136,9 +141,19 @@
   var TREE = [
     {
       kind: 'group',
-      label: 'Device',
+      label: 'Account / Device',
       items: [
-        { kind: 'method', id: 'getDeviceInfo', label: 'getDeviceInfo' },
+        // m11-01-01: v1 read-only / configure / address API를 playground에 노출 (8 method)
+        // 기존 Device 그룹의 getDeviceInfo는 이 그룹으로 흡수. method id는 trie 분기를 위해
+        // 'account:' prefix 사용 (selectMethod / Send dispatcher가 prefix로 분기).
+        { kind: 'method', id: 'account:info', label: 'info' },
+        { kind: 'method', id: 'account:getDeviceInfo', label: 'getDeviceInfo' },
+        { kind: 'method', id: 'account:getAccountInfo', label: 'getAccountInfo' },
+        { kind: 'method', id: 'account:setLabel', label: 'setLabel' },
+        { kind: 'method', id: 'account:syncAccount', label: 'syncAccount' },
+        { kind: 'method', id: 'account:selectAddress', label: 'selectAddress' },
+        { kind: 'method', id: 'account:getAddress', label: 'getAddress' },
+        { kind: 'method', id: 'account:getXPUB', label: 'getXPUB' },
       ],
     },
     {
@@ -443,8 +458,25 @@
         nonEvmPresetsMap = {}
       })
 
-    // 셋 다 완료 후 트리 재빌드
-    Promise.all([chainsPromise, evmPresetsPromise, nonEvmPresetsPromise]).then(function () {
+    // presets.account.json (m11-01-01) — syncAccount 폼 preset
+    var accountPresetsPromise = fetch('/playground/presets.account.json')
+      .then(function (r) {
+        if (!r.ok) throw new Error('presets.account.json fetch failed: ' + r.status)
+        return r.json()
+      })
+      .then(function (presets) {
+        accountPresetsList = presets
+        accountPresetsMap = {}
+        presets.forEach(function (p) { accountPresetsMap[p.id] = p })
+      })
+      .catch(function () {
+        // account preset 로드 실패 — preset selector 없는 syncAccount 폼으로 degraded mode
+        accountPresetsList = []
+        accountPresetsMap = {}
+      })
+
+    // 모두 완료 후 트리 재빌드
+    Promise.all([chainsPromise, evmPresetsPromise, nonEvmPresetsPromise, accountPresetsPromise]).then(function () {
       state.evmChainsLoaded = true
       buildEvmSignTxGroup()
       buildNonEvmSignTxGroups()
@@ -557,8 +589,9 @@
     formTitle.textContent = methodDef.label || methodDef.id
     formFields.innerHTML = ''
 
-    if (methodDef.id === 'getDeviceInfo') {
-      renderGetDeviceInfoForm()
+    if (methodDef.id.startsWith('account:')) {
+      // m11-01-01: account/device API form
+      renderAccountForm(methodDef)
     } else if (methodDef.id.startsWith('signMessage:')) {
       renderSignMessageForm(methodDef)
     } else if (methodDef.id.startsWith('signTx:evm:')) {
@@ -572,11 +605,160 @@
     updateSendBtn()
   }
 
-  function renderGetDeviceInfoForm () {
-    var note = document.createElement('p')
-    note.style.cssText = 'font-size:11px;color:#888;margin-bottom:8px;'
-    note.textContent = 'Fetches device firmware, model, and address info.'
-    formFields.appendChild(note)
+  // ── renderAccountForm (m11-01-01) ──
+  // v1 호환 account/device API 8개의 동적 form 빌더.
+  // methodDef.id는 'account:{name}' 형식으로 분기 — name별 input 구성이 다르다.
+  // 모든 form은 _unwrapV1Envelope를 통해 v1 envelope을 unwrap한 결과를 결과 로그에 표시한다.
+  //
+  // 룰 준수:
+  //   - dapp-input-sanitization: syncAccount JSON.parse 결과는 known fields whitelist만 추출
+  //   - boundary-validation: JSON.parse 결과 Array.isArray 검증
+  //   - error-handling-consistency: facade throw → catch → UI error 표시 통일 (appendLog error 분기)
+  function renderAccountForm (methodDef) {
+    var name = methodDef.id.slice('account:'.length)
+
+    if (name === 'info' || name === 'getDeviceInfo' || name === 'getAccountInfo') {
+      // no-arg — 안내문만
+      var note = document.createElement('p')
+      note.style.cssText = 'font-size:11px;color:#888;margin-bottom:8px;'
+      if (name === 'info') {
+        note.textContent = 'Fetches D\'CENT Bridge daemon status.'
+      } else if (name === 'getDeviceInfo') {
+        note.textContent = 'Fetches device firmware, model, and address info.'
+      } else {
+        note.textContent = 'Fetches account list registered in the wallet.'
+      }
+      formFields.appendChild(note)
+      return
+    }
+
+    if (name === 'setLabel') {
+      appendFormRow('label', 'Label', 'input', {
+        value: '',
+        placeholder: '2~14 chars: a-z A-Z 0-9 . ! # $ % & + - _',
+      })
+      return
+    }
+
+    if (name === 'syncAccount') {
+      // preset selector (loaded from presets.account.json)
+      var applicablePresets = accountPresetsList.filter(function (p) {
+        return !p.applicableMethodIds || p.applicableMethodIds.indexOf(methodDef.id) !== -1
+      })
+      if (applicablePresets.length > 0) {
+        var presetRow = document.createElement('div')
+        presetRow.className = 'form-row'
+        var presetLabel = document.createElement('label')
+        presetLabel.setAttribute('for', 'field-preset')
+        presetLabel.textContent = 'Preset'
+        var presetSelect = document.createElement('select')
+        presetSelect.id = 'field-preset'
+        var defaultOpt = document.createElement('option')
+        defaultOpt.value = ''
+        defaultOpt.textContent = '-- select preset --'
+        presetSelect.appendChild(defaultOpt)
+        applicablePresets.forEach(function (p) {
+          var opt = document.createElement('option')
+          opt.value = p.id
+          opt.textContent = p.label
+          presetSelect.appendChild(opt)
+        })
+        presetSelect.addEventListener('change', function () {
+          var presetId = presetSelect.value
+          if (!presetId) return
+          var preset = accountPresetsMap[presetId]
+          if (!preset) return
+          var ta = document.getElementById('field-accountInfosJson')
+          if (ta) ta.value = JSON.stringify(preset.value, null, 2)
+        })
+        presetRow.appendChild(presetLabel)
+        presetRow.appendChild(presetSelect)
+        formFields.appendChild(presetRow)
+      }
+      var ta = appendFormRow('accountInfosJson', 'accountInfos (JSON array)', 'textarea', {
+        value: '',
+        placeholder: '[{"coin_group":"EVM","coin_name":"ETHEREUM","label":"ETH-1"}]',
+      })
+      if (ta) ta.rows = 8
+      return
+    }
+
+    if (name === 'selectAddress') {
+      var ta2 = appendFormRow('addressesJson', 'addresses (JSON array)', 'textarea', {
+        value: '',
+        placeholder: '["0xabc...", "0xdef..."]',
+      })
+      if (ta2) ta2.rows = 4
+      return
+    }
+
+    if (name === 'getAddress') {
+      // coinType <select> — src/types/coinType.ts enum 키 사용
+      var coinTypeKeys = Object.keys((window.dcent && window.dcent.coinType) || {})
+      if (coinTypeKeys.length === 0) {
+        // fallback (test 환경 등에서 window.dcent 미설정 시)
+        coinTypeKeys = ['BITCOIN', 'ETHEREUM', 'KLAYTN', 'RIPPLE', 'TRON', 'STELLAR']
+      }
+      var ctRow = document.createElement('div')
+      ctRow.className = 'form-row'
+      var ctLabel = document.createElement('label')
+      ctLabel.setAttribute('for', 'field-coinType')
+      ctLabel.textContent = 'coinType'
+      var ctSelect = document.createElement('select')
+      ctSelect.id = 'field-coinType'
+      coinTypeKeys.forEach(function (k) {
+        var opt = document.createElement('option')
+        opt.value = k
+        opt.textContent = k
+        ctSelect.appendChild(opt)
+      })
+      // default 'ETHEREUM' if available
+      if (coinTypeKeys.indexOf('ETHEREUM') !== -1) ctSelect.value = 'ETHEREUM'
+      ctRow.appendChild(ctLabel)
+      ctRow.appendChild(ctSelect)
+      formFields.appendChild(ctRow)
+
+      appendFormRow('path', 'Key Path', 'input', {
+        value: "m/44'/60'/0'/0/0",
+        placeholder: "m/44'/60'/0'/0/0",
+      })
+      appendFormRow('prefix', 'prefix (optional, parachain)', 'input', {
+        value: '',
+        placeholder: '(leave empty unless parachain)',
+      })
+      return
+    }
+
+    if (name === 'getXPUB') {
+      appendFormRow('key', 'Key Path', 'input', {
+        value: "m/44'/60'/0'",
+        placeholder: "m/44'/60'/0'",
+      })
+      appendFormRow('bip32name', 'bip32name (optional)', 'input', {
+        value: '',
+        placeholder: '(default "Bitcoin seed")',
+      })
+      return
+    }
+  }
+
+  // ── sanitize helper for syncAccount (m11-01-01) ──
+  // dapp-input-sanitization 룰: known fields whitelist만 추출, __proto__ / unknown key silent drop.
+  // playground 로컬 helper (connector src/sign/sanitize.ts는 string scalar 전용으로 다른 용도).
+  function _sanitizeSyncAccountInfos (parsed) {
+    if (!Array.isArray(parsed)) {
+      throw new Error('accountInfos must be an array')
+    }
+    return parsed.map(function (a) {
+      if (!a || typeof a !== 'object') {
+        throw new Error('each account entry must be an object')
+      }
+      return {
+        coin_group: String(a.coin_group == null ? '' : a.coin_group),
+        coin_name: String(a.coin_name == null ? '' : a.coin_name),
+        label: String(a.label == null ? '' : a.label),
+      }
+    })
   }
 
   function renderSignMessageForm (methodDef) {
@@ -938,8 +1120,9 @@
 
     clearFieldErrors()
 
-    if (methodId === 'getDeviceInfo') {
-      sendGetDeviceInfo()
+    if (methodId.startsWith('account:')) {
+      // m11-01-01: account/device API dispatcher
+      sendAccountCall(methodId)
     } else if (methodId.startsWith('signMessage:')) {
       sendSignMessage()
     } else if (methodId.startsWith('signTx:evm:')) {
@@ -962,23 +1145,122 @@
     }
   }
 
-  function sendGetDeviceInfo () {
+  // ── sendAccountCall (m11-01-01) ──
+  // v1 호환 account/device API 8개 dispatcher.
+  //   - facade는 v1 envelope ({header, body.parameter})으로 resolve 또는 dcentException throw.
+  //   - _unwrapV1Envelope: success → body.parameter unwrap, failure → throw (b08-01: DC-2097 회귀 방지).
+  //   - 모든 분기는 동일 패턴: try/catch + appendLog (error-handling-consistency).
+  //
+  // setLabel / syncAccount는 facade가 **synchronously** throw할 수 있다 (regex / coinGroup / coinName 검증).
+  // 모두 try 안에서 호출하여 Promise rejection으로 통일한다.
+  function sendAccountCall (methodId) {
+    var name = methodId.slice('account:'.length)
     var startMs = Date.now()
     var dcent = _getDcent()
-    // m08-01-05: facade의 v1 호환 API — 응답은 v1 envelope ({header, body.parameter})
-    // b08-01: _unwrapV1Envelope이 success → body.parameter unwrap, failure → throw로 변환
-    dcent.getDeviceInfo().then(_unwrapV1Envelope).then(function (result) {
-      state.device = result
+
+    // method별 인자 수집 + facade 호출. async IIFE로 sync throw → Promise rejection 통일.
+    var callPromise = (function () {
+      try {
+        if (name === 'info') return dcent.info()
+        if (name === 'getDeviceInfo') return dcent.getDeviceInfo()
+        if (name === 'getAccountInfo') return dcent.getAccountInfo()
+
+        if (name === 'setLabel') {
+          var labelEl = document.getElementById('field-label')
+          var label = labelEl ? labelEl.value : ''
+          return dcent.setLabel(label)
+        }
+
+        if (name === 'syncAccount') {
+          var taEl = document.getElementById('field-accountInfosJson')
+          var raw = taEl ? taEl.value.trim() : ''
+          if (!raw) {
+            return Promise.reject(new Error('accountInfos JSON is required'))
+          }
+          var parsed
+          try {
+            parsed = JSON.parse(raw)
+          } catch (e) {
+            return Promise.reject(new Error('Invalid JSON: ' + e.message))
+          }
+          var sanitized = _sanitizeSyncAccountInfos(parsed)
+          return dcent.syncAccount(sanitized)
+        }
+
+        if (name === 'selectAddress') {
+          var addrEl = document.getElementById('field-addressesJson')
+          var addrRaw = addrEl ? addrEl.value.trim() : ''
+          if (!addrRaw) {
+            return Promise.reject(new Error('addresses JSON is required'))
+          }
+          var addrParsed
+          try {
+            addrParsed = JSON.parse(addrRaw)
+          } catch (e2) {
+            return Promise.reject(new Error('Invalid JSON: ' + e2.message))
+          }
+          if (!Array.isArray(addrParsed)) {
+            return Promise.reject(new Error('addresses must be a JSON array'))
+          }
+          // dapp-input-sanitization: each element → string (silent coerce)
+          var addrs = addrParsed.map(function (a) { return String(a) })
+          return dcent.selectAddress(addrs)
+        }
+
+        if (name === 'getAddress') {
+          var ctEl = document.getElementById('field-coinType')
+          var pathEl = document.getElementById('field-path')
+          var prefixEl = document.getElementById('field-prefix')
+          var coinTypeKey = ctEl ? ctEl.value : ''
+          // playground select는 enum 키 (예: 'ETHEREUM')를 노출 — facade의 isAvaliableCoinType은
+          // key 또는 value 모두 toLowerCase 비교로 매치하므로 그대로 전달해도 동작.
+          // 단, facade 시그니처는 v1 1:1 — getAddress(coinType, path, prefix).
+          // 사용자가 enum 키로 보낼지 value로 보낼지 결정해야 한다. coinType.ts enum이 import되어 있으면
+          // key → value 변환을 한 번 거친다.
+          var coinTypeValue = coinTypeKey
+          var coinTypeEnum = (window.dcent && window.dcent.coinType) || {}
+          if (coinTypeEnum[coinTypeKey] !== undefined) {
+            coinTypeValue = coinTypeEnum[coinTypeKey]
+          }
+          var path = pathEl ? pathEl.value.trim() : ''
+          var prefixRaw = prefixEl ? prefixEl.value.trim() : ''
+          var prefix = prefixRaw === '' ? null : prefixRaw
+          return dcent.getAddress(coinTypeValue, path, prefix)
+        }
+
+        if (name === 'getXPUB') {
+          var keyEl = document.getElementById('field-key')
+          var bipEl = document.getElementById('field-bip32name')
+          var key = keyEl ? keyEl.value.trim() : ''
+          var bip32name = bipEl ? bipEl.value.trim() : ''
+          // facade signature: getXPUB(key, bip32name). bip32name이 빈 값이면 undefined 전달
+          // (facade 내부에서 default 'Bitcoin seed' 처리는 spec에 명시되지 않으므로 그대로 위임).
+          return dcent.getXPUB(key, bip32name === '' ? undefined : bip32name)
+        }
+
+        return Promise.reject(new Error('Unknown method: ' + methodId))
+      } catch (syncErr) {
+        // setLabel / syncAccount의 facade sync throw (dcentException) → Promise rejection으로 통일
+        return Promise.reject(syncErr)
+      }
+    })()
+
+    // common envelope unwrap + log
+    callPromise.then(_unwrapV1Envelope).then(function (result) {
+      if (name === 'getDeviceInfo') {
+        state.device = result
+      }
       appendLog({
-        method: 'getDeviceInfo',
+        method: name,
         request: {},
         response: result,
         latencyMs: Date.now() - startMs,
-        deviceFirmware: result && result.firmware,
+        deviceFirmware: (name === 'getDeviceInfo' && result && result.firmware) ||
+          (state.device && state.device.firmware),
       })
     }).catch(function (err) {
       appendLog({
-        method: 'getDeviceInfo',
+        method: name,
         request: {},
         error: normalizeError(err),
         latencyMs: Date.now() - startMs,
@@ -1475,5 +1757,13 @@
     simulateRestLoad: function (chains, presets) {
       return window._playgroundTestAPI.simulateNonEvmLoad(chains, presets)
     },
+    // ── Account preset helpers (m11-01-01) ──
+    getAccountPresetsList: function () { return accountPresetsList },
+    simulateAccountPresetsLoad: function (presets) {
+      accountPresetsList = presets || []
+      accountPresetsMap = {}
+      accountPresetsList.forEach(function (p) { accountPresetsMap[p.id] = p })
+    },
+    _sanitizeSyncAccountInfos: _sanitizeSyncAccountInfos,
   }
 })()

--- a/playground/presets.account.json
+++ b/playground/presets.account.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "syncAccount:eth-single",
+    "label": "Ethereum (single)",
+    "applicableMethodIds": ["account:syncAccount"],
+    "value": [
+      { "coin_group": "EVM", "coin_name": "ETHEREUM", "label": "ETH-1" }
+    ]
+  },
+  {
+    "id": "syncAccount:btc-single",
+    "label": "Bitcoin (single)",
+    "applicableMethodIds": ["account:syncAccount"],
+    "value": [
+      { "coin_group": "BITCOIN", "coin_name": "BITCOIN", "label": "BTC-1" }
+    ]
+  },
+  {
+    "id": "syncAccount:multi",
+    "label": "Multi (ETH + BTC)",
+    "applicableMethodIds": ["account:syncAccount"],
+    "value": [
+      { "coin_group": "EVM", "coin_name": "ETHEREUM", "label": "ETH-1" },
+      { "coin_group": "BITCOIN", "coin_name": "BITCOIN", "label": "BTC-1" }
+    ]
+  }
+]

--- a/tests/unit/2_v2_e2e/playground.account.spec.ts
+++ b/tests/unit/2_v2_e2e/playground.account.spec.ts
@@ -1,0 +1,365 @@
+/**
+ * playground.account.spec.ts — Playground v2 account/device API e2e (m11-01-01)
+ *
+ * index-v2.html 페이지를 puppeteer로 로드 후, _playgroundTestAPI.simulateConnect로
+ * facade-shaped mock을 inject한 뒤 8개 method 각각의 form 채우기 + Send round-trip을 검증한다.
+ *
+ * T-E2E-01 ~ T-E2E-09 (9개)
+ *
+ * 전제조건:
+ * - globalSetup이 harness server (port 9091) 구동 중
+ * - sdk dist build 존재 (또는 mock — 본 spec은 facade를 mock으로 대체하므로 sdk 미사용)
+ */
+const { launchBrowser } = require('./launchBrowser')
+
+const HARNESS_BASE = 'http://localhost:9091'
+const PLAYGROUND_URL = `${HARNESS_BASE}/index-v2.html`
+
+describe('[v2 e2e] playground account/device APIs', () => {
+  let browser: any
+  let page: any
+
+  beforeAll(async () => {
+    browser = await launchBrowser()
+    page = await browser.newPage()
+  })
+
+  afterAll(async () => {
+    await browser.close()
+  })
+
+  /**
+   * 각 it block 공통 셋업:
+   *   - playground 로드
+   *   - facade-shaped mock 주입 + spy 캡처
+   *   - test가 알아서 method node click + form 입력 + Send → log assertion
+   *
+   * mock spies는 page에 stash해두고 page.evaluate로 검사.
+   */
+  async function setupPlaygroundWithSpy () {
+    await page.goto(PLAYGROUND_URL, { waitUntil: 'networkidle0' })
+
+    await page.evaluate(() => {
+      const api = (window as any)._playgroundTestAPI
+      const calls: Array<{ method: string; args: any[] }> = []
+      const stubFor = (name: string) => (...args: any[]) => {
+        calls.push({ method: name, args })
+        return Promise.resolve({
+          header: { status: 'success', response_from: name },
+          body: { parameter: { ok: true, name }, command: name },
+        })
+      }
+      const mockDcent = {
+        info: stubFor('info'),
+        getDeviceInfo: stubFor('getDeviceInfo'),
+        getAccountInfo: stubFor('getAccountInfo'),
+        setLabel: stubFor('setLabel'),
+        syncAccount: stubFor('syncAccount'),
+        selectAddress: stubFor('selectAddress'),
+        getAddress: stubFor('getAddress'),
+        getXPUB: stubFor('getXPUB'),
+        sign: stubFor('sign'),
+        popupWindowClose: () => {},
+        setConnectionListener: () => {},
+        // expose enum for playground select rendering (subset for test)
+        coinType: { ETHEREUM: 'ethereum', BITCOIN: 'bitcoin' },
+      }
+      ;(window as any)._mockCalls = calls
+      ;(window as any)._mockDcent = mockDcent
+      // ensure window.dcent exposes coinType enum for renderAccountForm select
+      ;(window as any).dcent = (window as any).dcent || {}
+      ;(window as any).dcent.coinType = mockDcent.coinType
+
+      // account presets — fixture (시연용 1개로 충분)
+      api.simulateAccountPresetsLoad([
+        {
+          id: 'syncAccount:multi',
+          label: 'Multi (ETH + BTC)',
+          applicableMethodIds: ['account:syncAccount'],
+          value: [
+            { coin_group: 'EVM', coin_name: 'ETHEREUM', label: 'ETH-1' },
+            { coin_group: 'BITCOIN', coin_name: 'BITCOIN', label: 'BTC-1' },
+          ],
+        },
+      ])
+
+      api.simulateConnect(mockDcent, null, { model: 'Bio', firmware: '3.0' })
+    })
+  }
+
+  // ────────────────────────────────────────────────────────
+  // T-E2E-01: method tree에 'Account / Device' 그룹 + 8개 method node 렌더링
+  // ────────────────────────────────────────────────────────
+  it('T-E2E-01: account method tree에 8개 method node가 모두 렌더링된다', async () => {
+    await page.goto(PLAYGROUND_URL, { waitUntil: 'networkidle0' })
+
+    const expectedIds = [
+      'account:info',
+      'account:getDeviceInfo',
+      'account:getAccountInfo',
+      'account:setLabel',
+      'account:syncAccount',
+      'account:selectAddress',
+      'account:getAddress',
+      'account:getXPUB',
+    ]
+    for (const id of expectedIds) {
+      const sel = `[data-method-id="${id}"]`
+      const handle = await page.$(sel)
+      expect(handle).not.toBeNull()
+    }
+
+    // 그룹 label 확인
+    const labels = await page.$$eval('.tree-group-label', (els: Element[]) =>
+      els.map((e) => (e.textContent || '').trim())
+    )
+    expect(labels).toContain('Account / Device')
+  }, 30000)
+
+  // ────────────────────────────────────────────────────────
+  // T-E2E-02: setLabel — label input → Send → mock 수신 + success log
+  // ────────────────────────────────────────────────────────
+  it('T-E2E-02: setLabel round-trip → mock 수신 args + success log', async () => {
+    await setupPlaygroundWithSpy()
+
+    await page.click('[data-method-id="account:setLabel"]')
+    await page.type('#field-label', 'TEST-LABEL')
+    await page.click('#btn-send')
+    await new Promise((r) => setTimeout(r, 200))
+
+    const calls = await page.evaluate(() => (window as any)._mockCalls)
+    const setLabelCall = calls.find((c: any) => c.method === 'setLabel')
+    expect(setLabelCall).toBeDefined()
+    expect(setLabelCall.args[0]).toBe('TEST-LABEL')
+
+    const entries = await page.evaluate(() =>
+      (window as any)._playgroundTestAPI.getLogEntries()
+    )
+    const last = entries[entries.length - 1]
+    expect(last.method).toBe('setLabel')
+    expect(last.response).toBeDefined()
+    expect(last.error).toBeUndefined()
+  }, 30000)
+
+  // ────────────────────────────────────────────────────────
+  // T-E2E-03: syncAccount preset 클릭 → textarea 로드 → Send → accountInfos.length === 2
+  // ────────────────────────────────────────────────────────
+  it('T-E2E-03: syncAccount preset "Multi" 선택 → Send → mock 수신 accountInfos.length === 2', async () => {
+    await setupPlaygroundWithSpy()
+
+    await page.click('[data-method-id="account:syncAccount"]')
+    // preset select에서 multi 선택 (HTML select element 값 변경 후 change 이벤트 dispatch)
+    await page.select('#field-preset', 'syncAccount:multi')
+    // textarea가 채워졌는지 확인
+    const taValue = await page.$eval('#field-accountInfosJson', (el: HTMLTextAreaElement) => el.value)
+    expect(taValue).toContain('coin_group')
+    expect(taValue).toContain('ETHEREUM')
+    expect(taValue).toContain('BITCOIN')
+
+    await page.click('#btn-send')
+    await new Promise((r) => setTimeout(r, 200))
+
+    const calls = await page.evaluate(() => (window as any)._mockCalls)
+    const syncCall = calls.find((c: any) => c.method === 'syncAccount')
+    expect(syncCall).toBeDefined()
+    expect(Array.isArray(syncCall.args[0])).toBe(true)
+    expect(syncCall.args[0].length).toBe(2)
+    // sanitize: known fields only
+    expect(syncCall.args[0][0]).toEqual({
+      coin_group: 'EVM',
+      coin_name: 'ETHEREUM',
+      label: 'ETH-1',
+    })
+
+    const entries = await page.evaluate(() =>
+      (window as any)._playgroundTestAPI.getLogEntries()
+    )
+    const last = entries[entries.length - 1]
+    expect(last.method).toBe('syncAccount')
+    expect(last.error).toBeUndefined()
+  }, 30000)
+
+  // ────────────────────────────────────────────────────────
+  // T-E2E-04: getAddress coinType/path → Send → mock 수신 + 결과 출력
+  // ────────────────────────────────────────────────────────
+  it('T-E2E-04: getAddress (ETHEREUM, path) → mock 수신 args + success log', async () => {
+    await setupPlaygroundWithSpy()
+
+    await page.click('[data-method-id="account:getAddress"]')
+    // coinType select default 'ETHEREUM', path default fills key path
+    await page.click('#btn-send')
+    await new Promise((r) => setTimeout(r, 200))
+
+    const calls = await page.evaluate(() => (window as any)._mockCalls)
+    const gaCall = calls.find((c: any) => c.method === 'getAddress')
+    expect(gaCall).toBeDefined()
+    // coinType enum value (lowercased — coinType.ETHEREUM === 'ethereum')
+    expect(gaCall.args[0]).toBe('ethereum')
+    expect(gaCall.args[1]).toBe("m/44'/60'/0'/0/0")
+    // prefix is null when empty
+    expect(gaCall.args[2]).toBeNull()
+
+    const entries = await page.evaluate(() =>
+      (window as any)._playgroundTestAPI.getLogEntries()
+    )
+    const last = entries[entries.length - 1]
+    expect(last.method).toBe('getAddress')
+    expect(last.error).toBeUndefined()
+  }, 30000)
+
+  // ────────────────────────────────────────────────────────
+  // T-E2E-05: getXPUB — key input → Send → mock 수신
+  // ────────────────────────────────────────────────────────
+  it('T-E2E-05: getXPUB (key) → mock 수신 args + success log', async () => {
+    await setupPlaygroundWithSpy()
+
+    await page.click('[data-method-id="account:getXPUB"]')
+    // key input default "m/44'/60'/0'", bip32name empty
+    await page.click('#btn-send')
+    await new Promise((r) => setTimeout(r, 200))
+
+    const calls = await page.evaluate(() => (window as any)._mockCalls)
+    const xpubCall = calls.find((c: any) => c.method === 'getXPUB')
+    expect(xpubCall).toBeDefined()
+    expect(xpubCall.args[0]).toBe("m/44'/60'/0'")
+    // bip32name empty → undefined (puppeteer JSON-serializes undefined as null when crossing
+    // page boundary). 실제 facade call에는 undefined가 전달됨 — null 또는 undefined 모두 OK.
+    expect(xpubCall.args[1] == null).toBe(true)
+
+    const entries = await page.evaluate(() =>
+      (window as any)._playgroundTestAPI.getLogEntries()
+    )
+    const last = entries[entries.length - 1]
+    expect(last.method).toBe('getXPUB')
+    expect(last.error).toBeUndefined()
+  }, 30000)
+
+  // ────────────────────────────────────────────────────────
+  // T-E2E-06: selectAddress — JSON array textarea → Send → mock 수신 addresses.length === 2
+  // ────────────────────────────────────────────────────────
+  it('T-E2E-06: selectAddress JSON array → mock 수신 addresses.length === 2', async () => {
+    await setupPlaygroundWithSpy()
+
+    await page.click('[data-method-id="account:selectAddress"]')
+    await page.type('#field-addressesJson', '["0xabc","0xdef"]')
+    await page.click('#btn-send')
+    await new Promise((r) => setTimeout(r, 200))
+
+    const calls = await page.evaluate(() => (window as any)._mockCalls)
+    const saCall = calls.find((c: any) => c.method === 'selectAddress')
+    expect(saCall).toBeDefined()
+    expect(Array.isArray(saCall.args[0])).toBe(true)
+    expect(saCall.args[0]).toEqual(['0xabc', '0xdef'])
+
+    const entries = await page.evaluate(() =>
+      (window as any)._playgroundTestAPI.getLogEntries()
+    )
+    const last = entries[entries.length - 1]
+    expect(last.method).toBe('selectAddress')
+    expect(last.error).toBeUndefined()
+  }, 30000)
+
+  // ────────────────────────────────────────────────────────
+  // T-E2E-07: 3 no-arg cases — info / getDeviceInfo / getAccountInfo 각각 mock 수신
+  // ────────────────────────────────────────────────────────
+  it('T-E2E-07: 3 no-arg (info / getDeviceInfo / getAccountInfo) → 각각 mock 수신 + log', async () => {
+    await setupPlaygroundWithSpy()
+
+    // info
+    await page.click('[data-method-id="account:info"]')
+    await page.click('#btn-send')
+    await new Promise((r) => setTimeout(r, 100))
+
+    // getDeviceInfo
+    await page.click('[data-method-id="account:getDeviceInfo"]')
+    await page.click('#btn-send')
+    await new Promise((r) => setTimeout(r, 100))
+
+    // getAccountInfo
+    await page.click('[data-method-id="account:getAccountInfo"]')
+    await page.click('#btn-send')
+    await new Promise((r) => setTimeout(r, 100))
+
+    const calls = await page.evaluate(() => (window as any)._mockCalls)
+    const names = calls.map((c: any) => c.method)
+    expect(names).toContain('info')
+    expect(names).toContain('getDeviceInfo')
+    expect(names).toContain('getAccountInfo')
+
+    // 각 call의 args는 빈 배열 (no-arg)
+    const infoCall = calls.find((c: any) => c.method === 'info')
+    expect(infoCall.args.length).toBe(0)
+
+    const entries = await page.evaluate(() =>
+      (window as any)._playgroundTestAPI.getLogEntries()
+    )
+    const methods = entries.map((e: any) => e.method)
+    expect(methods).toContain('info')
+    expect(methods).toContain('getDeviceInfo')
+    expect(methods).toContain('getAccountInfo')
+  }, 30000)
+
+  // ────────────────────────────────────────────────────────
+  // T-E2E-08 (negative): syncAccount 잘못된 JSON → "Invalid JSON" + facade 미호출
+  // ────────────────────────────────────────────────────────
+  it('T-E2E-08 (negative): syncAccount invalid JSON → error log + facade 미호출', async () => {
+    await setupPlaygroundWithSpy()
+
+    await page.click('[data-method-id="account:syncAccount"]')
+    await page.type('#field-accountInfosJson', '{not valid json')
+    await page.click('#btn-send')
+    await new Promise((r) => setTimeout(r, 200))
+
+    const calls = await page.evaluate(() => (window as any)._mockCalls)
+    const syncCall = calls.find((c: any) => c.method === 'syncAccount')
+    expect(syncCall).toBeUndefined()
+
+    const entries = await page.evaluate(() =>
+      (window as any)._playgroundTestAPI.getLogEntries()
+    )
+    const errEntry = entries.find(
+      (e: any) => e.method === 'syncAccount' && e.error && /Invalid JSON/i.test(e.error.message || '')
+    )
+    expect(errEntry).toBeDefined()
+  }, 30000)
+
+  // ────────────────────────────────────────────────────────
+  // T-E2E-09 (negative): setLabel 빈 label → facade dcentException → error envelope log
+  //
+  // facade의 isAvaliableLabel regex가 fail하면 setLabel은 **synchronously** throw한다.
+  // 이번 테스트는 mock으로 facade를 대체하므로, mock의 setLabel을 일부러 reject하도록 만들어
+  // playground catch → appendLog error 분기가 동작함을 검증.
+  // ────────────────────────────────────────────────────────
+  it('T-E2E-09 (negative): setLabel empty label (mock rejects with param_error) → error log', async () => {
+    await setupPlaygroundWithSpy()
+
+    // setLabel mock을 override — empty label이면 param_error reject
+    await page.evaluate(() => {
+      const md = (window as any)._mockDcent
+      md.setLabel = (label: string) => {
+        if (!label || label.length < 2) {
+          const err: any = new Error('Invalid Label : ' + label)
+          err.code = 'param_error'
+          return Promise.reject(err)
+        }
+        return Promise.resolve({
+          header: { status: 'success' },
+          body: { parameter: { ok: true }, command: 'setLabel' },
+        })
+      }
+    })
+
+    await page.click('[data-method-id="account:setLabel"]')
+    // 빈 label 그대로 Send (default 값 '')
+    await page.click('#btn-send')
+    await new Promise((r) => setTimeout(r, 200))
+
+    const entries = await page.evaluate(() =>
+      (window as any)._playgroundTestAPI.getLogEntries()
+    )
+    const errEntry = entries.find(
+      (e: any) => e.method === 'setLabel' && e.error && e.error.code === 'param_error'
+    )
+    expect(errEntry).toBeDefined()
+  }, 30000)
+})

--- a/tests/unit/2_v2_e2e/playground.skeleton.spec.ts
+++ b/tests/unit/2_v2_e2e/playground.skeleton.spec.ts
@@ -91,7 +91,8 @@ describe('[v2 e2e] playground skeleton', () => {
     expect(dotClass).toContain('connected')
 
     // getDeviceInfo 선택 + Send
-    await page.click('[data-method-id="getDeviceInfo"]')
+    // m11-01-01: getDeviceInfo가 'Account / Device' 그룹으로 이동 — method id는 'account:getDeviceInfo'
+    await page.click('[data-method-id="account:getDeviceInfo"]')
     const sendDisabled = await page.$eval('#btn-send', (el: HTMLButtonElement) => el.disabled)
     expect(sendDisabled).toBe(false)
     await page.click('#btn-send')
@@ -191,7 +192,8 @@ describe('[v2 e2e] playground skeleton', () => {
     })
 
     // getDeviceInfo 선택
-    await page.click('[data-method-id="getDeviceInfo"]')
+    // m11-01-01: getDeviceInfo가 'Account / Device' 그룹으로 이동 — method id는 'account:getDeviceInfo'
+    await page.click('[data-method-id="account:getDeviceInfo"]')
 
     // simulateConnect로 state.connected=true이므로 method 선택 후 Send 활성화
     await page.click('#btn-send')
@@ -231,7 +233,8 @@ describe('[v2 e2e] playground skeleton', () => {
       api.simulateConnect(mockDcent, null, { model: 'Bio', firmware: '3.0' })
     })
 
-    await page.click('[data-method-id="getDeviceInfo"]')
+    // m11-01-01: getDeviceInfo가 'Account / Device' 그룹으로 이동 — method id는 'account:getDeviceInfo'
+    await page.click('[data-method-id="account:getDeviceInfo"]')
     await page.click('#btn-send')
     await new Promise((r) => setTimeout(r, 200))
 

--- a/tests/unit/v2/playground.signtx-evm.test.ts
+++ b/tests/unit/v2/playground.signtx-evm.test.ts
@@ -123,9 +123,10 @@ afterEach(() => {
 it('T-U-EVM-01: simulateEvmLoad 후 EVM 체인 노드가 TREE에 추가된다', () => {
   const api = (window as any)._playgroundTestAPI
 
-  // 로드 전: placeholder 제외 메서드 개수 (5 = 기존)
+  // 로드 전: placeholder 제외 메서드 개수
+  // m11-01-01: account/device 그룹 8 method + sign message 4 method = 12 (기존 5에서 변경)
   const beforeCount = api.countMethodNodes()
-  expect(beforeCount).toBe(5)
+  expect(beforeCount).toBe(12)
 
   // EVM 체인 로드 시뮬레이션
   api.simulateEvmLoad(SAMPLE_CHAINS, SAMPLE_PRESETS)

--- a/tests/unit/v2/playground.smoke.test.ts
+++ b/tests/unit/v2/playground.smoke.test.ts
@@ -68,19 +68,21 @@ afterEach(() => {
 })
 
 // ─────────────────────────────────────────────────────────
-// T-U-01: 트리 DOM 빌더 — TREE 선언적 객체에서 expected node 개수(getDeviceInfo 1 + signMessage 4 = 5)
+// T-U-01: 트리 DOM 빌더 — TREE 선언적 객체에서 expected node 개수
+// m11-01-01: Account/Device 그룹 8 method + signMessage 4 method = 12 (기존 5에서 변경)
 // ─────────────────────────────────────────────────────────
-it('T-U-01: 트리 DOM에 5개 non-placeholder method node가 렌더링된다', () => {
+it('T-U-01: 트리 DOM에 12개 non-placeholder method node가 렌더링된다', () => {
   const api = (window as any)._playgroundTestAPI
   expect(api).toBeDefined()
 
-  // countMethodNodes: placeholder 제외 카운트 (getDeviceInfo 1 + signMessage 4 = 5)
+  // countMethodNodes: placeholder 제외 카운트
+  // m11-01-01: Account/Device(8) + signMessage(4) = 12
   const count = api.countMethodNodes()
-  expect(count).toBe(5) // getDeviceInfo(1) + eth:personal(1) + eth:v3(1) + eth:v4(1) + sol:raw(1)
+  expect(count).toBe(12)
 
-  // DOM에는 placeholder 포함 6개 .tree-item (EVM 체인 로드 전 placeholder 1개 추가)
+  // DOM에는 placeholder 포함 13개 .tree-item (EVM 체인 로드 전 placeholder 1개 추가)
   const domItems = document.querySelectorAll('.tree-item')
-  expect(domItems.length).toBe(6) // 5 non-placeholder + 1 EVM loading placeholder
+  expect(domItems.length).toBe(13) // 12 non-placeholder + 1 EVM loading placeholder
 })
 
 // ─────────────────────────────────────────────────────────
@@ -259,7 +261,8 @@ it('T-U-08: facade v1 형식 error → LogEntry.error 매핑', async () => {
   api.simulateConnect(mockDcent, null, { model: 'Bio', firmware: '3.0' })
 
   // getDeviceInfo 선택
-  const getDeviceItem = document.querySelector('[data-method-id="getDeviceInfo"]') as HTMLElement
+  // m11-01-01: getDeviceInfo가 'Account / Device' 그룹으로 이동 — method id는 'account:getDeviceInfo'
+  const getDeviceItem = document.querySelector('[data-method-id="account:getDeviceInfo"]') as HTMLElement
   getDeviceItem.click()
 
   // Send 클릭
@@ -303,7 +306,8 @@ it('T-R-06: failure envelope resolve 시 error로 기록되고 state.device 미�
   expect(api.state.device).toBeNull()
 
   // getDeviceInfo 선택 후 Send
-  const getDeviceItem = document.querySelector('[data-method-id="getDeviceInfo"]') as HTMLElement
+  // m11-01-01: getDeviceInfo가 'Account / Device' 그룹으로 이동 — method id는 'account:getDeviceInfo'
+  const getDeviceItem = document.querySelector('[data-method-id="account:getDeviceInfo"]') as HTMLElement
   getDeviceItem.click()
   document.getElementById('btn-send')?.click()
 
@@ -347,7 +351,8 @@ it('T-R-09: onConnect → getDeviceInfo Send 흐름에서 state.device가 채워
   expect(mockGetDeviceInfo).not.toHaveBeenCalled()
 
   // 트리에서 getDeviceInfo 선택 → Send
-  const getDeviceItem = document.querySelector('[data-method-id="getDeviceInfo"]') as HTMLElement
+  // m11-01-01: getDeviceInfo가 'Account / Device' 그룹으로 이동 — method id는 'account:getDeviceInfo'
+  const getDeviceItem = document.querySelector('[data-method-id="account:getDeviceInfo"]') as HTMLElement
   getDeviceItem.click()
   document.getElementById('btn-send')?.click()
 
@@ -374,7 +379,8 @@ it('T-U-09: not connected → btn-send disabled; connect 후 method 선택 시 �
   expect(btnSend.getAttribute('aria-disabled')).toBe('true')
 
   // 메서드 선택 — 여전히 disabled (not connected)
-  const getDeviceItem = document.querySelector('[data-method-id="getDeviceInfo"]') as HTMLElement
+  // m11-01-01: getDeviceInfo가 'Account / Device' 그룹으로 이동 — method id는 'account:getDeviceInfo'
+  const getDeviceItem = document.querySelector('[data-method-id="account:getDeviceInfo"]') as HTMLElement
   getDeviceItem.click()
   expect(btnSend.disabled).toBe(true)
 


### PR DESCRIPTION
## 요약

connector v2 playground에 v1 호환 read-only / configure / address API 8개를 추가합니다. 기존 'Device' 그룹은 'Account / Device'로 확장되어 `getDeviceInfo`(기존) + 신규 7개를 포함합니다.

facade(`src/sign/info.ts`, `configure.ts`, `address.ts`)는 이미 m08-01-02.5에서 1:1 port되어 있으므로 본 작업은 playground UI만 변경합니다 — facade 시그니처 무변경, chain-agnostic 유지.

## Objective / 컨텍스트

- **Objective**: `m11-01-01-playground-account-apis` (epic m11-01 의 child 1)
- **Jira**: [DC-2297](https://iotrust.atlassian.net/browse/DC-2297)
- **Base**: `epic/DC-2223_m09-04-connector-v2-cleanup` (nested epic — m11-01 epic이 자체적으로 m09-04 epic 산하)
- **Type**: feature (epic child)

## 추가된 method (id prefix `account:`)

| method | form fields | facade |
|---|---|---|
| `info` | (no-arg) | `dcent.info()` |
| `getDeviceInfo` | (no-arg) | `dcent.getDeviceInfo()` |
| `getAccountInfo` | (no-arg) | `dcent.getAccountInfo()` |
| `setLabel` | label (text) | `dcent.setLabel(label)` |
| `syncAccount` | accountInfos (JSON textarea + preset) | `dcent.syncAccount(infos)` |
| `selectAddress` | addresses (JSON array textarea) | `dcent.selectAddress(addrs)` |
| `getAddress` | coinType `<select>` + path + prefix? | `dcent.getAddress(ct, p, pre)` |
| `getXPUB` | key + bip32name? | `dcent.getXPUB(key, bip32name)` |

## 변경 사항

**신규**:
- `playground/presets.account.json` — syncAccount용 sample preset 3종 (ETH single / BTC single / Multi)
- `tests/unit/2_v2_e2e/playground.account.spec.ts` — mock round-trip e2e (T-E2E-01~09, 9개)

**수정**:
- `playground.js`
  - TREE 'Device' 그룹 → 'Account / Device' (method node 8개)
  - `renderAccountForm(methodDef)` 신규 — methodId 분기로 8종 form 빌더
  - `sendAccountCall(methodId)` 신규 — 8종 facade dispatcher (sync throw → Promise rejection 통일)
  - `_sanitizeSyncAccountInfos(parsed)` 신규 — known fields whitelist (`coin_group`/`coin_name`/`label`)
  - `loadChainsData()`에 `presets.account.json` runtime fetch 추가
  - `_playgroundTestAPI`에 `getAccountPresetsList` / `simulateAccountPresetsLoad` / `_sanitizeSyncAccountInfos` 노출
- 기존 spec/test 4개 위치 (`getDeviceInfo` method id가 `account:getDeviceInfo`로 이동된 것을 반영):
  - `tests/unit/2_v2_e2e/playground.skeleton.spec.ts` — selector 3곳
  - `tests/unit/v2/playground.smoke.test.ts` — selector 4곳 + `countMethodNodes` 기대값 5→12
  - `tests/unit/v2/playground.signtx-evm.test.ts` — `beforeCount` 기대값 5→12

## 룰 준수

- **`dapp-input-sanitization`**: syncAccount/selectAddress JSON.parse 결과는 known fields whitelist만 추출. `__proto__` / unknown key silent drop
- **`boundary-validation`**: JSON.parse 결과 `Array.isArray` + 객체 타입 검증, 실패 시 throw
- **`error-handling-consistency`**: facade throw → playground catch → `appendLog({error})` 통일. setLabel/syncAccount의 sync throw(`dcentException`)도 Promise rejection으로 통일
- **`reuse-shared-utils`**: 기존 `_unwrapV1Envelope` / `appendFormRow` / `normalizeError` 재사용. local sanitize helper는 connector `src/sign/sanitize.ts`와 용도가 달라(string scalar vs array-of-object) playground 로컬에 신규
- **`connector-chain-addition-isolation`**: 8개 API 모두 chain-agnostic. facade 변경 없음. chain enum / `switch(chain)` 추가 없음
- **`no-version-bump`**: `package.json` `version` 무변경
- **DC-2097 회귀 방지**: 모든 dispatcher가 `_unwrapV1Envelope`를 거쳐 v1 failure envelope을 throw로 변환 (silent success로 흡수 방지)

## 자동 검증 결과 (T-XX coverage)

| 명령 | 결과 | T-XX |
|---|---|---|
| `yarn unit-v2-e2e -- playground.account.spec.ts` | ✅ 9/9 pass | T-E2E-01~09 |
| `yarn unit-v2-e2e -- playground` (전체 playground spec 5개) | ✅ 18/18 pass | 기존 + 신규 |
| `yarn unit-v2` | ✅ 462/462 pass | 회귀 0 |
| `yarn unit-mock` | ✅ 69/69 pass | 회귀 0 |
| `yarn lint` | ✅ pass | T-LINT-01 |
| `yarn build-dev` | ✅ pass | T-BUILD-01 |
| `yarn build` (production) | ✅ pass | T-BUILD-PROD-01 |

## Diff size

- 6 files changed: 728 insertions / 36 deletions (objective-pr-granularity 600 LOC ≤ 권장 초과 사유: 290 LOC가 본질적인 playground UI 신규 코드(renderAccountForm + sendAccountCall + sanitize helper), 나머지 ~150 LOC는 spec 파일. 카테고리 분리 없이 epic child 1 PR로 묶음)

## 비스코프 (다음 sibling에서 처리)

- Bitcoin tx builder 3개 — `m11-01-03-playground-bitcoin-tx-builder`
- `getAddress` chainId 재설계 — `m11-01-02-getaddress-chainid-facade` (facade) / `m11-01-04-playground-getaddress-form-migration` (UI)
- sdk 측 짝맞춤 — 별도 epic `m11-02-00-sdk-getaddress-chainid-handler`

## Test plan

- [ ] CI 모든 체크 통과
- [ ] 리뷰어 코드 리뷰
- [ ] (선택) 로컬에서 `yarn dev` 후 playground에서 8개 method 클릭 → form 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)