### PR TITLE
[DC-2300] feat(sign): getAddress v2 chainId facade overload — m11-01-02

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,8 @@ export {
   addBitcoinTransactionOutput,
 } from './sign'
 export type { SyncAccountInfo, BitcoinTxObject, BitcoinTxParameter } from './sign'
+// m11-01-02: v2 chainId facade input type for getAddress overload
+export type { GetAddressV2Input } from './sign'
 // v1 validator helpers — dApp 표면 1:1 보존 (v1 typo `getCzonePrifix` 포함)
 export {
   isAvaliableCoinType,

--- a/src/sign/address.ts
+++ b/src/sign/address.ts
@@ -1,9 +1,18 @@
 /**
- * v1 getAddress / getXPUB port (m08-01-02.5)
+ * v1 getAddress / getXPUB port (m08-01-02.5) + v2 chainId facade (m11-01-02)
  *
  * v1 src-v1/index.js의 `dcent.getAddress` (l781-813), `dcent.getXPUB` (l822-830)를 1:1 port.
  *
- * getAddress 핵심 동작:
+ * **m11-01-02**: `getAddress`에 sign 패턴과 동일한 chainId 컨셉을 도입.
+ *   - 신규 v2 시그니처: `getAddress({chainId, keyPath, prefix?})` — chainId pass-through
+ *   - 기존 v1 시그니처: `getAddress(coinType, path, prefix?)` — backward-compat 유지
+ *   - 런타임 typeguard로 분기 (첫 인자가 object면 v2, string이면 v1)
+ *
+ * connector-chain-addition-isolation 룰: v2 path는 chainId pass-through만 수행한다.
+ * chain enum / chain → method 정적 매핑 / chain-prefixed switch 분기 추가 0건.
+ * 실제 chainId → 디바이스 명령 변환은 sdk + wallet-models 책임 (m11-02).
+ *
+ * getAddress v1 핵심 동작 (변경 없음):
  *   1. coinType 검증 (`isAvaliableCoinType`) — fail 시 `coin_type_error` throw
  *   2. params 구성 — czone이면 `coinType: 'czone'`, 아니면 원본 coinType
  *   3. czone이면 `optionParam = getCzonePrifix(coinType)` (Buffer hex)
@@ -11,18 +20,27 @@
  *   5. `_call({method: 'getAddress', params})` 호출
  *   6. 응답 `header.response_from === 'czone'` → 원본 coinType으로 복원
  *
+ * getAddress v2 동작 (m11-01-02 신규):
+ *   1. input.chainId 검증 (`_sanitizeChainId`) — type/length/whitelist
+ *   2. input.keyPath 검증 — non-empty string
+ *   3. `_call({method: 'getAddress', chainId, params: {chainId, keyPath, prefix?}})` 호출
+ *   4. 응답 그대로 반환 (czone 복원 같은 v1 특례 분기 없음 — sdk가 family-specific 처리)
+ *
  * **v1 1:1 보존 디테일**:
  *   - czone과 parachain은 별도 if 두 개 (mutually exclusive 강제 안 함 — v1 동작 그대로)
  *   - parachain prefix 검증은 `!Number(prefix)` (0/''/null/undefined/NaN/non-numeric string 모두 reject)
  *   - response_from 복원은 mutation으로 수행 (`_call`이 매 호출마다 새 객체 반환하므로 안전 — mutation-isolation)
  *
  * 룰 준수:
- *   - boundary-validation: coinType / parachain prefix 모두 검증
+ *   - boundary-validation: coinType / parachain prefix / chainId / keyPath / array 모두 검증
  *   - error-handling-consistency: 모든 검증 실패는 `dcentException` throw (v1 1:1)
  *   - mutation-isolation: `_call` 결과의 header 수정은 호출자 view에 영향 없음 (cloned)
+ *   - connector-chain-addition-isolation: v2 path는 chainId pass-through만, chain 매핑/enum 0건
+ *   - dapp-input-sanitization: v2 input은 known fields만 추출 (`_sanitizeChainId` + keyPath 검증)
  */
 
 import { _call } from './call'
+import { _sanitizeChainId } from './sanitize'
 import {
   isAvaliableCoinType,
   isCzoneCoinType,
@@ -33,14 +51,76 @@ import { dcentException } from '../v1/dcent-exception'
 import type { V1Response } from './types'
 
 /**
- * v1 dcent.getAddress (src-v1/index.js#l781-813) 1:1 port.
+ * v2 getAddress 입력 — sign 패턴과 동일한 chainId-based 시그니처.
  *
- * @param coinType 지원되는 coinType (`isAvaliableCoinType` 검증)
- * @param path BIP44 key path
- * @param prefix parachain의 경우 필수 (`Number(prefix)` truthy)
- * @returns address가 담긴 V1Response
+ * connector는 chainId를 sanitize 후 sdk로 pass-through만 수행한다.
+ * chainId → 디바이스 명령 변환은 sdk가 wallet-models registry로 dispatch.
  */
-export async function getAddress (
+export interface GetAddressV2Input {
+  /**
+   * CAIP-19 chain identifier (예: 'eip155:1', 'eip155:1/slip44:60', 'bip122:000000...')
+   * sdk가 본 값을 wallet-models registry로 dispatch에 사용.
+   */
+  chainId: string
+  /**
+   * BIP32 key path — 디바이스에서 주소를 도출할 경로 (예: "m/44'/60'/0'/0/0").
+   * non-empty string 강제.
+   */
+  keyPath: string
+  /**
+   * 일부 chain (czone / parachain 등)에 필요한 추가 prefix.
+   * sdk가 chainId에 따라 의미를 결정. connector는 sanitize 없이 pass-through.
+   */
+  prefix?: string | null
+}
+
+/**
+ * v2 getAddress — chainId 시그니처 (m11-01-02).
+ *
+ * connector-chain-addition-isolation 룰 준수:
+ *   - chainId 문자열 sanitize만 수행 (character whitelist)
+ *   - chain enum / chain → method 매핑 / chain-prefixed switch 분기 부재
+ *   - method는 'getAddress' literal 고정 — chain identifier 단위 분기 0건
+ *
+ * @param input { chainId, keyPath, prefix? }
+ * @returns V1Response (v1 호환 응답 shape)
+ * @throws V1Exception(param_error) — chainId / keyPath 검증 실패 시
+ */
+async function _getAddressV2 (input: GetAddressV2Input): Promise<V1Response> {
+  // chainId sanitize는 ProviderError로 throw — v1 호환을 위해 catch + dcentException re-throw
+  let safeChainId: string
+  try {
+    safeChainId = _sanitizeChainId(input.chainId)
+  } catch {
+    // _sanitizeChainId는 string이 아니거나 빈 문자열 / disallowed char이면 ProviderError를 던진다.
+    // v1 dApp이 .catch(err => err.body?.error?.code) 패턴을 쓰므로 dcentException으로 통일.
+    throw dcentException('param_error', 'chainId required')
+  }
+
+  if (typeof input.keyPath !== 'string' || input.keyPath.length === 0) {
+    throw dcentException('param_error', 'keyPath required')
+  }
+
+  // chainId pass-through — connector는 method dispatch / chain 분기 0건.
+  // params에 chainId/keyPath/prefix를 그대로 담아 sdk로 forward.
+  // sdk가 chainId를 보고 family-specific handler로 dispatch (m11-02 책임).
+  const params: Record<string, unknown> = {
+    chainId: safeChainId,
+    keyPath: input.keyPath,
+  }
+  if (input.prefix !== undefined && input.prefix !== null) {
+    params.prefix = input.prefix
+  }
+
+  return _call({ method: 'getAddress', chainId: safeChainId, params })
+}
+
+/**
+ * v1 getAddress — coinType 기반 시그니처 (m08-01-02.5 그대로).
+ *
+ * 기존 v1 dApp 호환을 위해 보존. 변경 없음.
+ */
+async function _getAddressV1 (
   coinType: string,
   path: string,
   prefix: string | number | null = null,
@@ -75,6 +155,58 @@ export async function getAddress (
     res.header.response_from = coinType
   }
   return res
+}
+
+/**
+ * v1 dcent.getAddress (src-v1/index.js#l781-813) port + m11-01-02 v2 chainId facade.
+ *
+ * Overload signatures:
+ *   - v2: `getAddress(input: GetAddressV2Input)` — chainId / keyPath / prefix? 객체
+ *   - v1: `getAddress(coinType: string, path: string, prefix?: string|number|null)` — 기존 시그니처
+ *
+ * 런타임 분기 — 첫 인자가 plain object면 v2, string이면 v1.
+ * Array 입력은 `typeof [] === 'object'` 함정 방지를 위해 명시적 거부.
+ *
+ * @example v2 (신규)
+ *   await dcent.getAddress({
+ *     chainId: 'eip155:1/slip44:60',
+ *     keyPath: "m/44'/60'/0'/0/0",
+ *   })
+ *
+ * @example v1 (보존)
+ *   await dcent.getAddress('ETHEREUM', "m/44'/60'/0'/0/0")
+ *
+ * @returns V1Response (v1 호환 응답 shape)
+ */
+export function getAddress (input: GetAddressV2Input): Promise<V1Response>
+export function getAddress (
+  coinType: string,
+  path: string,
+  prefix?: string | number | null,
+): Promise<V1Response>
+export function getAddress (
+  arg1: GetAddressV2Input | string,
+  arg2?: string,
+  arg3?: string | number | null,
+): Promise<V1Response> {
+  // 런타임 분기:
+  //   - Array → 명시적 거부 (typeof [] === 'object' 함정 방지)
+  //   - plain object → v2 path
+  //   - string → v1 path
+  if (Array.isArray(arg1)) {
+    return Promise.reject(
+      dcentException(
+        'param_error',
+        'getAddress: array input not supported (expected string coinType or object {chainId, keyPath})',
+      ),
+    )
+  }
+  if (typeof arg1 === 'object' && arg1 !== null) {
+    return _getAddressV2(arg1)
+  }
+  // string 외 타입(undefined / number / boolean)도 v1 경로로 보내면
+  // isAvaliableCoinType에서 coin_type_error로 reject되므로 안전.
+  return _getAddressV1(arg1 as string, arg2 as string, arg3 ?? null)
 }
 
 /**

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -28,6 +28,8 @@ export { providerErrorToV1 } from './error'
 // m08-01-02.5: read-only / configure / Bitcoin tx-builder + v1 validators
 export { info, getDeviceInfo, getAccountInfo } from './info'
 export { getAddress, getXPUB } from './address'
+// m11-01-02: v2 chainId facade input type for getAddress
+export type { GetAddressV2Input } from './address'
 export { setLabel, syncAccount, selectAddress } from './configure'
 export type { SyncAccountInfo } from './configure'
 export {

--- a/tests/unit/v2/sign/address.test.ts
+++ b/tests/unit/v2/sign/address.test.ts
@@ -57,7 +57,7 @@ describe('getAddress — m08-01-02.5', () => {
     const resp = await getAddress('ETHEREUM', "m/44'/60'/0'/0/0")
 
     expect(sendSpy).toHaveBeenCalledTimes(1)
-    const callArg = sendSpy.mock.calls[0][0]
+    const callArg = sendSpy.mock.calls[0][0] as any
     expect(callArg.method).toBe('getAddress')
     expect(callArg.params).toEqual({
       coinType: 'ETHEREUM',
@@ -76,7 +76,7 @@ describe('getAddress — m08-01-02.5', () => {
 
     await getAddress('COREUM', "m/44'/118'/0'/0/0")
 
-    const callArg = sendSpy.mock.calls[0][0]
+    const callArg = sendSpy.mock.calls[0][0] as any
     expect(callArg.params?.coinType).toBe('czone')
     expect(callArg.params?.optionParam).toBe(Buffer.from('core', 'utf8').toString('hex'))
   })
@@ -90,7 +90,7 @@ describe('getAddress — m08-01-02.5', () => {
 
     await getAddress('PARA', "m/44'/354'/0'/0/0", '5')
 
-    const callArg = sendSpy.mock.calls[0][0]
+    const callArg = sendSpy.mock.calls[0][0] as any
     expect(callArg.params?.coinType).toBe('PARA')
     expect(callArg.params?.optionParam).toBe(5)
     expect(typeof callArg.params?.optionParam).toBe('number')
@@ -133,7 +133,7 @@ describe('getXPUB — m08-01-02.5', () => {
 
     await getXPUB("m/44'/0'/0'", 'Bitcoin seed')
 
-    const callArg = sendSpy.mock.calls[0][0]
+    const callArg = sendSpy.mock.calls[0][0] as any
     expect(callArg.method).toBe('getXPUB')
     expect(callArg.params).toEqual({ key: "m/44'/0'/0'", bip32name: 'Bitcoin seed' })
   })
@@ -188,7 +188,7 @@ describe('getAddress v2 chainId facade — m11-01-02', () => {
     })
 
     expect(sendSpy).toHaveBeenCalledTimes(1)
-    const callArg = sendSpy.mock.calls[0][0]
+    const callArg = sendSpy.mock.calls[0][0] as any
     expect(callArg.method).toBe('getAddress')
     expect(callArg.chainId).toBe('eip155:1/slip44:60')
     expect(callArg.params).toEqual({
@@ -215,7 +215,7 @@ describe('getAddress v2 chainId facade — m11-01-02', () => {
       prefix: 'core',
     })
 
-    const callArg = sendSpy.mock.calls[0][0]
+    const callArg = sendSpy.mock.calls[0][0] as any
     expect(callArg.params).toEqual({
       chainId: 'cosmos:core-mainnet-1',
       keyPath: "m/44'/118'/0'/0/0",
@@ -258,7 +258,7 @@ describe('getAddress v2 chainId facade — m11-01-02', () => {
 
     await getAddress('ETHEREUM', "m/44'/60'/0'/0/0")
 
-    const callArg = sendSpy.mock.calls[0][0]
+    const callArg = sendSpy.mock.calls[0][0] as any
     expect(callArg.method).toBe('getAddress')
     // v1 path는 chainId 필드를 보내지 않음
     expect(callArg.chainId).toBeUndefined()
@@ -277,7 +277,7 @@ describe('getAddress v2 chainId facade — m11-01-02', () => {
 
     await getAddress('PARA', "m/44'/354'/0'/0/0", '5')
 
-    const callArg = sendSpy.mock.calls[0][0]
+    const callArg = sendSpy.mock.calls[0][0] as any
     expect(callArg.params?.optionParam).toBe(5)
     expect(callArg.params?.coinType).toBe('PARA')
     expect(callArg.chainId).toBeUndefined()
@@ -317,7 +317,7 @@ describe('getAddress v2 chainId facade — m11-01-02', () => {
   test('T-U-08: array 입력 → param_error reject (typeof [] === object 함정 명시 거부)', async () => {
     await expect(
       // dApp이 실수로 array를 보낼 경우 (TypeScript 우회 시 catch 가능해야 함)
-      getAddress(['ETHEREUM', "m/44'/60'/0'/0/0"] as unknown as string),
+      getAddress(['ETHEREUM', "m/44'/60'/0'/0/0"] as any),
     ).rejects.toEqual(
       expectV1Error(
         'param_error',
@@ -338,7 +338,7 @@ describe('getAddress v2 chainId facade — m11-01-02', () => {
       keyPath: "m/44'/0'/0'/0/0",
     })
 
-    const callArg = sendSpy.mock.calls[0][0]
+    const callArg = sendSpy.mock.calls[0][0] as any
     // _call의 chainId 필드 — m11-02 sdk handler가 envelope의 chainId로 dispatch에 사용
     expect(callArg.chainId).toBe('bip122:000000000019d6689c085ae165831e93')
     // params에도 동일 chainId 포함 (sdk가 둘 중 어느 쪽을 쓰든 동등)

--- a/tests/unit/v2/sign/address.test.ts
+++ b/tests/unit/v2/sign/address.test.ts
@@ -1,22 +1,34 @@
 /**
- * getAddress / getXPUB 단위 테스트 (m08-01-02.5)
+ * getAddress / getXPUB 단위 테스트 (m08-01-02.5) + v2 chainId facade (m11-01-02)
  *
- * T-U-ADDR-01: getAddress('ETHEREUM', path) → 평범한 coinType (czone/parachain 분기 안 탐)
- * T-U-ADDR-02: getAddress('COREUM', path) → czone 변환 + optionParam
- * T-U-ADDR-03: getAddress('PARA', path, '5') → parachain prefix → optionParam: 5
- * T-U-ADDR-04: getAddress('PARA', path, NaN) → param_error reject
- * T-U-ADDR-05: response header.response_from === 'czone' → coinType으로 복원
- * T-U-ADDR-06: getAddress(invalidCoinType, ...) → coin_type_error reject
- * T-U-XPUB-01: getXPUB(key, bip32name) → _call
+ * v1 (기존 — 회귀 가드):
+ *   T-U-ADDR-01: getAddress('ETHEREUM', path) → 평범한 coinType (czone/parachain 분기 안 탐)
+ *   T-U-ADDR-02: getAddress('COREUM', path) → czone 변환 + optionParam
+ *   T-U-ADDR-03: getAddress('PARA', path, '5') → parachain prefix → optionParam: 5
+ *   T-U-ADDR-04: getAddress('PARA', path, NaN) → param_error reject
+ *   T-U-ADDR-05: response header.response_from === 'czone' → coinType으로 복원
+ *   T-U-ADDR-06: getAddress(invalidCoinType, ...) → coin_type_error reject
+ *   T-U-XPUB-01: getXPUB(key, bip32name) → _call
  *
- * T-U-PARACHAIN-PREFIX-01..04: 0 / '' / NaN / null 모두 reject (v1 !Number(prefix) 1:1)
+ * v1 parachain edge cases (기존):
+ *   T-U-PARACHAIN-PREFIX-01..04: 0 / '' / NaN / null 모두 reject (v1 !Number(prefix) 1:1)
  *
- * NOTE: getAddress는 `async function`이므로 sync `throw`도 reject로 변환된다.
+ * **v2 chainId facade (m11-01-02 신규)**:
+ *   T-U-01: getAddress({chainId, keyPath}) → params={chainId, keyPath} 송신
+ *   T-U-02: getAddress({chainId: '', keyPath}) → param_error (chainId required)
+ *   T-U-03: getAddress({chainId} as any) (keyPath 누락) → param_error (keyPath required)
+ *   T-U-04: v1 회귀 — getAddress('ETHEREUM', path) → 기존 동작 (T-U-ADDR-01 중복 가드)
+ *   T-U-05: v1 prefix 회귀 — getAddress('PARA', path, '5') → 기존 동작 (T-U-ADDR-03 중복 가드)
+ *   T-U-06: 컴파일 — overload 타입 추론 (TypeScript compile-time only; tsc로 검증)
+ *   T-U-07: getAddress({chainId: 'eip155:1@#$invalid', ...}) → param_error (whitelist 위반)
+ *   T-U-08: getAddress(['ETHEREUM', path] as any) → param_error (array 명시 거부)
+ *
+ * NOTE: getAddress는 overload async function이므로 sync `throw`도 reject로 변환된다.
  *       에러 검증은 `await expect(...).rejects.toEqual(...)` 패턴 사용.
  */
 
 import { Buffer } from 'buffer'
-import { getAddress, getXPUB } from '../../../../src/sign/address'
+import { getAddress, getXPUB, type GetAddressV2Input } from '../../../../src/sign/address'
 import { ensureSingleton, _resetForTesting } from '../../../../src/singleton'
 
 beforeEach(() => {
@@ -152,5 +164,210 @@ describe('parachain prefix edge cases — v1 !Number(prefix) 1:1', () => {
     await expect(getAddress('PARA', 'path', null)).rejects.toEqual(
       expectV1Error('param_error'),
     )
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────────
+// m11-01-02 — v2 chainId facade
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('getAddress v2 chainId facade — m11-01-02', () => {
+  test('T-U-01: v2 path {chainId, keyPath} → params={chainId, keyPath} 송신 (mock sdk가 수신)', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'v2-r1',
+      result: {
+        header: { version: '1.0', status: 'success', response_from: 'eip155:1' },
+        body: { command: 'getAddress', parameter: { address: '0xabc...' } },
+      },
+    })
+
+    const resp = await getAddress({
+      chainId: 'eip155:1/slip44:60',
+      keyPath: "m/44'/60'/0'/0/0",
+    })
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getAddress')
+    expect(callArg.chainId).toBe('eip155:1/slip44:60')
+    expect(callArg.params).toEqual({
+      chainId: 'eip155:1/slip44:60',
+      keyPath: "m/44'/60'/0'/0/0",
+    })
+    // v1 path의 흔적(coinType/path/optionParam)이 섞이지 않는지 가드
+    expect(callArg.params).not.toHaveProperty('coinType')
+    expect(callArg.params).not.toHaveProperty('path')
+    expect(callArg.params).not.toHaveProperty('optionParam')
+    expect(resp.header.status).toBe('success')
+  })
+
+  test('T-U-01.b: v2 path with prefix → params에 prefix 포함', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'v2-r1b',
+      result: { address: 'core1abc' },
+    })
+
+    await getAddress({
+      chainId: 'cosmos:core-mainnet-1',
+      keyPath: "m/44'/118'/0'/0/0",
+      prefix: 'core',
+    })
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.params).toEqual({
+      chainId: 'cosmos:core-mainnet-1',
+      keyPath: "m/44'/118'/0'/0/0",
+      prefix: 'core',
+    })
+  })
+
+  test('T-U-02: v2 path chainId 빈 문자열 → param_error reject', async () => {
+    await expect(
+      getAddress({ chainId: '', keyPath: "m/44'/60'/0'/0/0" }),
+    ).rejects.toEqual(expectV1Error('param_error', 'chainId required'))
+  })
+
+  test('T-U-02.b: v2 path chainId가 string이 아님 → param_error reject', async () => {
+    await expect(
+      // 런타임에 dApp이 typescript 우회해서 잘못된 타입을 보낼 수 있는 케이스 가드
+      getAddress({ chainId: 123 as unknown as string, keyPath: "m/44'/60'/0'/0/0" }),
+    ).rejects.toEqual(expectV1Error('param_error', 'chainId required'))
+  })
+
+  test('T-U-03: v2 path keyPath 누락 → param_error reject (keyPath required)', async () => {
+    await expect(
+      // dApp이 keyPath 빠뜨린 케이스
+      getAddress({ chainId: 'eip155:1/slip44:60' } as unknown as GetAddressV2Input),
+    ).rejects.toEqual(expectV1Error('param_error', 'keyPath required'))
+  })
+
+  test('T-U-03.b: v2 path keyPath 빈 문자열 → param_error reject', async () => {
+    await expect(
+      getAddress({ chainId: 'eip155:1/slip44:60', keyPath: '' }),
+    ).rejects.toEqual(expectV1Error('param_error', 'keyPath required'))
+  })
+
+  test('T-U-04: v1 path 회귀 — getAddress("ETHEREUM", path) → 기존 v1 payload 송신', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'v1-r1',
+      result: { address: '0xabc' },
+    })
+
+    await getAddress('ETHEREUM', "m/44'/60'/0'/0/0")
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.method).toBe('getAddress')
+    // v1 path는 chainId 필드를 보내지 않음
+    expect(callArg.chainId).toBeUndefined()
+    expect(callArg.params).toEqual({
+      coinType: 'ETHEREUM',
+      path: "m/44'/60'/0'/0/0",
+    })
+  })
+
+  test('T-U-05: v1 path 회귀 — getAddress("PARA", path, "5") → 기존 v1 prefix 동작', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'v1-r2',
+      result: { address: 'parachain-addr' },
+    })
+
+    await getAddress('PARA', "m/44'/354'/0'/0/0", '5')
+
+    const callArg = sendSpy.mock.calls[0][0]
+    expect(callArg.params?.optionParam).toBe(5)
+    expect(callArg.params?.coinType).toBe('PARA')
+    expect(callArg.chainId).toBeUndefined()
+  })
+
+  test('T-U-06: overload 타입 추론 — v2/v1 양쪽 모두 컴파일 통과 (compile-time, runtime은 stub)', async () => {
+    // 본 테스트는 TypeScript의 overload 타입 추론을 컴파일 시점에 검증한다.
+    // 실제 실행은 _call 호출이 가지 않도록 mock된 transport로 fast-fail.
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 't6',
+      result: { address: '0x' },
+    })
+
+    // v2 overload — input 객체 추론
+    const v2Input: GetAddressV2Input = {
+      chainId: 'eip155:1',
+      keyPath: "m/44'/60'/0'/0/0",
+    }
+    const v2Resp = await getAddress(v2Input)
+    expect(v2Resp.header.status).toBe('success')
+
+    // v1 overload — string coinType 추론 (positional args)
+    const v1Resp = await getAddress('ETHEREUM', "m/44'/60'/0'/0/0")
+    expect(v1Resp.header.status).toBe('success')
+  })
+
+  test('T-U-07: v2 path chainId whitelist 위반 (특수문자) → param_error reject', async () => {
+    await expect(
+      getAddress({
+        chainId: 'eip155:1@#$invalid',
+        keyPath: "m/44'/60'/0'/0/0",
+      }),
+    ).rejects.toEqual(expectV1Error('param_error', 'chainId required'))
+  })
+
+  test('T-U-08: array 입력 → param_error reject (typeof [] === object 함정 명시 거부)', async () => {
+    await expect(
+      // dApp이 실수로 array를 보낼 경우 (TypeScript 우회 시 catch 가능해야 함)
+      getAddress(['ETHEREUM', "m/44'/60'/0'/0/0"] as unknown as string),
+    ).rejects.toEqual(
+      expectV1Error(
+        'param_error',
+        'getAddress: array input not supported (expected string coinType or object {chainId, keyPath})',
+      ),
+    )
+  })
+
+  test('T-U-09: v2 path가 sdk에 chainId를 _call.chainId 필드로 전달 (m11-02 sdk handler가 활용)', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'v2-r9',
+      result: { address: '0xdef' },
+    })
+
+    await getAddress({
+      chainId: 'bip122:000000000019d6689c085ae165831e93',
+      keyPath: "m/44'/0'/0'/0/0",
+    })
+
+    const callArg = sendSpy.mock.calls[0][0]
+    // _call의 chainId 필드 — m11-02 sdk handler가 envelope의 chainId로 dispatch에 사용
+    expect(callArg.chainId).toBe('bip122:000000000019d6689c085ae165831e93')
+    // params에도 동일 chainId 포함 (sdk가 둘 중 어느 쪽을 쓰든 동등)
+    expect(callArg.params?.chainId).toBe('bip122:000000000019d6689c085ae165831e93')
+  })
+})
+
+// ──────────────────────────────────────────────────────────────────────────
+// m11-01-02 — chain isolation 회귀 가드
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('getAddress chain isolation — connector-chain-addition-isolation 룰', () => {
+  test('v2 path에서 method는 항상 "getAddress" literal (chain 식별자 단위 분기 0건)', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'iso-r1',
+      result: { address: '0x' },
+    })
+
+    // 서로 다른 chainId 3개에 대해 모두 method='getAddress' 송신 확인
+    const chainIds = ['eip155:1', 'bip122:000000000019d6689c085ae165831e93', 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc6']
+    for (const chainId of chainIds) {
+      await getAddress({ chainId, keyPath: "m/44'/0'/0'/0/0" })
+    }
+
+    expect(sendSpy).toHaveBeenCalledTimes(chainIds.length)
+    for (let i = 0; i < chainIds.length; i++) {
+      // chain enum / PREFIX_TO_METHOD / chain-prefixed switch 추가 없이 chain-agnostic
+      expect(sendSpy.mock.calls[i][0].method).toBe('getAddress')
+    }
   })
 })


### PR DESCRIPTION
## Objective

**ID**: m11-01-02-getaddress-chainid-facade
**Epic**: m11-01-00-playground-and-getaddress-v2 (nested epic — m09-04 산하)
**Jira**: [DC-2300](https://iotrust.atlassian.net/browse/DC-2300)
**Base**: `epic/DC-2223_m09-04-connector-v2-cleanup` (nested epic child)

## 요약

`dcent.getAddress` facade에 **sign 패턴과 동일한 chainId 컨셉**을 도입한다.

```ts
// v2 (신규)
await dcent.getAddress({
  chainId: 'eip155:1/slip44:60',
  keyPath: "m/44'/60'/0'/0/0",
})

// v1 (보존 — backward-compat overload)
await dcent.getAddress('ETHEREUM', "m/44'/60'/0'/0/0")
```

런타임 분기:
- 첫 인자가 plain object → v2 path
- 첫 인자가 string → v1 path (기존 로직 무변경)
- 첫 인자가 Array → `param_error` 명시 거부 (typeof [] === object 함정 가드)

## connector-chain-addition-isolation 4개 질문 답변

본 PR은 `src/sign/address.ts` 등 connector interface 파일을 수정하므로 isolation 룰 자체 점검:

**(a) 이 변경이 정말 connector 책임인가?**
Yes — `dcent.getAddress` public API의 시그니처 확장은 transport layer 자체의 변경이며, npm published 패키지의 호환 표면에 해당. wm/sdk는 chainId를 받는 measure point가 아님.

**(b) wm cryptoCurrencies registry로 표현 불가능한가?**
Yes — chainId 시그니처는 connector ↔ sdk 사이의 wire-level API contract이며, wm은 chainId resolve의 backend로만 동작. registry에 표현할 차원이 아님.

**(c) sdk MethodRegistry에 새 generic method를 추가하는 방향이 더 적절한가?**
No — method 이름(`getAddress`)은 그대로, payload shape만 확장. method 추가가 아님. sdk 측 변경은 m11-02-01에서 별도 처리 (handler가 v1/v2 payload shape 양쪽 수용).

**(d) 결정 사유 PR description + objective 명시?**
Yes — 본 PR description + objective `m11-01-02-getaddress-chainid-facade.md` 본문 "Chain isolation 확인" 섹션.

**핵심 격리 보장**:
- v2 path는 **chainId 문자열 pass-through만 수행** — connector 내부에 `chainId → method` 매핑, chain enum, switch/case 분기 0건
- `_sanitizeChainId`는 character whitelist regex만 검사 (m09-04 기존 helper 재사용, chain prefix 화이트리스트 아님)
- method는 'getAddress' literal 고정 (테스트 `chain isolation` describe로 회귀 가드)

## 변경 사항

### 코드
- `src/sign/address.ts` — `getAddress` overload + 런타임 분기 + `_getAddressV2` 내부 함수 + `GetAddressV2Input` 타입
- `src/sign/index.ts` — `GetAddressV2Input` 타입 re-export
- `src/index.ts` — `GetAddressV2Input` 타입 re-export (facade entry)
- `tests/unit/v2/sign/address.test.ts` — v2 path 9개 케이스 + chain isolation 회귀 가드 1개

### 변경 노트 — 테스트 위치
objective 본문은 `tests/unit/2_v2_e2e/getAddress.v2.spec.ts` (puppeteer e2e)를 제안했으나, facade 단위 동작은 transport spy 기반 단위 테스트가 deterministic + 빠름. 기존 `tests/unit/v2/sign/address.test.ts`에 통합하여 v1/v2 회귀를 같은 파일에서 가드. v2 e2e round-trip은 m11-01-04 + m11-02 짝맞춤 이후 단계로 미룸 (objective `자동 검증 명령` 섹션에 노트 추가).

## 자동 검증 결과

| 명령 | 결과 |
|---|---|
| `yarn unit-v2 -- tests/unit/v2/sign/address.test.ts` | ✅ 475/475 passed |
| `yarn tsc` | ✅ exit 0 |
| `yarn lint` | ✅ exit 0 |
| `yarn build` | ✅ exit 0 (v2 번들 555 KiB) |

## DoD 체크

- [x] `getAddress` overload 도입 + 런타임 분기 동작
- [x] v2 path가 chainId pass-through만 수행 (chain enum/매핑 추가 0)
- [x] v1 path 회귀 0 (기존 dApp 호출 그대로 동작 — T-U-04, T-U-05 가드)
- [x] T-U-01~09, T-LINT-01, T-BUILD-01, T-TSC-01 모두 통과
- [x] PR description에 `connector-chain-addition-isolation` 4개 질문 답변 명시
- [x] PR 생성 (base=epic branch, diff = +353 LOC < 600)
- [ ] CI 모든 체크 통과 (이 PR 생성 후 CI 결과 대기)

## 후속

- **m11-02-01**: sdk handler 측 짝맞춤 — v2 chainId payload 수신 + family-specific dispatch (wallet-models 활용)
- **m11-01-04**: playground 폼을 새 v2 시그니처로 마이그
- m11-01 epic 모든 child MERGED_TO_EPIC 후 → epic → m09-04 epic branch 최종 PR

머지 정책: AI는 머지하지 않음 (`objective-no-auto-merge` 룰). 리뷰 후 사람이 epic branch로 머지.

---
🤖 Generated by `/uap-autopilot-chain` orchestrator + `/uap-autopilot-objective` skill.