### PR TITLE
[DC-2376] feat(sign): dcent.sign() per-call transport 옵션 도입 (m09-04-03)

### DIFF
--- a/index-v2.html
+++ b/index-v2.html
@@ -54,6 +54,26 @@
     #btn-disconnect { background: #dc2626; color: #fff; display: none; }
     #btn-disconnect:hover { background: #b91c1c; }
 
+    /* ── Transport selector (m09-04-03) ── */
+    #transport-selector {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 12px;
+      color: #aaa;
+    }
+    #transport-selector label { color: #aaa; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; }
+    #transport-selector select {
+      background: #2a2a3e;
+      color: #e2e8f0;
+      border: 1px solid #444;
+      border-radius: 4px;
+      padding: 4px 6px;
+      font-size: 12px;
+      cursor: pointer;
+    }
+    #transport-selector select:focus { outline: none; border-color: #4f46e5; }
+
     /* ── Main layout: sidebar + log panel ── */
     #main {
       display: flex;
@@ -245,6 +265,15 @@
   <div id="conn-dot"></div>
   <h1>D'CENT Connector v2 Playground</h1>
   <span id="device-info">Not connected</span>
+  <!-- m09-04-03: transport option demo — per-call transport hint sent in _handshake -->
+  <div id="transport-selector">
+    <label for="select-transport">Transport</label>
+    <select id="select-transport" title="Per-call transport hint passed to dcent.sign()">
+      <option value="">auto (default)</option>
+      <option value="hid">hid (WebHID)</option>
+      <option value="ble">ble (WebBLE)</option>
+    </select>
+  </div>
   <button id="btn-connect">Connect</button>
   <button id="btn-disconnect">Disconnect</button>
 </div>

--- a/playground.js
+++ b/playground.js
@@ -574,6 +574,19 @@
     return state._testDcent || window.dcent
   }
 
+  // ── Transport option helper (m09-04-03) ──
+  // #select-transport 값을 읽어 dcent.sign()의 transport 옵션으로 전달할 값 반환.
+  // '' (auto/default) → undefined (옵션 미전달 = 기존 동작 유지, backward compat)
+  // 'hid' | 'ble' → string 그대로 반환
+  // connector-chain-addition-isolation: transport는 chain과 직교, chain-specific 분기 없음.
+  function _getTransportOption () {
+    var el = document.getElementById('select-transport')
+    if (!el) return undefined
+    var val = el.value
+    if (val === 'hid' || val === 'ble') return val
+    return undefined // '' → undefined: 옵션 미전달 (dcent.sign이 'auto' handshake 전송)
+  }
+
   // ── Build Tree DOM ──
   function buildTree () {
     treePanel.innerHTML = ''
@@ -2374,11 +2387,11 @@
         // m09-04-01/DC-2221: NEW sign schema { method, chainId, payload } — OLD { chain, payload } 금지.
         // connector-chain-addition-isolation: bsChainId는 사용자 입력 그대로 pass-through (chain enum 없음).
         // b08-01: _unwrapV1Envelope이 success → body.parameter unwrap, failure → throw로 변환.
-        dcent.sign({
-          method: 'signTransaction',
-          chainId: bsChainId,
-          payload: { keyPath: bsKeyPath, transaction: builtTx },
-        }).then(_unwrapV1Envelope).then(function (result) {
+        // m09-04-03: transport 옵션 — #select-transport 선택값. undefined이면 미전달 (backward compat).
+        var bsTransport = _getTransportOption()
+        var bsSignInput = { method: 'signTransaction', chainId: bsChainId, payload: { keyPath: bsKeyPath, transaction: builtTx } }
+        if (bsTransport !== undefined) bsSignInput.transport = bsTransport
+        dcent.sign(bsSignInput).then(_unwrapV1Envelope).then(function (result) {
           appendLog({
             method: 'signTransaction',
             chainId: bsChainId,
@@ -2456,7 +2469,11 @@
     // method는 intent literal ('signMessage'), chainId(CAIP-19)는 top-level, payload에는 chainId 제거.
     var dcent = _getDcent()
     // b08-01: _unwrapV1Envelope이 success → body.parameter unwrap, failure → throw로 변환
-    dcent.sign({ method: 'signMessage', chainId: chainId, payload: { keyPath: keyPath, message: message, meta: metaObj } }).then(_unwrapV1Envelope).then(function (result) {
+    // m09-04-03: transport 옵션 — #select-transport 선택값. undefined이면 미전달 (backward compat).
+    var smTransport = _getTransportOption()
+    var smSignInput = { method: 'signMessage', chainId: chainId, payload: { keyPath: keyPath, message: message, meta: metaObj } }
+    if (smTransport !== undefined) smSignInput.transport = smTransport
+    dcent.sign(smSignInput).then(_unwrapV1Envelope).then(function (result) {
       appendLog({
         method: 'signMessage',
         chainId: chainId,
@@ -2520,7 +2537,11 @@
     // sdk resolveChainId가 wallet-models registry로 currency 결정.
     var dcent = _getDcent()
     // b08-01: _unwrapV1Envelope이 success → body.parameter unwrap, failure → throw로 변환
-    dcent.sign({ method: 'signTransaction', chainId: chainId, payload: { keyPath: keyPath, transaction: txObj } }).then(_unwrapV1Envelope).then(function (result) {
+    // m09-04-03: transport 옵션 — #select-transport 선택값. undefined이면 미전달 (backward compat).
+    var evmTransport = _getTransportOption()
+    var evmSignInput = { method: 'signTransaction', chainId: chainId, payload: { keyPath: keyPath, transaction: txObj } }
+    if (evmTransport !== undefined) evmSignInput.transport = evmTransport
+    dcent.sign(evmSignInput).then(_unwrapV1Envelope).then(function (result) {
       appendLog({
         method: 'signTransaction',
         chainId: chainId,
@@ -2584,7 +2605,11 @@
     // bip122/solana/xrpl/cosmos/stellar/hedera 등 비-EVM도 동일 패턴. chains.json의 chainId가 이미 CAIP-19.
     var dcent = _getDcent()
     // b08-01: _unwrapV1Envelope이 success → body.parameter unwrap, failure → throw로 변환
-    dcent.sign({ method: 'signTransaction', chainId: chainId, payload: { keyPath: keyPath, transaction: txObj } }).then(_unwrapV1Envelope).then(function (result) {
+    // m09-04-03: transport 옵션 — #select-transport 선택값. undefined이면 미전달 (backward compat).
+    var nonEvmTransport = _getTransportOption()
+    var nonEvmSignInput = { method: 'signTransaction', chainId: chainId, payload: { keyPath: keyPath, transaction: txObj } }
+    if (nonEvmTransport !== undefined) nonEvmSignInput.transport = nonEvmTransport
+    dcent.sign(nonEvmSignInput).then(_unwrapV1Envelope).then(function (result) {
       appendLog({
         method: 'signTransaction',
         chainId: chainId,

--- a/src/sign/_sanitizeTransportOption.ts
+++ b/src/sign/_sanitizeTransportOption.ts
@@ -1,0 +1,57 @@
+/**
+ * transport 옵션 sanitize + wire 변환 (m09-04-03)
+ *
+ * dApp이 dcent.sign() 옵션으로 넘긴 transport 값을 sanitize한다.
+ *
+ * 적용 룰:
+ *   - dapp-input-sanitization: known whitelist ('hid' | 'ble' | undefined)만 허용, 나머지 throw
+ *   - provider-security-checklist C3: transport는 dApp-controllable — connector facade에서 검증
+ *   - provider-security-checklist C6: invalid 값 → ProviderError(INVALID_PARAMS) 래핑
+ *   - error-handling-consistency: invalid 값은 throw로 통일 (silent return 금지)
+ *   - boundary-validation: "throw 우선" 원칙 — null / '' / 그 외 string / object 모두 throw
+ *
+ * audit 2026-05-19:
+ *   R5: _sanitize{Concern} 컨벤션 정렬 (_sanitizeChain / _sanitizeEthereumTypeOptions sibling 패턴)
+ *   R6: sanitize 출력 3-state ('hid'|'ble'|undefined) → toWireTransport에서 wire 3-state로 변환
+ *   R9: invalid value → throw ProviderError(INVALID_PARAMS) — C4 WARN 반영 (복수형 INVALID_PARAMS)
+ *   R10: null / 빈 문자열은 undefined로 coerce 금지, throw로 통일
+ */
+
+import { ProviderError } from '../error/ProviderError'
+import { ErrorCode } from '../error/ErrorCode'
+
+/**
+ * dApp이 dcent.sign 옵션으로 넘긴 transport 값을 sanitize.
+ *
+ * - 정상: 'hid' | 'ble' → 그대로 반환
+ * - 미사용: undefined → undefined (toWireTransport에서 'auto'로 변환)
+ * - invalid: null / '' / 그 외 string / object → throw ProviderError(INVALID_PARAMS)
+ *
+ * @param transport dApp이 넘긴 transport 값 (unknown)
+ * @returns 'hid' | 'ble' | undefined
+ * @throws ProviderError(INVALID_PARAMS) — invalid 값
+ */
+export function _sanitizeTransportOption (
+  transport: unknown,
+): 'hid' | 'ble' | undefined {
+  if (transport === undefined) return undefined
+  if (transport === 'hid' || transport === 'ble') return transport
+  throw new ProviderError(
+    ErrorCode.INVALID_PARAMS,
+    `Invalid transport option: "${String(transport)}". Expected 'hid' | 'ble' | undefined.`,
+  )
+}
+
+/**
+ * sanitize 결과를 wire 값으로 변환.
+ * handshake message body params.transport 동봉 시점에 호출.
+ *
+ * - 'hid' → 'hid'
+ * - 'ble' → 'ble'
+ * - undefined → 'auto' (sdk picker UI fallback 신호)
+ */
+export function toWireTransport (
+  sanitized: 'hid' | 'ble' | undefined,
+): 'hid' | 'ble' | 'auto' {
+  return sanitized ?? 'auto'
+}

--- a/src/sign/call.ts
+++ b/src/sign/call.ts
@@ -51,6 +51,12 @@ export interface CallInput {
    * 미명시 시 기존 흐름 (picker UI). 첫 호출에는 dApp이 deviceId를 모르므로 undefined.
    */
   deviceId?: string
+  /**
+   * (m09-04-03) sanitize된 transport 힌트. PopupTransport의 setPendingTransport로 등록되어
+   * sdk handshake params.transport로 송신됨. popup lifecycle 단위 first-wins (audit R12).
+   * undefined 시 toWireTransport에서 'auto'로 변환 → sdk picker UI fallback.
+   */
+  transport?: 'hid' | 'ble'
   params?: Record<string, unknown>
 }
 
@@ -138,6 +144,17 @@ export async function _call (input: CallInput): Promise<V1Response> {
   ) {
     ;(transport as { setPendingDeviceId: (id: string | undefined) => void }).setPendingDeviceId(
       input.deviceId,
+    )
+  }
+
+  // (m09-04-03) transport 힌트를 다음 handshake에 전달. popup lifecycle 단위 first-wins.
+  // setPendingTransport가 있는 transport(PopupTransport)에만 적용.
+  if (
+    'setPendingTransport' in transport &&
+    typeof (transport as { setPendingTransport?: unknown }).setPendingTransport === 'function'
+  ) {
+    ;(transport as { setPendingTransport: (t: 'hid' | 'ble' | undefined) => void }).setPendingTransport(
+      input.transport,
     )
   }
 

--- a/src/sign/sign.ts
+++ b/src/sign/sign.ts
@@ -27,6 +27,7 @@
 import { _call } from './call'
 import { _sanitizeMethod, _sanitizeChainId } from './sanitize'
 import { _validateSignPayload } from './_validateSignPayload'
+import { _sanitizeTransportOption } from './_sanitizeTransportOption'
 import type { V1Response } from './types'
 
 export type { SignPayload } from './_validateSignPayload'
@@ -54,6 +55,20 @@ export interface SignInput {
    * (code 4001). 미명시 시 기존 picker 흐름.
    */
   deviceId?: string
+  /**
+   * (m09-04-03) per-call HW transport 힌트. 명시 시 sdk popup이 picker UI를 skip하고
+   * 해당 transport로 즉시 connect한다. 미명시 시 sdk picker UI fallback.
+   *
+   * - 'hid': WebHID 강제
+   * - 'ble': WebBLE 강제
+   * - undefined: sdk picker UI (기본)
+   *
+   * 같은 popup lifecycle 내 두 번째 호출의 transport 옵션은 silent ignore (first-wins).
+   * connector-chain-addition-isolation: transport는 chain과 직교 (모든 chain 공통).
+   *
+   * @throws ProviderError(INVALID_PARAMS) — invalid 값('webusb', null, '' 등)
+   */
+  transport?: 'hid' | 'ble'
 }
 
 /**
@@ -99,6 +114,8 @@ export async function sign (input: SignInput): Promise<V1Response> {
   const safeMethod = _sanitizeMethod(input.method)
   const safeChainId = _sanitizeChainId(input.chainId)
   _validateSignPayload(safeChainId, input.payload)
+  // (m09-04-03) transport 옵션 sanitize — 'hid' | 'ble' | undefined (INVALID_PARAMS throw 가능)
+  const safeTransport = _sanitizeTransportOption(input.transport)
   // (Session deviceId, 2026-05-22) deviceId hint를 _call로 전달. _call이 PopupTransport
   // .setPendingDeviceId로 등록 + handshake에 echo. dApp이 sign({..., deviceId})로 호출하면
   // sdk가 자동 cached connect 시도.
@@ -107,5 +124,6 @@ export async function sign (input: SignInput): Promise<V1Response> {
     chainId: safeChainId,
     params: input.payload,
     deviceId: input.deviceId,
+    transport: safeTransport,
   })
 }

--- a/src/transport/PopupTransport.ts
+++ b/src/transport/PopupTransport.ts
@@ -6,6 +6,7 @@ import {
 } from './MessageTransport'
 import { ProviderError } from '../error/ProviderError'
 import { ErrorCode } from '../error/ErrorCode'
+import { toWireTransport } from '../sign/_sanitizeTransportOption'
 
 /**
  * PopupTransport 옵션
@@ -80,6 +81,13 @@ export class PopupTransport implements MessageTransport {
    * 같은 popup 세션 도중 reuse하는 후속 send에는 영향 없음(handshake는 1회만 fire).
    */
   private pendingDeviceId: string | undefined = undefined
+  /**
+   * (m09-04-03) caller가 다음 handshake 시점에 sdk로 전달할 transport 힌트.
+   * popup lifecycle 단위 first-wins (audit R12): handshake는 첫 send에서만 1회 fire.
+   * 두 번째 sign 호출 시 setPendingTransport가 다시 호출되어도 handshakePromise가 이미
+   * 존재하므로 ensureHandshake가 새 handshake를 보내지 않음 → transport 변경 silent ignore.
+   */
+  private pendingTransport: 'hid' | 'ble' | undefined = undefined
   private stateHandlers: Set<(state: TransportState) => void> = new Set()
   private messageListener: ((event: MessageEvent) => void) | null = null
   private closePollingInterval: ReturnType<typeof setInterval> | null = null
@@ -202,6 +210,21 @@ export class PopupTransport implements MessageTransport {
    */
   setPendingDeviceId (deviceId: string | undefined): void {
     this.pendingDeviceId = deviceId
+  }
+
+  /**
+   * (m09-04-03) 다음 handshake에 sdk로 전달할 transport 힌트를 설정.
+   *
+   * 호출 시점: 첫 send 호출이 handshake를 trigger하기 전에 _call이 본 method로 설정.
+   * popup lifecycle 단위 first-wins (audit R12): handshakePromise가 이미 생성된 후에는
+   * 본 setter가 호출되어도 ensureHandshake가 기존 Promise를 재사용하므로 transport 변경이
+   * 실제로는 반영되지 않음 (silent ignore). 이는 의도된 동작 — popup 내 transport 재변경은
+   * application error로 간주.
+   *
+   * @param transport 설정할 transport 힌트. undefined로 호출하면 hint 비우기 (sdk picker 흐름).
+   */
+  setPendingTransport (transport: 'hid' | 'ble' | undefined): void {
+    this.pendingTransport = transport
   }
 
   async close (): Promise<void> {
@@ -455,11 +478,18 @@ export class PopupTransport implements MessageTransport {
       // (Session deviceId, 2026-05-22) pendingDeviceId 가 있으면 handshake params 에 포함.
       // sdk가 권한 캐시된 device 중 deviceId 매칭하는 것을 chooser 없이 자동 연결한다.
       // mismatch 시 ProviderRpcError(4001) — sdk envelope.error로 변환되어 send promise reject.
+      // (m09-04-03) pendingTransport를 toWireTransport로 변환하여 항상 동봉 (undefined → 'auto').
+      // sdk가 'auto'를 받으면 picker UI fallback, 'hid'/'ble'를 받으면 즉시 connect.
       const handshakeParams: {
         version: string
         clientName: string
         deviceId?: string
-      } = { version: this.protocolVersion, clientName: 'connector' }
+        transport: 'hid' | 'ble' | 'auto'
+      } = {
+        version: this.protocolVersion,
+        clientName: 'connector',
+        transport: toWireTransport(this.pendingTransport),
+      }
       if (this.pendingDeviceId) {
         handshakeParams.deviceId = this.pendingDeviceId
       }

--- a/tests/unit/v2/sign/transport-option.test.ts
+++ b/tests/unit/v2/sign/transport-option.test.ts
@@ -1,0 +1,473 @@
+/**
+ * transport option 단위 테스트 (m09-04-03)
+ *
+ * dcent.sign({ method, chainId, payload, transport? }) per-call 옵션 검증.
+ * _sanitizeTransportOption / toWireTransport helper + PopupTransport handshake 동봉 검증.
+ *
+ * T-U-01: transport: 'hid' → handshake params.transport === 'hid'
+ * T-U-02: transport: 'ble' → handshake params.transport === 'ble'
+ * T-U-03: transport 미명시 → handshake params.transport === 'auto'
+ * T-U-04: transport: 'webusb' → throw ProviderError(INVALID_PARAMS)
+ * T-U-05: transport: null / '' / {} → throw ProviderError(INVALID_PARAMS)
+ * T-U-06: 두 번째 sign 호출 transport는 silent ignore (first-wins)
+ * T-U-07: toWireTransport 단위 — 'hid'→'hid', 'ble'→'ble', undefined→'auto'
+ * T-BC-01: 기존 sign({method, chainId, payload}) 호출 회귀 0
+ * T-BC-02: sdk가 transport 미파싱 시 silent ignore + 정상 응답 반환 (race-safe mock)
+ * T-BC-03: 구 sdk transport 힌트 수신 후 PROTOCOL_VERSION_MISMATCH(5007) 미발생 회귀
+ * T-BC-04: 옵션 미명시 시 handshake params keys — transport 필드 항상 포함(==='auto')
+ */
+
+import { sign } from '../../../../src/sign/sign'
+import { _sanitizeTransportOption, toWireTransport } from '../../../../src/sign/_sanitizeTransportOption'
+import { PopupTransport } from '../../../../src/transport/PopupTransport'
+import { ensureSingleton, _resetForTesting } from '../../../../src/singleton'
+import { ProviderError } from '../../../../src/error/ProviderError'
+import { ErrorCode } from '../../../../src/error/ErrorCode'
+
+// ────────────────────────────────────────────────────────────────────────────
+// Helpers (PopupTransport.test.ts 패턴 재사용 — reuse-shared-utils 룰)
+// ────────────────────────────────────────────────────────────────────────────
+
+const DEFAULT_ORIGIN = 'https://bridge.dcentwallet.com'
+
+interface MockPopup {
+  closed: boolean
+  close: jest.Mock
+  postMessage: jest.Mock
+}
+
+function makeMockPopup (): MockPopup {
+  const popup: MockPopup = {
+    closed: false,
+    close: jest.fn(() => { popup.closed = true }),
+    postMessage: jest.fn(),
+  }
+  return popup
+}
+
+function dispatchResponse (origin: string, data: unknown): void {
+  const event = new MessageEvent('message', { origin, data: data as never })
+  window.dispatchEvent(event)
+}
+
+let _readyAutoRespondAddSpy: jest.SpyInstance | null = null
+let _readyAutoRespondConfig: { origin: string; version: string; serverName: string } | null = null
+
+function installReadyAutoRespondOnce (origin: string, version: string, serverName: string): void {
+  _readyAutoRespondConfig = { origin, version, serverName }
+  if (_readyAutoRespondAddSpy) return
+  const origAdd = window.addEventListener.bind(window)
+  _readyAutoRespondAddSpy = jest
+    .spyOn(window, 'addEventListener')
+    .mockImplementation(((type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions) => {
+      const ret = origAdd(type, listener, options)
+      if (type === 'message') {
+        Promise.resolve().then(() => {
+          if (_readyAutoRespondConfig) {
+            const c = _readyAutoRespondConfig
+            dispatchResponse(c.origin, { type: '_ready', version: c.version, serverName: c.serverName })
+          }
+        })
+      }
+      return ret
+    }) as typeof window.addEventListener)
+}
+
+function uninstallReadyAutoRespond (): void {
+  if (_readyAutoRespondAddSpy) {
+    _readyAutoRespondAddSpy.mockRestore()
+    _readyAutoRespondAddSpy = null
+  }
+  _readyAutoRespondConfig = null
+}
+
+function installHandshakeAutoRespond (
+  mockPopup: MockPopup,
+  origin: string = DEFAULT_ORIGIN,
+  sdkVersion: string = '2.0',
+  serverName: string = 'bridge-ui',
+): void {
+  mockPopup.postMessage.mockImplementation((message: { method?: unknown; id?: unknown }, msgOrigin: string) => {
+    if (message?.method === '_handshake' && typeof message.id === 'string') {
+      const responseOrigin = msgOrigin || origin
+      Promise.resolve().then(() => {
+        dispatchResponse(responseOrigin, {
+          id: message.id,
+          result: { version: sdkVersion, serverName },
+        })
+      })
+    }
+  })
+  installReadyAutoRespondOnce(origin, sdkVersion, serverName)
+}
+
+/**
+ * Ready + Handshake round-trip 마이크로태스크 flush.
+ * PopupTransport.test.ts의 flushHandshake()와 동일 (reuse-shared-utils).
+ */
+async function flushHandshake (): Promise<void> {
+  for (let i = 0; i < 6; i++) {
+    await Promise.resolve()
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// T-U-07: toWireTransport 단위 테스트
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('toWireTransport — unit', () => {
+  test('T-U-07a: "hid" → "hid"', () => {
+    expect(toWireTransport('hid')).toBe('hid')
+  })
+
+  test('T-U-07b: "ble" → "ble"', () => {
+    expect(toWireTransport('ble')).toBe('ble')
+  })
+
+  test('T-U-07c: undefined → "auto"', () => {
+    expect(toWireTransport(undefined)).toBe('auto')
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// _sanitizeTransportOption 단위 테스트
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('_sanitizeTransportOption — unit', () => {
+  test('valid "hid" → returns "hid"', () => {
+    expect(_sanitizeTransportOption('hid')).toBe('hid')
+  })
+
+  test('valid "ble" → returns "ble"', () => {
+    expect(_sanitizeTransportOption('ble')).toBe('ble')
+  })
+
+  test('undefined → returns undefined', () => {
+    expect(_sanitizeTransportOption(undefined)).toBeUndefined()
+  })
+
+  test('T-U-04: "webusb" → throws ProviderError(INVALID_PARAMS)', () => {
+    let caught: unknown
+    try {
+      _sanitizeTransportOption('webusb')
+    } catch (e) {
+      caught = e
+    }
+    expect(caught instanceof ProviderError).toBe(true)
+    expect((caught as ProviderError).code).toBe(ErrorCode.INVALID_PARAMS)
+  })
+
+  test('T-U-05a: null → throws ProviderError(INVALID_PARAMS)', () => {
+    let caught: unknown
+    try {
+      _sanitizeTransportOption(null)
+    } catch (e) {
+      caught = e
+    }
+    expect(caught instanceof ProviderError).toBe(true)
+    expect((caught as ProviderError).code).toBe(ErrorCode.INVALID_PARAMS)
+  })
+
+  test('T-U-05b: empty string → throws ProviderError(INVALID_PARAMS)', () => {
+    let caught: unknown
+    try {
+      _sanitizeTransportOption('')
+    } catch (e) {
+      caught = e
+    }
+    expect(caught instanceof ProviderError).toBe(true)
+    expect((caught as ProviderError).code).toBe(ErrorCode.INVALID_PARAMS)
+  })
+
+  test('T-U-05c: object → throws ProviderError(INVALID_PARAMS)', () => {
+    let caught: unknown
+    try {
+      _sanitizeTransportOption({})
+    } catch (e) {
+      caught = e
+    }
+    expect(caught instanceof ProviderError).toBe(true)
+    expect((caught as ProviderError).code).toBe(ErrorCode.INVALID_PARAMS)
+  })
+
+  test('T-U-05d: array → throws ProviderError(INVALID_PARAMS)', () => {
+    let caught: unknown
+    try {
+      _sanitizeTransportOption([])
+    } catch (e) {
+      caught = e
+    }
+    expect(caught instanceof ProviderError).toBe(true)
+  })
+
+  test('T-U-05e: "serial" → throws ProviderError(INVALID_PARAMS)', () => {
+    let caught: unknown
+    try {
+      _sanitizeTransportOption('serial')
+    } catch (e) {
+      caught = e
+    }
+    expect(caught instanceof ProviderError).toBe(true)
+    expect((caught as ProviderError).code).toBe(ErrorCode.INVALID_PARAMS)
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// PopupTransport handshake message transport 동봉 테스트 (T-U-01~03, T-BC-04)
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('PopupTransport — handshake transport 동봉', () => {
+  let openSpy: jest.SpyInstance
+  let mockPopup: MockPopup
+  let transport: PopupTransport
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    mockPopup = makeMockPopup()
+    openSpy = jest.spyOn(window, 'open').mockImplementation(() => mockPopup as unknown as Window)
+    transport = new PopupTransport({ origin: DEFAULT_ORIGIN })
+    installHandshakeAutoRespond(mockPopup, DEFAULT_ORIGIN)
+  })
+
+  afterEach(async () => {
+    await transport.close()
+    jest.useRealTimers()
+    openSpy.mockRestore()
+    uninstallReadyAutoRespond()
+  })
+
+  test('T-U-01: transport "hid" → handshake params.transport === "hid"', async () => {
+    transport.setPendingTransport('hid')
+    const sendPromise = transport.send({ id: 'req1', method: 'signTransaction', params: {} })
+    await flushHandshake()
+    dispatchResponse(DEFAULT_ORIGIN, { id: 'req1', result: { header: { version: '1.0', status: 'success' }, body: { command: 'signTransaction' } } })
+    await sendPromise
+
+    const hsCall = mockPopup.postMessage.mock.calls.find(
+      (call: unknown[]) => (call[0] as { method?: unknown })?.method === '_handshake',
+    )
+    expect(hsCall).toBeDefined()
+    const hsParams = (hsCall![0] as { params: { transport: unknown } }).params
+    expect(hsParams.transport).toBe('hid')
+  })
+
+  test('T-U-02: transport "ble" → handshake params.transport === "ble"', async () => {
+    transport.setPendingTransport('ble')
+    const sendPromise = transport.send({ id: 'req2', method: 'signTransaction', params: {} })
+    await flushHandshake()
+    dispatchResponse(DEFAULT_ORIGIN, { id: 'req2', result: { header: { version: '1.0', status: 'success' }, body: { command: 'signTransaction' } } })
+    await sendPromise
+
+    const hsCall = mockPopup.postMessage.mock.calls.find(
+      (call: unknown[]) => (call[0] as { method?: unknown })?.method === '_handshake',
+    )
+    expect(hsCall).toBeDefined()
+    const hsParams = (hsCall![0] as { params: { transport: unknown } }).params
+    expect(hsParams.transport).toBe('ble')
+  })
+
+  test('T-U-03: transport 미명시 → handshake params.transport === "auto"', async () => {
+    // setPendingTransport 호출 없음 (pendingTransport === undefined → 'auto')
+    const sendPromise = transport.send({ id: 'req3', method: 'signTransaction', params: {} })
+    await flushHandshake()
+    dispatchResponse(DEFAULT_ORIGIN, { id: 'req3', result: { header: { version: '1.0', status: 'success' }, body: { command: 'signTransaction' } } })
+    await sendPromise
+
+    const hsCall = mockPopup.postMessage.mock.calls.find(
+      (call: unknown[]) => (call[0] as { method?: unknown })?.method === '_handshake',
+    )
+    expect(hsCall).toBeDefined()
+    const hsParams = (hsCall![0] as { params: { transport: unknown } }).params
+    expect(hsParams.transport).toBe('auto')
+  })
+
+  test('T-BC-04: 옵션 미명시 시 handshake params에 transport 필드 항상 포함 (==="auto")', async () => {
+    const sendPromise = transport.send({ id: 'req4', method: 'getDeviceInfo', params: {} })
+    await flushHandshake()
+    dispatchResponse(DEFAULT_ORIGIN, { id: 'req4', result: { header: { version: '1.0', status: 'success' }, body: { command: 'getDeviceInfo' } } })
+    await sendPromise
+
+    const hsCall = mockPopup.postMessage.mock.calls.find(
+      (call: unknown[]) => (call[0] as { method?: unknown })?.method === '_handshake',
+    )
+    expect(hsCall).toBeDefined()
+    const hsParams = (hsCall![0] as { params: Record<string, unknown> }).params
+    // transport 필드가 항상 존재해야 함
+    expect(Object.keys(hsParams)).toContain('transport')
+    expect(hsParams.transport).toBe('auto')
+    // 기존 필드들도 그대로 있어야 함
+    expect(hsParams.clientName).toBe('connector')
+    expect(typeof hsParams.version).toBe('string')
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// T-U-06: popup lifecycle 내 first-wins (두 번째 transport silent ignore)
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('PopupTransport — first-wins (T-U-06)', () => {
+  let openSpy: jest.SpyInstance
+  let mockPopup: MockPopup
+  let transport: PopupTransport
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    mockPopup = makeMockPopup()
+    openSpy = jest.spyOn(window, 'open').mockImplementation(() => mockPopup as unknown as Window)
+    transport = new PopupTransport({ origin: DEFAULT_ORIGIN })
+    installHandshakeAutoRespond(mockPopup, DEFAULT_ORIGIN)
+  })
+
+  afterEach(async () => {
+    await transport.close()
+    jest.useRealTimers()
+    openSpy.mockRestore()
+    uninstallReadyAutoRespond()
+  })
+
+  test('T-U-06: 두 번째 sign 호출 transport는 silent ignore — first-wins', async () => {
+    // 첫 번째 호출: transport 'hid'
+    transport.setPendingTransport('hid')
+    const p1 = transport.send({ id: 'req-fw-1', method: 'signTransaction', params: {} })
+    await flushHandshake()
+    dispatchResponse(DEFAULT_ORIGIN, { id: 'req-fw-1', result: { header: { version: '1.0', status: 'success' }, body: { command: 'signTransaction' } } })
+    await p1
+
+    // 첫 번째 handshake 확인 — transport: 'hid'
+    const hsCalls = mockPopup.postMessage.mock.calls.filter(
+      (call: unknown[]) => (call[0] as { method?: unknown })?.method === '_handshake',
+    )
+    expect(hsCalls).toHaveLength(1)
+    expect((hsCalls[0][0] as { params: { transport: unknown } }).params.transport).toBe('hid')
+
+    // 두 번째 호출: transport 'ble' 시도 — handshakePromise가 이미 resolve되어 재사용
+    transport.setPendingTransport('ble')
+    const p2 = transport.send({ id: 'req-fw-2', method: 'signTransaction', params: {} })
+    await flushHandshake()
+    dispatchResponse(DEFAULT_ORIGIN, { id: 'req-fw-2', result: { header: { version: '1.0', status: 'success' }, body: { command: 'signTransaction' } } })
+    await p2
+
+    // 두 번째 호출에서는 새 handshake가 없어야 함 (여전히 1회만)
+    const hsCallsAfter = mockPopup.postMessage.mock.calls.filter(
+      (call: unknown[]) => (call[0] as { method?: unknown })?.method === '_handshake',
+    )
+    expect(hsCallsAfter).toHaveLength(1) // 새 handshake 없음 — first-wins
+    expect((hsCallsAfter[0][0] as { params: { transport: unknown } }).params.transport).toBe('hid')
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────────
+// sign() 통합 — T-U-04/05 throw, T-BC-01/02/03
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('sign() — transport option throw + backward compat', () => {
+  beforeEach(() => {
+    _resetForTesting()
+    jest.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    _resetForTesting()
+    jest.restoreAllMocks()
+  })
+
+  test('T-U-04: sign({transport: "webusb"}) → throws ProviderError(INVALID_PARAMS)', async () => {
+    let caught: unknown
+    try {
+      await sign({
+        method: 'signTransaction',
+        chainId: 'eip155:1',
+        payload: { keyPath: "m/44'/60'/0'/0/0" },
+        transport: 'webusb' as never,
+      })
+    } catch (e) {
+      caught = e
+    }
+    expect(caught instanceof ProviderError).toBe(true)
+    expect((caught as ProviderError).code).toBe(ErrorCode.INVALID_PARAMS)
+  })
+
+  test('T-U-05-sign: sign({transport: null}) → throws ProviderError(INVALID_PARAMS)', async () => {
+    let caught: unknown
+    try {
+      await sign({
+        method: 'signTransaction',
+        chainId: 'eip155:1',
+        payload: { keyPath: "m/44'/60'/0'/0/0" },
+        transport: null as never,
+      })
+    } catch (e) {
+      caught = e
+    }
+    expect(caught instanceof ProviderError).toBe(true)
+    expect((caught as ProviderError).code).toBe(ErrorCode.INVALID_PARAMS)
+  })
+
+  test('T-BC-01: 기존 sign({method, chainId, payload}) 호출 — transport 미명시 → 회귀 0', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'bc01',
+      result: {
+        header: { version: '1.0', status: 'success' as const },
+        body: { command: 'signTransaction' },
+      },
+    })
+
+    // transport 옵션 없는 기존 호출 패턴
+    const resp = await sign({
+      method: 'signTransaction',
+      chainId: 'eip155:1',
+      payload: { keyPath: "m/44'/60'/0'/0/0", transaction: { to: '0x1', value: '0x1' } },
+    })
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    expect(resp.header.status).toBe('success')
+  })
+
+  test('T-BC-02: sdk가 transport 미파싱 시 (m09-03-03 미SHIPPED) — silent ignore + 정상 응답', async () => {
+    // sdk가 transport 필드를 무시하고 정상 응답을 반환하는 시나리오 mock
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'bc02',
+      result: {
+        header: { version: '1.0', status: 'success' as const },
+        body: { command: 'signTransaction', parameter: { signed_tx: '0xsigned' } },
+      },
+    })
+
+    const resp = await sign({
+      method: 'signTransaction',
+      chainId: 'eip155:1',
+      payload: { keyPath: "m/44'/60'/0'/0/0" },
+      transport: 'hid',
+    })
+
+    // sdk가 transport를 무시해도 정상 응답
+    expect(resp.header.status).toBe('success')
+    expect(resp.body.parameter?.signed_tx).toBe('0xsigned')
+  })
+
+  test('T-BC-03: transport 힌트 수신 후 PROTOCOL_VERSION_MISMATCH(5007) 미발생 회귀', async () => {
+    // sdk가 transport 필드를 받고도 PROTOCOL_VERSION_MISMATCH를 던지지 않는 시나리오 mock
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'bc03',
+      result: {
+        header: { version: '1.0', status: 'success' as const },
+        body: { command: 'signTransaction' },
+      },
+    })
+
+    // transport 힌트 있어도 정상 응답 반환 — PROTOCOL_VERSION_MISMATCH 없음
+    const resp = await sign({
+      method: 'signTransaction',
+      chainId: 'eip155:1',
+      payload: { keyPath: "m/44'/60'/0'/0/0" },
+      transport: 'hid',
+    })
+
+    expect(resp.header.status).toBe('success')
+    // PROTOCOL_VERSION_MISMATCH(5007) 에러가 없음을 확인
+    expect(resp.body.error?.code).not.toBe('protocol_version_mismatch')
+  })
+})

--- a/tests/unit/v2/transport/PopupTransport.test.ts
+++ b/tests/unit/v2/transport/PopupTransport.test.ts
@@ -486,10 +486,11 @@ describe('PopupTransport', () => {
         (c: unknown[]) => (c[0] as { method?: string })?.method === '_handshake',
       )
       expect(handshakeCalls.length).toBe(1)
-      const handshakeMsg = handshakeCalls[0][0] as { id: string; method: string; params: { version: string; clientName: string } }
+      const handshakeMsg = handshakeCalls[0][0] as { id: string; method: string; params: { version: string; clientName: string; transport: string } }
       expect(handshakeMsg.id.startsWith('_handshake_')).toBe(true)
       expect(handshakeMsg.method).toBe('_handshake')
-      expect(handshakeMsg.params).toEqual({ version: '2.0', clientName: 'connector' })
+      // m09-04-03: transport 필드가 항상 포함됨 (옵션 미명시 시 'auto')
+      expect(handshakeMsg.params).toEqual({ version: '2.0', clientName: 'connector', transport: 'auto' })
       expect(handshakeCalls[0][1]).toBe(DEFAULT_ORIGIN)
 
       await transport.close()


### PR DESCRIPTION
## 개요

**Objective**: `m09-04-03-connector-transport-option`
**Jira**: [DC-2376](https://iotrust.atlassian.net/browse/DC-2376)
**Epic**: m09-04 connector v2 cleanup
**Base**: `epic/DC-2223_m09-04-connector-v2-cleanup`

`dcent.sign()` API에 per-call `transport` 옵션을 additive하게 도입한다. dApp이 옵션을 명시하면 connector가 popup으로 sdk에 transport 힌트를 전달하고, sdk(m09-03-03)는 picker UI를 skip한 채 해당 transport로 즉시 connect한다.

## 구현 내용

### 신규 파일
- `src/sign/_sanitizeTransportOption.ts` — `_sanitizeTransportOption` + `toWireTransport` helper
- `tests/unit/v2/sign/transport-option.test.ts` — 단위 테스트 22건 (T-U-01~07, T-BC-01~04)

### 수정 파일
- `src/sign/sign.ts` — `SignInput`에 `transport?: 'hid' | 'ble'` 옵션 추가 + sanitize 호출
- `src/sign/call.ts` — `CallInput`에 `transport?` 추가 + `setPendingTransport` 호출
- `src/transport/PopupTransport.ts` — `_pendingTransport` 상태 + `setPendingTransport()` + handshake params에 `transport` 항상 동봉
- `tests/unit/v2/transport/PopupTransport.test.ts` — T-U-HS-01 handshake params assertion 갱신

## 핵심 동작

| 호출 | handshake params.transport | sdk 동작 |
|---|---|---|
| `dcent.sign({method, chainId, payload})` | `'auto'` | picker UI |
| `dcent.sign({..., transport: 'hid'})` | `'hid'` | WebHID 즉시 connect |
| `dcent.sign({..., transport: 'ble'})` | `'ble'` | WebBLE 즉시 connect |
| `dcent.sign({..., transport: 'webusb'})` | — | `throw ProviderError(INVALID_PARAMS)` |

## 설계 원칙

- **additive backward compat**: 기존 `dcent.sign({method, chainId, payload})` 호출 변경 0
- **per-call 옵션만**: `dcent.setTransport()` stateful setter 없음 (audit 결정 — deprecate 비용 회피)
- **popup lifecycle 단위 first-wins** (audit R12): `handshakePromise` 재사용으로 자동 보장. 두 번째 호출의 transport는 silent ignore (에러 없음)
- **race-safe cross-repo**: sdk m09-03-03 미SHIPPED 상태에서 connector가 transport 힌트를 보내도 sdk가 silent ignore + picker UI fallback (`release-unit-versioning-exemption: race-safe-cross-repo`)
- **connector-chain-addition-isolation 무위반**: transport는 chain과 직교 (모든 chain 공통 HW 통신 채널)

## 검증 결과

```
T-LINT-01  npm run lint         ✅ PASS (exit 0)
T-TSC-01   npm run tsc          ✅ PASS (exit 0)
T-U-01~07  transport-option.test.ts (22 tests)  ✅ PASS
T-BC-01~04 transport-option.test.ts             ✅ PASS
T-BUILD-01 npm run build        ✅ PASS (webpack compiled)
T-INTEG    conditional skip — m09-03-03 미SHIPPED (m09-03-03 SHIPPED 후 재실행 권장)
```

전체 v2 suite: 535/537 통과 (2 failures = playground.smoke, playground.signtx-evm — base branch pre-existing)

## Cross-repo 정합

- sdk 측 `PopupListener.ts`: `transport?: unknown` 필드 이미 구현됨 (m09-03-03 dev branch MERGED_TO_EPIC)
- handshake message shape: `{ version, clientName, transport?: 'hid'|'ble'|'auto' }`
- m09-03-03 SHIPPED 후 전체 round-trip 검증 권장 (T-INTEG-01/02)

## Notes

- connector public API minor bump 필요 (release manager 결정 — `no-version-bump` 룰 준수, 본 PR는 version 미수정)
- `no-version-bump` 룰 준수: `package.json` version 미수정
- INVALID_PARAMS (복수형) 사용 — C4 WARN 반영

---
_Generated by uap-autopilot-objective · Objective m09-04-03-connector-transport-option_