### PR TITLE
[DC-2391] feat(playground): wm full-coverage chains.json + presets 확장 (m09-04-10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "unit-v2-e2e:slowmo": "E2E_HEADLESS=false E2E_SLOWMO=100 jest --config jest.v2-e2e.config.js --runInBand",
     "unit-v2-e2e:devtools": "E2E_HEADLESS=false E2E_DEVTOOLS=true jest --config jest.v2-e2e.config.js --runInBand",
     "extract-chains": "node scripts/extract-chains.js",
-    "lint": "eslint --ext .js src-v1 tests playground.js",
+    "lint": "eslint --ext .js src-v1 tests playground.js scripts",
     "lint:fix": "eslint --ext .js src-v1 tests playground.js --fix",
     "tsc": "tsc --noEmit"
   },

--- a/playground/chains.json
+++ b/playground/chains.json
@@ -1,459 +1,903 @@
 [
   {
-    "chainId": "eip155:1/slip44:60",
+    "chainId": "eip155:1",
     "family": "ethereum",
     "displayName": "Ethereum",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:30/slip44:60",
+    "chainId": "eip155:16",
+    "family": "ethereum",
+    "displayName": "Flare Network Coston",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:30",
     "family": "ethereum",
     "displayName": "RSK Smart Bitcoin",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:8217/slip44:60",
+    "chainId": "eip155:31",
+    "family": "ethereum",
+    "displayName": "RSK Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:8217",
     "family": "ethereum",
     "displayName": "Kaia",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:61/slip44:60",
+    "chainId": "eip155:1001",
+    "family": "ethereum",
+    "displayName": "Kaia Kairos",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:61",
     "family": "ethereum",
     "displayName": "Ethereum Classic",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:256/slip44:60",
+    "chainId": "eip155:256",
     "family": "ethereum",
     "displayName": "Luniverse",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:50/slip44:60",
+    "chainId": "eip155:50",
     "family": "ethereum",
     "displayName": "XDC (XinFin)",
     "defaultKeyPath": "m/44'/550'/0'/0/0"
   },
   {
-    "chainId": "eip155:56/slip44:60",
+    "chainId": "eip155:51",
+    "family": "ethereum",
+    "displayName": "XDC Apothem",
+    "defaultKeyPath": "m/44'/550'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:56",
     "family": "ethereum",
     "displayName": "Binance Smart Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:10/slip44:60",
+    "chainId": "eip155:97",
+    "family": "ethereum",
+    "displayName": "BSC Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:10",
     "family": "ethereum",
     "displayName": "Optimism",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:11/slip44:60",
+    "chainId": "eip155:11",
     "family": "ethereum",
     "displayName": "Metadium",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:14/slip44:60",
+    "chainId": "eip155:14",
     "family": "ethereum",
     "displayName": "Flare Network",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:19/slip44:60",
+    "chainId": "eip155:19",
     "family": "ethereum",
     "displayName": "Songbird Canary-Network",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:25/slip44:60",
+    "chainId": "eip155:25",
     "family": "ethereum",
     "displayName": "Cronos",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:66/slip44:60",
+    "chainId": "eip155:66",
     "family": "ethereum",
     "displayName": "OKX Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:100/slip44:60",
+    "chainId": "eip155:100",
     "family": "ethereum",
     "displayName": "Gnosis",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:246/slip44:60",
+    "chainId": "eip155:246",
     "family": "ethereum",
     "displayName": "Energy Web Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:248/slip44:60",
+    "chainId": "eip155:248",
     "family": "ethereum",
     "displayName": "Oasys",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:250/slip44:60",
+    "chainId": "eip155:250",
     "family": "ethereum",
     "displayName": "Fantom Opera",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:255/slip44:60",
+    "chainId": "eip155:255",
     "family": "ethereum",
     "displayName": "Kroma",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:288/slip44:60",
+    "chainId": "eip155:288",
     "family": "ethereum",
     "displayName": "Boba",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:321/slip44:60",
+    "chainId": "eip155:321",
     "family": "ethereum",
     "displayName": "KCC",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:592/slip44:60",
+    "chainId": "eip155:592",
     "family": "ethereum",
     "displayName": "Astar EVM",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:2017/slip44:60",
+    "chainId": "eip155:2017",
     "family": "ethereum",
     "displayName": "Orbit Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:7518/slip44:60",
+    "chainId": "eip155:7518",
     "family": "ethereum",
     "displayName": "MEVerse",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:8453/slip44:60",
+    "chainId": "eip155:8453",
     "family": "ethereum",
     "displayName": "Base",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:42161/slip44:60",
+    "chainId": "eip155:42161",
     "family": "ethereum",
     "displayName": "Arbitrum One",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:42220/slip44:60",
+    "chainId": "eip155:42220",
     "family": "ethereum",
     "displayName": "Celo",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:43114/slip44:60",
+    "chainId": "eip155:43114",
     "family": "ethereum",
     "displayName": "Avalanche C-Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:1666600000/slip44:60",
+    "chainId": "eip155:1666600000",
     "family": "ethereum",
     "displayName": "Harmony",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:11297108109/slip44:60",
+    "chainId": "eip155:11297108109",
     "family": "ethereum",
     "displayName": "Palm",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:137/slip44:60",
+    "chainId": "eip155:12",
+    "family": "ethereum",
+    "displayName": "Metadium Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:2358",
+    "family": "ethereum",
+    "displayName": "Kroma Sepolia",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:11155111",
+    "family": "ethereum",
+    "displayName": "Sepolia Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:1666700000",
+    "family": "ethereum",
+    "displayName": "Harmony Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:80002",
+    "family": "ethereum",
+    "displayName": "Polygon Amoy",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:137",
     "family": "ethereum",
     "displayName": "Polygon",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "conflux:cfx/slip44:503",
+    "chainId": "conflux:cfx",
     "family": "conflux",
     "displayName": "Conflux",
     "defaultKeyPath": "m/44'/60'/0'"
   },
   {
-    "chainId": "eip155:3776/slip44:60",
+    "chainId": "eip155:3776",
     "family": "ethereum",
     "displayName": "Astar zkEVM",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:612/slip44:60",
+    "chainId": "eip155:612",
     "family": "ethereum",
     "displayName": "EIOB Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:4613/slip44:60",
+    "chainId": "eip155:4613",
     "family": "ethereum",
     "displayName": "VERY Mainnet",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:37/slip44:60",
+    "chainId": "eip155:37",
     "family": "ethereum",
     "displayName": "XPLA",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:81/slip44:60",
+    "chainId": "eip155:81",
     "family": "ethereum",
     "displayName": "Japan Open Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:1625/slip44:60",
+    "chainId": "eip155:1625",
     "family": "ethereum",
     "displayName": "Gravity Alpha",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:102030/slip44:60",
+    "chainId": "eip155:10081",
+    "family": "ethereum",
+    "displayName": "JOC Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:13505",
+    "family": "ethereum",
+    "displayName": "Gravity Sepolia Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:102030",
     "family": "ethereum",
     "displayName": "Creditcoin EVM",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:314/slip44:60",
+    "chainId": "eip155:102031",
+    "family": "ethereum",
+    "displayName": "Creditcoin EVM Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:314",
     "family": "ethereum",
     "displayName": "Filecoin EVM",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:1689/slip44:60",
+    "chainId": "eip155:314159",
+    "family": "ethereum",
+    "displayName": "Filecoin EVM Calibration Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:338",
+    "family": "ethereum",
+    "displayName": "Cronos Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:1689",
     "family": "ethereum",
     "displayName": "NERO",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:146/slip44:60",
+    "chainId": "eip155:146",
     "family": "ethereum",
     "displayName": "Sonic",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:22776/slip44:60",
+    "chainId": "eip155:22776",
     "family": "ethereum",
     "displayName": "MAP Protocol",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:1868/slip44:60",
+    "chainId": "eip155:10143",
+    "family": "ethereum",
+    "displayName": "Monad Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:1868",
     "family": "ethereum",
     "displayName": "Soneium",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:534352/slip44:60",
+    "chainId": "eip155:534352",
     "family": "ethereum",
     "displayName": "Scroll",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:41923/slip44:60",
+    "chainId": "eip155:41923",
     "family": "ethereum",
     "displayName": "Edu Chain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:5050/slip44:60",
+    "chainId": "eip155:656476",
+    "family": "ethereum",
+    "displayName": "Edu Chain Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:5050",
     "family": "ethereum",
     "displayName": "Skate",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:888888888/slip44:60",
+    "chainId": "eip155:888888888",
     "family": "ethereum",
     "displayName": "Ancient8",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:88888/slip44:60",
+    "chainId": "eip155:88888",
     "family": "ethereum",
     "displayName": "Chiliz",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:167000/slip44:60",
+    "chainId": "eip155:167000",
     "family": "ethereum",
     "displayName": "Taiko Alethia",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:80094/slip44:60",
+    "chainId": "eip155:80094",
     "family": "ethereum",
     "displayName": "Berachain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:1514/slip44:60",
+    "chainId": "eip155:1449000",
+    "family": "ethereum",
+    "displayName": "XRPL EVM Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:1514",
     "family": "ethereum",
     "displayName": "Story Network",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:1440000/slip44:60",
+    "chainId": "eip155:123420001114",
+    "family": "ethereum",
+    "displayName": "Basecamp Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:1440000",
     "family": "ethereum",
     "displayName": "XRPL EVM",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:169/slip44:60",
+    "chainId": "eip155:169",
     "family": "ethereum",
     "displayName": "Manta Pacific",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:20250217/slip44:60",
+    "chainId": "eip155:20250217",
     "family": "ethereum",
     "displayName": "Xphere",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:999/slip44:60",
+    "chainId": "eip155:84532",
+    "family": "ethereum",
+    "displayName": "Base Sepolia Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:999",
     "family": "ethereum",
     "displayName": "HyperEVM",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:484/slip44:60",
+    "chainId": "eip155:484",
     "family": "ethereum",
     "displayName": "Camp Mainnet",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:6985385/slip44:60",
+    "chainId": "eip155:6985385",
     "family": "ethereum",
     "displayName": "Humanity Protocol",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:210000/slip44:60",
+    "chainId": "eip155:2201",
+    "family": "ethereum",
+    "displayName": "Stable Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:210000",
     "family": "ethereum",
     "displayName": "JuChain",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:50104/slip44:60",
+    "chainId": "eip155:50104",
     "family": "ethereum",
     "displayName": "Sophon",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:4352/slip44:60",
+    "chainId": "eip155:4352",
     "family": "ethereum",
     "displayName": "MemeCore",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:98866/slip44:60",
+    "chainId": "eip155:1439",
+    "family": "ethereum",
+    "displayName": "Injective Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:98866",
     "family": "ethereum",
     "displayName": "Plume",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:1776/slip44:60",
+    "chainId": "eip155:1776",
     "family": "ethereum",
     "displayName": "Injective",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:143/slip44:60",
+    "chainId": "eip155:904",
+    "family": "ethereum",
+    "displayName": "Ault Mainnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "eip155:143",
     "family": "ethereum",
     "displayName": "Monad Mainnet",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:7300/slip44:60",
+    "chainId": "eip155:2731",
+    "family": "ethereum",
+    "displayName": "TIME Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:20250616",
+    "family": "ethereum",
+    "displayName": "LK Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:7300",
     "family": "ethereum",
     "displayName": "XPLAVerse",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:204/slip44:60",
+    "chainId": "eip155:2225",
+    "family": "ethereum",
+    "displayName": "XPLAVerse Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:204",
     "family": "ethereum",
     "displayName": "opBNB",
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "bip122:000000000019d6689c085ae165831e93/slip44:0",
+    "chainId": "eip155:5611",
+    "family": "ethereum",
+    "displayName": "opBNB Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:9372",
+    "family": "ethereum",
+    "displayName": "Oasys Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:42069",
+    "family": "ethereum",
+    "displayName": "DSRV Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:47",
+    "family": "ethereum",
+    "displayName": "XPLA Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "eip155:688689",
+    "family": "ethereum",
+    "displayName": "Pharos Atlantic Testnet",
+    "defaultKeyPath": "m/44'/60'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "bip122:000000000019d6689c085ae165831e93",
     "family": "bitcoin",
     "displayName": "Bitcoin",
     "defaultKeyPath": "m/84'/0'/0'/0/0"
   },
   {
-    "chainId": "bip122:000000000000000000651ef99cb9fcbe/slip44:145",
+    "chainId": "bip122:000000000933ea01ad0ee984209779ba",
+    "family": "bitcoin",
+    "displayName": "Bitcoin Testnet",
+    "defaultKeyPath": "m/84'/1'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "bip122:000000000000000000651ef99cb9fcbe",
     "family": "bitcoin",
     "displayName": "Bitcoin Cash",
     "defaultKeyPath": "m/84'/145'/0'/0/0"
   },
   {
-    "chainId": "bip122:12a765e31ffd4059bada1e25190f6e98/slip44:2",
+    "chainId": "bip122:000000000019d6689c085ae165831e93/slip44:145",
+    "family": "bitcoin",
+    "displayName": "eCash",
+    "defaultKeyPath": "m/84'/145'/0'/0/0"
+  },
+  {
+    "chainId": "bip122:00040fe8ec8471911baa1db1266ea15d/slip44:133",
+    "family": "bitcoin",
+    "displayName": "Zcash",
+    "defaultKeyPath": "m/84'/133'/0'/0/0"
+  },
+  {
+    "chainId": "bip122:12a765e31ffd4059bada1e25190f6e98",
     "family": "bitcoin",
     "displayName": "Litecoin",
     "defaultKeyPath": "m/84'/2'/0'/0/0"
   },
   {
-    "chainId": "bip122:1a91e3dace36e2be3bf030a65679fe82/slip44:3",
+    "chainId": "bip122:00000000e9fba3b4a12d04c0a48d70d5/slip44:156",
+    "family": "bitcoin",
+    "displayName": "Bitcoin Gold",
+    "defaultKeyPath": "m/84'/156'/0'/0/0"
+  },
+  {
+    "chainId": "bip122:00000000e0494ef974d8afb784e1bdeb/slip44:1",
+    "family": "bitcoin",
+    "displayName": "BitGold Testnet",
+    "defaultKeyPath": "m/84'/1'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "bip122:00000ffd590b1485b3caadc19b22e637/slip44:5",
+    "family": "bitcoin",
+    "displayName": "Dash",
+    "defaultKeyPath": "m/84'/5'/0'/0/0"
+  },
+  {
+    "chainId": "bip122:00000bafbc94add76cb75e2ec9289483/slip44:1",
+    "family": "bitcoin",
+    "displayName": "Dash Testnet",
+    "defaultKeyPath": "m/84'/1'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "bip122:7497ea1b465eb39f1c8f507bc877078f/slip44:20",
+    "family": "bitcoin",
+    "displayName": "DigiByte",
+    "defaultKeyPath": "m/84'/20'/0'/0/0"
+  },
+  {
+    "chainId": "bip122:fabe7dc4cf82e888f7afd9a1c7e05d10/slip44:1",
+    "family": "bitcoin",
+    "displayName": "DigiByte Testnet",
+    "defaultKeyPath": "m/84'/20'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "bip122:0000006b444bc2f2ffe627be9d9e7e7a/slip44:175",
+    "family": "bitcoin",
+    "displayName": "Ravencoin",
+    "defaultKeyPath": "m/84'/175'/0'/0/0"
+  },
+  {
+    "chainId": "bip122:000000b3e9edd0f7e8c60f9cf47ce5cc/slip44:1",
+    "family": "bitcoin",
+    "displayName": "Ravencoin Testnet",
+    "defaultKeyPath": "m/84'/175'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "bip122:1a91e3dace36e2be3bf030a65679fe82",
     "family": "bitcoin",
     "displayName": "Dogecoin",
     "defaultKeyPath": "m/84'/3'/0'/0/0"
   },
   {
-    "chainId": "xrpl:0/slip44:144",
+    "chainId": "bip122:0007104ccda289427919efc39dc9e4d4/slip44:121",
+    "family": "bitcoin",
+    "displayName": "Horizen",
+    "defaultKeyPath": "m/84'/121'/0'/0/0"
+  },
+  {
+    "chainId": "xrpl:0",
     "family": "xrp",
     "displayName": "XRPL",
     "defaultKeyPath": "m/44'/144'/0'/0/0"
   },
   {
-    "chainId": "cosmos:Binance-Chain-Tigris/slip44:714",
+    "chainId": "xrpl:1",
+    "family": "xrp",
+    "displayName": "XRP Testnet",
+    "defaultKeyPath": "m/44'/144'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "cosmos:Binance-Chain-Tigris",
     "family": "cosmos",
     "displayName": "Binance coin",
     "defaultKeyPath": "m/44'/714'/0'/0/0"
   },
   {
-    "chainId": "stellar:pubnet/slip44:148",
+    "chainId": "cosmos:Binance-Chain-Ganges/slip44:714",
+    "family": "cosmos",
+    "displayName": "Binance Testnet",
+    "defaultKeyPath": "m/44'/714'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "stellar:pubnet",
     "family": "stellar",
     "displayName": "Stellar",
     "defaultKeyPath": "m/44'/148'/0'"
   },
   {
-    "chainId": "hedera:mainnet/slip44:3030",
+    "chainId": "stellar:testnet",
+    "family": "stellar",
+    "displayName": "Stellar Testnet",
+    "defaultKeyPath": "m/44'/148'/0'",
+    "isTestnet": true
+  },
+  {
+    "chainId": "tron:0x2b6653dc",
+    "family": "tron",
+    "displayName": "TRON",
+    "defaultKeyPath": "m/44'/195'/0'/0/0"
+  },
+  {
+    "chainId": "tron:0x941250dc/slip44:195",
+    "family": "tron",
+    "displayName": "TRON Testnet",
+    "defaultKeyPath": "m/44'/195'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "cip34:1-764824073",
+    "family": "cardano",
+    "displayName": "Cardano",
+    "defaultKeyPath": "m/1852'/1815'/0'/0/0"
+  },
+  {
+    "chainId": "cip34:0-2",
+    "family": "cardano",
+    "displayName": "Cardano Testnet",
+    "defaultKeyPath": "m/1852'/1815'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "hedera:mainnet",
     "family": "hedera",
     "displayName": "Hedera Hashgraph",
     "defaultKeyPath": "m/44'/3030'/0'"
   },
   {
-    "chainId": "stacks:1/slip44:5757",
+    "chainId": "hedera:testnet",
+    "family": "hedera",
+    "displayName": "Hedera Testnet",
+    "defaultKeyPath": "m/44'/3030'/0'",
+    "isTestnet": true
+  },
+  {
+    "chainId": "stacks:1",
     "family": "stacks",
     "displayName": "Stacks",
     "defaultKeyPath": "m/44'/5757'/0'/0/0"
   },
   {
-    "chainId": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501",
+    "chainId": "stacks:2147483648",
+    "family": "stacks",
+    "displayName": "Stacks Testnet",
+    "defaultKeyPath": "m/44'/5757'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
     "family": "solana",
     "displayName": "Solana",
     "defaultKeyPath": "m/44'/501'/0'"
   },
   {
-    "chainId": "polkadot:91b171bb158e2d3848fa23a9f1c25182/slip44:354",
+    "chainId": "polkadot:91b171bb158e2d3848fa23a9f1c25182",
     "family": "polkadot",
     "displayName": "Polkadot",
     "defaultKeyPath": "m/44'/354'/0'/0/0"
+  },
+  {
+    "chainId": "cosmos:cosmoshub-4",
+    "family": "cosmos",
+    "displayName": "Cosmos",
+    "defaultKeyPath": "m/44'/118'/0'/0/0"
+  },
+  {
+    "chainId": "tezos:NetXdQprcVkpaWU",
+    "family": "tezos",
+    "displayName": "Tezos",
+    "defaultKeyPath": "m/44'/1729'/0'/0'"
+  },
+  {
+    "chainId": "tezos:NetXnHfVqm9iesp",
+    "family": "tezos",
+    "displayName": "Tezos Testnet",
+    "defaultKeyPath": "m/44'/1729'/0'/0'",
+    "isTestnet": true
+  },
+  {
+    "chainId": "vechain:b1ac3413d346d43539627e6be7ec1b4a",
+    "family": "vechain",
+    "displayName": "VeChain",
+    "defaultKeyPath": "m/44'/60'/0'/0/0"
+  },
+  {
+    "chainId": "near:mainnet/slip44:397",
+    "family": "near",
+    "displayName": "NEAR Protocol",
+    "defaultKeyPath": "m/44'/397'/0'"
+  },
+  {
+    "chainId": "near:testnet/slip44:397",
+    "family": "near",
+    "displayName": "NEAR Testnet",
+    "defaultKeyPath": "m/44'/397'/0'",
+    "isTestnet": true
+  },
+  {
+    "chainId": "cosmos:coreum-mainnet-1",
+    "family": "cosmos",
+    "displayName": "TX",
+    "defaultKeyPath": "m/44'/990'/0'/0/0"
+  },
+  {
+    "chainId": "cosmos:coreum-testnet-1",
+    "family": "cosmos",
+    "displayName": "Coreum Testnet",
+    "defaultKeyPath": "m/44'/990'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "cosmos:hippo-protocol-1/slip44:118",
+    "family": "cosmos",
+    "displayName": "Hippo Protocol",
+    "defaultKeyPath": "m/44'/118'/0'/0/0"
+  },
+  {
+    "chainId": "cosmos:hippo-protocol-testnet-1/slip44:118",
+    "family": "cosmos",
+    "displayName": "Hippo Protocol Testnet",
+    "defaultKeyPath": "m/44'/118'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "havah:mainnet/slip44:858",
+    "family": "havah",
+    "displayName": "Havah",
+    "defaultKeyPath": "m/44'/858'/0'/0/0"
+  },
+  {
+    "chainId": "havah:testnet/slip44:858",
+    "family": "havah",
+    "displayName": "Havah Testnet",
+    "defaultKeyPath": "m/44'/858'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k",
+    "family": "algorand",
+    "displayName": "Algorand",
+    "defaultKeyPath": "m/44'/283'/0'/0/0"
+  },
+  {
+    "chainId": "algorand:SGO1GKSzyE7IEPItTxCByw9x8FmnrCDe",
+    "family": "algorand",
+    "displayName": "Algorand Testnet",
+    "defaultKeyPath": "m/44'/283'/0'/0/0",
+    "isTestnet": true
   },
   {
     "chainId": "polkadot:9eb76c5184c4ab8679d2d5d819fdf90b/slip44:810",
@@ -462,43 +906,73 @@
     "defaultKeyPath": "m/44'/810'/0'/0/0"
   },
   {
-    "chainId": "cosmos:cosmoshub-4/slip44:118",
-    "family": "cosmos",
-    "displayName": "Cosmos",
-    "defaultKeyPath": "m/44'/118'/0'/0/0"
+    "chainId": "polkadot:ddb89643205c8fe1c79afeb31f48d50f/slip44:810",
+    "family": "polkadot",
+    "displayName": "Shibuya",
+    "defaultKeyPath": "m/44'/810'/0'/0/0",
+    "isTestnet": true
   },
   {
-    "chainId": "tezos:NetXdQprcVkpaWU/slip44:1729",
-    "family": "tezos",
-    "displayName": "Tezos",
-    "defaultKeyPath": "m/44'/1729'/0'/0'"
+    "chainId": "xahau:mainnet/slip44:144",
+    "family": "xahau",
+    "displayName": "Xahau",
+    "defaultKeyPath": "m/44'/144'/0'/0/0"
   },
   {
-    "chainId": "vechain:b1ac3413d346d43539627e6be7ec1b4a/slip44:818",
-    "family": "vechain",
-    "displayName": "VeChain",
-    "defaultKeyPath": "m/44'/60'/0'/0/0"
+    "chainId": "xahau:testnet/slip44:21337",
+    "family": "xahau",
+    "displayName": "Xahau Testnet",
+    "defaultKeyPath": "m/44'/21337'/0'/0/0",
+    "isTestnet": true
   },
   {
-    "chainId": "cosmos:coreum-mainnet-1/slip44:990",
-    "family": "cosmos",
-    "displayName": "TX",
-    "defaultKeyPath": "m/44'/990'/0'/0/0"
+    "chainId": "polkadot:6673c7e2c2b7bde45a60c71ef70d9c7c/slip44:354",
+    "family": "polkadot",
+    "displayName": "Creditcoin",
+    "defaultKeyPath": "m/44'/354'/0'/0/0"
   },
   {
-    "chainId": "algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k/slip44:283",
-    "family": "algorand",
-    "displayName": "Algorand",
-    "defaultKeyPath": "m/44'/283'/0'/0/0"
+    "chainId": "polkadot:8a2e8af69a7892d2e60a77e3df4e0fa0/slip44:354",
+    "family": "polkadot",
+    "displayName": "Creditcoin Testnet",
+    "defaultKeyPath": "m/44'/354'/0'/0/0",
+    "isTestnet": true
   },
   {
-    "chainId": "fil:f/slip44:461",
+    "chainId": "fil:f",
     "family": "fil",
     "displayName": "Filecoin",
     "defaultKeyPath": "m/44'/461'/0'/0/0"
   },
   {
-    "chainId": "tron:0x2b6653dc/slip44:195",
+    "chainId": "fil:t",
+    "family": "fil",
+    "displayName": "Filecoin Calibration Testnet",
+    "defaultKeyPath": "m/44'/461'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "constellation:mainnet/slip44:1137",
+    "family": "constellation",
+    "displayName": "Constellation",
+    "defaultKeyPath": "m/44'/1137'/0'/0/0"
+  },
+  {
+    "chainId": "constellation:testnet/slip44:1137",
+    "family": "constellation",
+    "displayName": "Constellation Testnet",
+    "defaultKeyPath": "m/44'/1137'/0'/0/0",
+    "isTestnet": true
+  },
+  {
+    "chainId": "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+    "family": "solana",
+    "displayName": "Solana Devnet",
+    "defaultKeyPath": "m/44'/501'/0'",
+    "isTestnet": true
+  },
+  {
+    "chainId": "tron:mainnet",
     "family": "tron",
     "displayName": "Tron",
     "defaultKeyPath": "m/44'/195'/0'/0/0"

--- a/playground/presets.non-evm.json
+++ b/playground/presets.non-evm.json
@@ -4,9 +4,19 @@
     "label": "Bitcoin native-segwit transfer",
     "family": "bitcoin",
     "applicableChainIds": [
-      "bip122:000000000019d6689c085ae165831e93/slip44:0"
+      "bip122:000000000019d6689c085ae165831e93",
+      "bip122:000000000019d6689c085ae165831e93/slip44:145",
+      "bip122:000000000000000000651ef99cb9fcbe",
+      "bip122:00040fe8ec8471911baa1db1266ea15d/slip44:133",
+      "bip122:12a765e31ffd4059bada1e25190f6e98",
+      "bip122:00000000e9fba3b4a12d04c0a48d70d5/slip44:156",
+      "bip122:00000ffd590b1485b3caadc19b22e637/slip44:5",
+      "bip122:7497ea1b465eb39f1c8f507bc877078f/slip44:20",
+      "bip122:0000006b444bc2f2ffe627be9d9e7e7a/slip44:175",
+      "bip122:1a91e3dace36e2be3bf030a65679fe82",
+      "bip122:0007104ccda289427919efc39dc9e4d4/slip44:121"
     ],
-    "note": "P2WPKH native SegWit output. Amounts in satoshi. Edit inputs/outputs before send.",
+    "note": "P2WPKH native SegWit output. Amounts in satoshi. Edit inputs/outputs before send. Note: signTransaction -32601 expected — wm BitcoinAPIImpl not yet registered via WalletConnect. Layer 1 (getAddress) passes for all bitcoin-family chains.",
     "sourceUrl": "https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/test/transaction_builder.spec.js",
     "transaction": {
       "inputs": [
@@ -32,7 +42,7 @@
     "label": "Solana SOL transfer (plain JSON, data: object)",
     "family": "solana",
     "applicableChainIds": [
-      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501"
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
     ],
     "note": "Case 2a — plain JSON instructions. SystemProgram.Transfer 의 data 를 {instruction, lamports} 객체로 표현. SystemProgram.Transfer 에만 적용.",
     "sourceUrl": "https://solana-labs.github.io/solana-web3.js/classes/VersionedTransaction.html",
@@ -68,7 +78,7 @@
     "label": "Solana SOL transfer (base58 serialized — recommended)",
     "family": "solana",
     "applicableChainIds": [
-      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501"
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
     ],
     "note": "Case 1 — 가장 안정적. dApp 이 @solana/web3.js 로 Transaction 또는 VersionedTransaction 을 만들고 bs58.encode(tx.serialize({requireAllSignatures: false, verifySignatures: false})) 로 직렬화한 base58 문자열. 모든 instruction type 자동 지원.",
     "sourceUrl": "https://solana-labs.github.io/solana-web3.js/classes/Transaction.html#serialize",
@@ -79,7 +89,7 @@
     "label": "Solana SOL transfer (plain JSON, data: 0x hex)",
     "family": "solana",
     "applicableChainIds": [
-      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501"
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
     ],
     "note": "Case 2b — plain JSON 의 instruction.data 를 0x-prefixed hex string 으로 표현. SystemProgram.Transfer 의 raw bytes(12 bytes: 4-byte instruction tag + 8-byte little-endian lamports). Token / ATA / Memo 등 SystemProgram.Transfer 외의 모든 instruction 에 권장.",
     "sourceUrl": "https://solana.com/docs/core/programs",
@@ -104,7 +114,7 @@
     "label": "Solana SOL transfer (plain JSON, data: base58 string)",
     "family": "solana",
     "applicableChainIds": [
-      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501"
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
     ],
     "note": "Case 2c — plain JSON 의 instruction.data 를 prefix 없는 base58 문자열로 표현. @solana/web3.js bs58.encode 결과와 동일.",
     "sourceUrl": "https://github.com/cryptocoinjs/bs58",
@@ -129,7 +139,7 @@
     "label": "Solana SOL transfer (plain JSON, data: number array)",
     "family": "solana",
     "applicableChainIds": [
-      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501"
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
     ],
     "note": "Case 2d — plain JSON 의 instruction.data 를 number array (Uint8Array JSON-serializable form) 로 표현. dApp 측에서 Array.from(uint8Array) 결과 그대로 전달.",
     "sourceUrl": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array",
@@ -154,7 +164,7 @@
     "label": "Solana SOL transfer (wm-internal TransactionCommon)",
     "family": "solana",
     "applicableChainIds": [
-      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501"
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
     ],
     "note": "Case 3 — wm-internal TransactionCommon shape ({type, sender, recipient, amount}). 주로 webview/RN 흐름에서 사용 (RN의 wallet-models 가 미리 만든 객체를 그대로 전달). SDK 에서는 거의 안 씀 — 호환성 용 pass-through.",
     "sourceUrl": "https://github.com/IotrustGitHub/dcent-wallet-models/blob/main/src/common/types/transaction.ts",
@@ -172,10 +182,30 @@
     "label": "XRP Payment",
     "family": "xrp",
     "applicableChainIds": [
-      "xrpl:0/slip44:144"
+      "xrpl:0"
     ],
     "note": "XRP Ledger Payment transaction. Edit Destination/Amount before send.",
     "sourceUrl": "https://js.xrpl.org/interfaces/Payment.html",
+    "transaction": {
+      "TransactionType": "Payment",
+      "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+      "Destination": "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
+      "Amount": "1000000",
+      "Fee": "12",
+      "Sequence": 1,
+      "Flags": 0
+    }
+  },
+  {
+    "id": "xahau-payment",
+    "label": "Xahau XAH Payment",
+    "family": "xahau",
+    "applicableChainIds": [
+      "xahau:mainnet/slip44:144",
+      "xahau:testnet/slip44:21337"
+    ],
+    "note": "Xahau (XRPL sidechain) payment transaction. Uses same shape as XRP Ledger. Note: signTransaction -32601 expected — wm XahauAPIImpl not yet registered via WalletConnect. Layer 1 getAddress passes.",
+    "sourceUrl": "https://xahau.network/",
     "transaction": {
       "TransactionType": "Payment",
       "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
@@ -191,9 +221,9 @@
     "label": "Hedera HBAR transfer",
     "family": "hedera",
     "applicableChainIds": [
-      "hedera:mainnet/slip44:3030"
+      "hedera:mainnet"
     ],
-    "note": "Hedera TransferTransaction (CryptoTransfer). Edit accountId/amount before send.",
+    "note": "Hedera TransferTransaction (CryptoTransfer). Edit accountId/amount before send. Note: signTransaction -32601 expected — wm HederaAPIImpl not yet registered via WalletConnect. Layer 1 getAddress passes.",
     "sourceUrl": "https://docs.hedera.com/hedera/sdks-and-apis/sdks/cryptocurrency/transfer-cryptocurrency",
     "transaction": {
       "type": "CryptoTransfer",
@@ -217,9 +247,9 @@
     "label": "Stellar XLM payment",
     "family": "stellar",
     "applicableChainIds": [
-      "stellar:pubnet/slip44:148"
+      "stellar:pubnet"
     ],
-    "note": "Stellar Operation.payment for native XLM. Edit destination/amount before send.",
+    "note": "Stellar Operation.payment for native XLM. Edit destination/amount before send. Note: signTransaction -32601 expected — wm StellarAPIImpl not yet registered via WalletConnect. Layer 1 getAddress passes.",
     "sourceUrl": "https://stellar.github.io/js-stellar-sdk/Operation.payment.html",
     "transaction": {
       "type": "payment",
@@ -234,6 +264,157 @@
       },
       "fee": 100,
       "sequenceNumber": "0"
+    }
+  },
+  {
+    "id": "ada-transfer",
+    "label": "Cardano ADA transfer",
+    "family": "cardano",
+    "applicableChainIds": [
+      "cip34:1-764824073",
+      "cip34:0-2"
+    ],
+    "note": "Minimal ADA payment (TransactionCommon shape). Edit sender/recipient before send. Note: signTransaction -32601 expected — wm CardanoAPIImpl not yet registered via WalletConnect. Layer 1 getAddress passes.",
+    "sourceUrl": "https://cips.cardano.org/cips/cip30/",
+    "transaction": {
+      "type": "transfer",
+      "family": "cardano",
+      "sender": "addr1qy2z6xu9y07vkdnx26jq06l7jqnmhv8jh2v8sth47pltfq4vnv7mhjy7p2d3zf9p9xr2hq4wv3wgdl8p2c8kpv7lgfqcmfr7p",
+      "recipient": "addr1qy2z6xu9y07vkdnx26jq06l7jqnmhv8jh2v8sth47pltfq4vnv7mhjy7p2d3zf9p9xr2hq4wv3wgdl8p2c8kpv7lgfqcmfr7p",
+      "amount": "1000000"
+    }
+  },
+  {
+    "id": "near-transfer",
+    "label": "NEAR Protocol transfer",
+    "family": "near",
+    "applicableChainIds": [
+      "near:mainnet/slip44:397",
+      "near:testnet/slip44:397"
+    ],
+    "note": "NEAR Protocol transfer (UnionTransaction shape). blockHash and publicKey required. Note: signTransaction -32601 expected — wm NearAPIImpl not yet registered via WalletConnect. Layer 1 getAddress passes.",
+    "sourceUrl": "https://docs.near.org/concepts/basics/transactions/overview",
+    "transaction": {
+      "type": "transfer",
+      "family": "near",
+      "key": "NEAR",
+      "symbol": "NEAR",
+      "decimals": 24,
+      "optionParam": "",
+      "sender": "sender.near",
+      "recipient": "receiver.near",
+      "amount": "1000000000000000000000000",
+      "blockHash": "GJp9NRJGBnXqWJAKFxkzD8p9cJTiSNi1J3UWKVBbcfRw",
+      "publicKey": "ed25519:11111111111111111111111111111111"
+    }
+  },
+  {
+    "id": "dot-transfer",
+    "label": "Polkadot DOT transfer",
+    "family": "polkadot",
+    "applicableChainIds": [
+      "polkadot:91b171bb158e2d3848fa23a9f1c25182",
+      "polkadot:9eb76c5184c4ab8679d2d5d819fdf90b/slip44:810",
+      "polkadot:6673c7e2c2b7bde45a60c71ef70d9c7c/slip44:354"
+    ],
+    "note": "Polkadot balances.transfer extrinsic (TransactionCommon shape). Edit sender/recipient before send.",
+    "sourceUrl": "https://polkadot.js.org/docs/substrate/extrinsics/#transferdest-multiaddress-value-compact",
+    "transaction": {
+      "type": "transfer",
+      "family": "polkadot",
+      "sender": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+      "recipient": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+      "amount": "1000000000"
+    }
+  },
+  {
+    "id": "xtz-transfer",
+    "label": "Tezos XTZ transfer",
+    "family": "tezos",
+    "applicableChainIds": [
+      "tezos:NetXdQprcVkpaWU",
+      "tezos:NetXnHfVqm9iesp"
+    ],
+    "note": "Tezos transaction op (UnionTransaction shape). key/symbol/decimals required by wm TezosAPIImpl.",
+    "sourceUrl": "https://tezos.gitlab.io/shell/rpc.html",
+    "transaction": {
+      "type": "transfer",
+      "family": "tezos",
+      "key": "XTZ",
+      "symbol": "XTZ",
+      "decimals": 6,
+      "optionParam": "",
+      "hexNonce": "0000000000000000",
+      "revealed": false,
+      "sender": "tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb",
+      "recipient": "tz1aSkwEot3L2kmUanuneWHL7zayzaovkujr",
+      "amount": "1000000"
+    }
+  },
+  {
+    "id": "atom-transfer",
+    "label": "Cosmos ATOM transfer (MsgSend)",
+    "family": "cosmos",
+    "applicableChainIds": [
+      "cosmos:cosmoshub-4",
+      "cosmos:coreum-mainnet-1",
+      "cosmos:hippo-protocol-1/slip44:118"
+    ],
+    "note": "Cosmos MsgSend transaction (UnionTransaction shape). accountNumber/sequence/pubKey/chainId required. Note: signTransaction may return -32601 for families where wm CosmosAPIImpl dispatch is not yet registered.",
+    "sourceUrl": "https://docs.cosmos.network/api",
+    "transaction": {
+      "type": "transfer",
+      "family": "cosmos",
+      "key": "ATOM",
+      "symbol": "ATOM",
+      "decimals": 6,
+      "optionParam": "",
+      "sender": "cosmos1qnk2n4nlkpw9xfqntladh74er2xa62wm7p7p5z",
+      "recipient": "cosmos1ht3qs0a8fgg04y2w8u7k9z7vefkf38qnmqjvmq",
+      "amount": "1000000",
+      "accountNumber": "12345",
+      "sequence": "0",
+      "pubKey": "A0000000000000000000000000000000000000000000",
+      "pubKeyType": "/cosmos.crypto.secp256k1.PubKey",
+      "chainId": "cosmoshub-4",
+      "signature": "",
+      "txRaw": "",
+      "feeRate": { "low": "0.01", "average": "0.025", "high": "0.04" }
+    }
+  },
+  {
+    "id": "vet-transfer",
+    "label": "VeChain VET transfer",
+    "family": "vechain",
+    "applicableChainIds": [
+      "vechain:b1ac3413d346d43539627e6be7ec1b4a"
+    ],
+    "note": "VeChain clauses transaction (TransactionCommon shape). Edit sender/recipient before send.",
+    "sourceUrl": "https://docs.vechain.org/how-to-run-a-node/custom-network",
+    "transaction": {
+      "type": "transfer",
+      "family": "vechain",
+      "sender": "0x7567D83b7b8d80ADdCb281A71d54Fc7B3364ffed",
+      "recipient": "0xd3ae78222BEADB038203bE21eD5ce7C9B1BfF602",
+      "amount": "1000000000000000000"
+    }
+  },
+  {
+    "id": "dag-transfer",
+    "label": "Constellation DAG transfer",
+    "family": "constellation",
+    "applicableChainIds": [
+      "constellation:mainnet/slip44:1137",
+      "constellation:testnet/slip44:1137"
+    ],
+    "note": "Constellation DAG transfer (TransactionCommon shape). Note: signTransaction -32601 expected — wm ConstellationAPIImpl not yet registered via WalletConnect. Layer 1 getAddress passes.",
+    "sourceUrl": "https://docs.constellationnetwork.io/",
+    "transaction": {
+      "type": "transfer",
+      "family": "constellation",
+      "sender": "DAG0000000000000000000000000000000000000000",
+      "recipient": "DAG0000000000000000000000000000000000000001",
+      "amount": "100000000"
     }
   }
 ]

--- a/scripts/extract-chains.js
+++ b/scripts/extract-chains.js
@@ -3,24 +3,26 @@
  * extract-chains.js — 모든 family chain metadata 추출 스크립트
  *
  * refer-repos/dcent-wallet-models/src/common/assets/coins/families/ 또는
- * npm 패키지에서 mainnet 체인 목록을 추출하여 playground/chains.json으로 저장한다.
+ * npm 패키지에서 mainnet + testnet 체인 목록을 추출하여 playground/chains.json으로 저장한다.
  *
  * 출력 shape (ChainEntry):
- *   chainId:        string  — CAIP-19 namespace only, e.g. "eip155:1", "bip122:000…", "solana:5eykt…"
- *   family:         string  — deriveFamily() 출력 (14개 known + 알 수 없는 namespace fallback)
- *   displayName:    string  — human readable name
- *   defaultKeyPath: string  — default BIP32 derivation path
+ *   chainId:        string   — CAIP-19 or chainIdentifier.value, e.g. "eip155:1", "bip122:000…", "cip34:1-764824073"
+ *   family:         string   — deriveFamily() 출력 (known map + 알 수 없는 namespace fallback)
+ *   displayName:    string   — human readable name
+ *   defaultKeyPath: string   — default BIP32 derivation path
+ *   isTestnet?:     boolean  — true if testnet entry (omitted for mainnet)
  *
  * 실행: node scripts/extract-chains.js
  * 또는 yarn extract-chains (package.json scripts에 등록)
  *
  * 출력 경로: playground/chains.json (통합 파일 — m06-01-03)
  *
- * deriveFamily() — CAIP-19 namespace → family name (m06-01-04 generic화).
- * known map (14 namespace, R1=a 결정):
+ * deriveFamily() — CAIP-19 / chainIdentifier namespace → family name (m09-04-10 확장).
+ * known map (기존 14 + 신규 5 namespace):
  *   eip155 → ethereum, bip122 → bitcoin, solana → solana, xrpl → xrp,
  *   hedera → hedera, stellar → stellar, tron → tron (caip19 미지정 → TRON_STATIC fallback),
  *   algorand / conflux / cosmos / fil / polkadot / stacks / tezos / vechain → 동일 family명.
+ *   [신규] cip34 → cardano, near → near, havah → havah, xahau → xahau, constellation → constellation.
  * 알 수 없는 namespace는 namespace 자체를 family명으로 사용 (fallback).
  */
 
@@ -31,31 +33,38 @@ const path = require('path')
 
 const OUTPUT_PATH = path.resolve(__dirname, '..', 'playground', 'chains.json')
 
-// ── deriveFamily: CAIP-19 namespace → family name ─────────────────────────────
+// ── deriveFamily: CAIP-19 / chainIdentifier namespace → family name ───────────
 // wallet-models cryptoCurrencies registry의 모든 namespace를 family로 매핑.
 // 알 수 없는 namespace는 namespace 자체를 family명으로 사용 (fallback).
 // R1=a 결정: wallet-models 인벤토리 기준 14개 namespace 매핑.
+// m09-04-10: 신규 5개 namespace 추가 (cip34 / near / havah / xahau / constellation).
 const FAMILY_KNOWN_MAP = {
   // 기존 7 family (Child 1-3 covered)
-  eip155: 'ethereum',
-  bip122: 'bitcoin',
-  solana: 'solana',
-  xrpl:   'xrp',
-  hedera: 'hedera',
-  stellar:'stellar',
-  tron:   'tron',
+  eip155:        'ethereum',
+  bip122:        'bitcoin',
+  solana:        'solana',
+  xrpl:          'xrp',
+  hedera:        'hedera',
+  stellar:       'stellar',
+  tron:          'tron',
   // m06-01-04 신규 8 family
-  algorand: 'algorand',
-  conflux:  'conflux',
-  cosmos:   'cosmos',
-  fil:      'fil',
-  polkadot: 'polkadot',
-  stacks:   'stacks',
-  tezos:    'tezos',
-  vechain:  'vechain',
+  algorand:      'algorand',
+  conflux:       'conflux',
+  cosmos:        'cosmos',
+  fil:           'fil',
+  polkadot:      'polkadot',
+  stacks:        'stacks',
+  tezos:         'tezos',
+  vechain:       'vechain',
+  // m09-04-10 신규 5 family (chainIdentifier namespace)
+  cip34:         'cardano',
+  near:          'near',
+  havah:         'havah',
+  xahau:         'xahau',
+  constellation: 'constellation',
 }
 
-// CAIP-19 namespace로부터 family 도출.
+// CAIP-19 / chainIdentifier namespace로부터 family 도출.
 // chainId가 빈 문자열 / non-string / `:` 미포함이면 null 반환 (caller가 skip).
 // known map에 있으면 그 값, 없으면 namespace 자체를 family명으로 사용 (fallback).
 function deriveFamily (chainId) {
@@ -63,6 +72,41 @@ function deriveFamily (chainId) {
   const ns = chainId.split(':')[0]
   if (!ns) return null
   return FAMILY_KNOWN_MAP[ns] || ns
+}
+
+// ── defaultKeyPath 결정 ────────────────────────────────────────────────────────
+// family + bip44CoinType + derivationFormat 으로 derivation path 생성.
+// m09-04-10: cardano (CIP-1852) / near / havah / xahau / constellation 신규 추가.
+function buildDefaultKeyPath (family, bip44CoinType, derivationFormat) {
+  if (derivationFormat) {
+    // <accountIdx> → 0 으로 치환해 구체 path 생성
+    return derivationFormat.replace(/<accountIdx>/g, '0')
+  }
+  if (bip44CoinType === null || bip44CoinType === undefined) return null
+
+  switch (family) {
+    case 'bitcoin':
+      // Native SegWit (BIP-84): m/84'/coinType'/0'/0/0
+      // objective §3 비스코프: native segwit 단일
+      return `m/84'/${bip44CoinType}'/0'/0/0`
+    case 'solana':
+      return `m/44'/${bip44CoinType}'/0'`
+    case 'stellar':
+      return `m/44'/${bip44CoinType}'/0'`
+    case 'cardano':
+      // CIP-1852: m/1852'/1815'/0'/0/0 (role 0 = external chain)
+      // bip44CoinType=1815 → path reflects CIP-1852 standard
+      return `m/1852'/${bip44CoinType}'/0'/0/0`
+    case 'near':
+      return `m/44'/${bip44CoinType}'/0'`
+    case 'tezos':
+      return `m/44'/${bip44CoinType}'/0'/0'`
+    case 'constellation':
+      // bip44CoinType=1137 (SLIP-0044 DAG)
+      return `m/44'/${bip44CoinType}'/0'/0/0`
+    default:
+      return `m/44'/${bip44CoinType}'/0'/0/0`
+  }
 }
 
 // ── 소스 결정: npm 패키지 우선, 없으면 refer-repos TypeScript 파싱 ──────────────
@@ -94,7 +138,8 @@ function findFamilySource (fileName) {
 }
 
 // ── TypeScript 소스를 regex 파싱하여 family별 체인 추출 ───────────────────────
-// caip19 line을 pivot으로, entry block 경계 안에서만 필드를 스캔한다.
+// caip19 또는 chainIdentifier line을 pivot으로, entry block 경계 안에서 필드를 스캔한다.
+// m09-04-10: chainIdentifier pivot 추가 + testnet inclusion + isTestnet 필드 출력.
 function parseFamilyTs (tsPath) {
   const src = fs.readFileSync(tsPath, 'utf8')
   const chains = []
@@ -103,14 +148,47 @@ function parseFamilyTs (tsPath) {
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]
+
+    // ── pivot 1: caip19 단일 라인 ──
+    let chainId = null
     const caip19Match = line.match(/caip19:\s*['"]([^'"]+)['"]/)
-    if (!caip19Match) continue
+    if (caip19Match) {
+      const caip19Full = caip19Match[1]
+      // namespace:chainRef/slip44:N → namespace:chainRef (caip19는 suffix 제거)
+      chainId = caip19Full.replace(/\/slip44:\d+$/, '')
+    }
 
-    const caip19Full = caip19Match[1]
-    // namespace:chainRef/slip44:N → namespace:chainRef
-    const chainId = caip19Full.replace(/\/slip44:\d+$/, '')
+    // ── pivot 2: chainIdentifier 단일 라인 (value 포함) ──
+    // single-line: chainIdentifier: { type: 'xxx', value: 'yyy' },
+    if (!chainId) {
+      const ciSingleMatch = line.match(/chainIdentifier:\s*\{\s*type:\s*['"][^'"]+['"]\s*,\s*value:\s*['"]([^'"]+)['"]\s*\}/)
+      if (ciSingleMatch) {
+        // chainIdentifier.value는 full string 그대로 사용 (wm _buildChainIdLookupMap이 full string key 사용)
+        chainId = ciSingleMatch[1]
+      }
+    }
 
-    // family 판별 (m06-01-04: deriveFamily generic화)
+    // ── pivot 3: chainIdentifier multi-line 블록 시작 ──
+    // multi-line: chainIdentifier: {
+    //   type: 'xxx',
+    //   value: 'yyy',
+    // },
+    if (!chainId && /chainIdentifier:\s*\{/.test(line)) {
+      // scan forward up to 5 lines for value:
+      for (let k = i + 1; k < Math.min(lines.length, i + 6); k++) {
+        const vMatch = lines[k].match(/value:\s*['"]([^'"]+)['"]/)
+        if (vMatch) {
+          chainId = vMatch[1]
+          break
+        }
+        // stop at closing brace
+        if (/^\s*\}/.test(lines[k])) break
+      }
+    }
+
+    if (!chainId) continue
+
+    // family 판별
     const family = deriveFamily(chainId)
     if (!family) continue
 
@@ -122,7 +200,7 @@ function parseFamilyTs (tsPath) {
     // entry block 시작을 뒤로 탐색 (indent 2칸 + id key 패턴)
     let blockStart = i
     for (let j = i - 1; j >= Math.max(0, i - 40); j--) {
-      if (/^  ['"]?[\w:.-]+['"]?\s*:\s*\{/.test(lines[j])) {
+      if (/^[ ]{2}['"]?[\w:.-]+['"]?\s*:\s*\{/.test(lines[j])) {
         blockStart = j
         break
       }
@@ -132,7 +210,7 @@ function parseFamilyTs (tsPath) {
     // 탐색 범위를 150줄로 확대 — BITCOIN entry는 90줄 이상 (feeRateRule 등 nested 구조)
     let blockEnd = i
     for (let j = i + 1; j < Math.min(lines.length, i + 150); j++) {
-      if (/^  \},?$/.test(lines[j])) {
+      if (/^[ ]{2}\},?$/.test(lines[j])) {
         blockEnd = j
         break
       }
@@ -147,7 +225,7 @@ function parseFamilyTs (tsPath) {
       const l = lines[j]
       if (/isTestnet:\s*true/.test(l)) isTestnet = true
       // name 필드: indent 4칸 이상
-      const nameMatch = l.match(/^    name:\s*['"]([^'"]+)['"]/)
+      const nameMatch = l.match(/^[ ]{4}name:\s*['"]([^'"]+)['"]/)
       if (nameMatch && displayName === null) displayName = nameMatch[1]
       const bip44Match = l.match(/bip44CoinType:\s*(\d+)/)
       if (bip44Match && bip44CoinType === null) bip44CoinType = parseInt(bip44Match[1], 10)
@@ -156,62 +234,48 @@ function parseFamilyTs (tsPath) {
       if (derivFmtMatch && derivationFormat === null) derivationFormat = derivFmtMatch[1]
     }
 
-    if (isTestnet) continue
+    // m09-04-10: testnet も포함 (isTestnet skip 제거 — isTestnet 필드를 출력에 보존)
     if (!displayName) continue
     if (seen.has(chainId)) continue
     seen.add(chainId)
 
-    // defaultKeyPath 결정
-    let defaultKeyPath
-    if (derivationFormat) {
-      // <accountIdx> → 0 으로 치환해 구체 path 생성
-      defaultKeyPath = derivationFormat.replace(/<accountIdx>/g, '0')
-    } else if (bip44CoinType !== null) {
-      if (family === 'ethereum') {
-        defaultKeyPath = `m/44'/${bip44CoinType}'/0'/0/0`
-      } else if (family === 'bitcoin') {
-        // Native SegWit (BIP-84): m/84'/0'/0'/0/0 for mainnet, legacy m/44'/0'/0'/0/0
-        // objective §3 비스코프: native segwit 단일 — m/84'/0'/0'/0/0
-        defaultKeyPath = `m/84'/${bip44CoinType}'/0'/0/0`
-      } else if (family === 'solana') {
-        defaultKeyPath = `m/44'/${bip44CoinType}'/0'`
-      } else if (family === 'xrp') {
-        defaultKeyPath = `m/44'/${bip44CoinType}'/0'/0/0`
-      } else if (family === 'hedera') {
-        defaultKeyPath = `m/44'/${bip44CoinType}'/0'/0/0`
-      } else if (family === 'stellar') {
-        defaultKeyPath = `m/44'/${bip44CoinType}'/0'`
-      } else {
-        defaultKeyPath = `m/44'/${bip44CoinType}'/0'/0/0`
-      }
-    } else {
-      continue // bip44CoinType 없으면 skip
-    }
+    const defaultKeyPath = buildDefaultKeyPath(family, bip44CoinType, derivationFormat)
+    if (!defaultKeyPath) continue
 
-    chains.push({ chainId, family, displayName, defaultKeyPath })
+    const entry = { chainId, family, displayName, defaultKeyPath }
+    if (isTestnet) entry.isTestnet = true
+    chains.push(entry)
   }
 
   return chains
 }
 
 // ── JS 모듈에서 추출 (npm 패키지 빌드 결과) ────────────────────────────────────
+// m09-04-10: chainIdentifier 지원 추가 + testnet 포함 + isTestnet 필드 출력.
 function parseFamilyJs (jsPath) {
-  // eslint-disable-next-line import/no-dynamic-require
-  const mod = require(jsPath)
+  const mod = require(jsPath) // eslint-disable-line global-require
   // 파일마다 export 이름이 다름 — 여러 후보 시도
-  const currencies = mod.ethereumFamilyCurrencies
-    || mod.bitcoinFamilyCurrencies
-    || mod.otherNetworksCurrencies
-    || mod.default
-    || {}
+  const currencies =
+    mod.ethereumFamilyCurrencies ||
+    mod.bitcoinFamilyCurrencies ||
+    mod.otherNetworksCurrencies ||
+    mod.default ||
+    {}
   const chains = []
   const seen = new Set()
 
   for (const [, entry] of Object.entries(currencies)) {
-    if (!entry || !entry.caip19) continue
-    if (entry.isTestnet) continue
+    if (!entry) continue
 
-    const chainId = entry.caip19.replace(/\/slip44:\d+$/, '')
+    let chainId = null
+    if (entry.caip19) {
+      // caip19: full string, strip /slip44:N suffix
+      chainId = entry.caip19.replace(/\/slip44:\d+$/, '')
+    } else if (entry.chainIdentifier && entry.chainIdentifier.value) {
+      // chainIdentifier.value: full string (wm lookup key)
+      chainId = entry.chainIdentifier.value
+    }
+    if (!chainId) continue
 
     // family 판별 (m06-01-04: deriveFamily generic화)
     const family = deriveFamily(chainId)
@@ -224,23 +288,13 @@ function parseFamilyJs (jsPath) {
     if (seen.has(chainId)) continue
     seen.add(chainId)
 
-    const bip44 = entry.bip44CoinType || 0
-    let defaultKeyPath
-    if (entry.derivationFormat) {
-      defaultKeyPath = entry.derivationFormat.replace(/<accountIdx>/g, '0')
-    } else if (family === 'ethereum') {
-      defaultKeyPath = `m/44'/${bip44}'/0'/0/0`
-    } else if (family === 'bitcoin') {
-      defaultKeyPath = `m/84'/${bip44}'/0'/0/0`
-    } else if (family === 'solana') {
-      defaultKeyPath = `m/44'/${bip44}'/0'`
-    } else if (family === 'stellar') {
-      defaultKeyPath = `m/44'/${bip44}'/0'`
-    } else {
-      defaultKeyPath = `m/44'/${bip44}'/0'/0/0`
-    }
+    const isTestnet = !!entry.isTestnet
+    const defaultKeyPath = buildDefaultKeyPath(family, entry.bip44CoinType || null, entry.derivationFormat || null)
+    if (!defaultKeyPath) continue
 
-    chains.push({ chainId, family, displayName: entry.name, defaultKeyPath })
+    const chainEntry = { chainId, family, displayName: entry.name, defaultKeyPath }
+    if (isTestnet) chainEntry.isTestnet = true
+    chains.push(chainEntry)
   }
   return chains
 }
@@ -249,14 +303,20 @@ function parseFamilyJs (jsPath) {
 // TVM namespace는 아직 ChainAgnostic에 정의되지 않았으므로 static entry 사용
 // ref: wallet-models other-networks.ts TRON entry comment
 // ref: https://developers.tron.network/docs/dapp-integration-guide
+// m09-04-10: TRX-TESTNET chainIdentifier value를 함께 static 등록
 const TRON_STATIC = [
   {
     chainId: 'tron:mainnet',
     family: 'tron',
     displayName: 'Tron',
     defaultKeyPath: "m/44'/195'/0'/0/0",
-    // Source: SLIP-0044 coin type 195 for TRON
-    // https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+  },
+  {
+    chainId: 'tron:0x941250dc/slip44:195',
+    family: 'tron',
+    displayName: 'Tron Testnet (Nile)',
+    defaultKeyPath: "m/44'/195'/0'/0/0",
+    isTestnet: true,
   },
 ]
 
@@ -288,18 +348,18 @@ function main () {
   }
 
   // TRON static fallback (caip19 없는 family)
-  // 중복 방지: allChains에 tron:mainnet이 이미 있으면 skip
+  // 중복 방지: allChains에 동일 chainId가 이미 있으면 skip
   const existingChainIds = new Set(allChains.map(function (c) { return c.chainId }))
   for (const entry of TRON_STATIC) {
     if (!existingChainIds.has(entry.chainId)) {
-      // entry에서 source comment 제거 후 push
-      allChains.push({ chainId: entry.chainId, family: entry.family, displayName: entry.displayName, defaultKeyPath: entry.defaultKeyPath })
+      const staticEntry = { chainId: entry.chainId, family: entry.family, displayName: entry.displayName, defaultKeyPath: entry.defaultKeyPath }
+      if (entry.isTestnet) staticEntry.isTestnet = true
+      allChains.push(staticEntry)
     }
   }
 
   // 각 family 최소 1개 이상 있는지 확인 (Child 1-3 covered family 기준)
-  // m06-01-04 신규 8 family는 wallet-models 인벤토리에 entry가 없을 수 있으므로 missing 검사 대상에서 제외.
-  // 신규 family 누락은 known map 기반 fallback으로 자동 노출되므로 별도 검증 불필요.
+  // m06-01-04 신규 family는 wallet-models 인벤토리에 entry가 없을 수 있으므로 missing 검사 대상에서 제외.
   const COVERED_FAMILIES = ['ethereum', 'bitcoin', 'solana', 'xrp', 'hedera', 'stellar', 'tron']
   const missing = COVERED_FAMILIES.filter(function (fam) {
     return !allChains.some(function (c) { return c.family === fam })
@@ -321,10 +381,12 @@ function main () {
 
   // family별 통계 출력
   const stats = {}
+  const testnetCount = allChains.filter(function (c) { return c.isTestnet }).length
   for (const c of allChains) {
     stats[c.family] = (stats[c.family] || 0) + 1
   }
   console.log('extract-chains: wrote ' + allChains.length + ' chains to ' + OUTPUT_PATH)
+  console.log('  mainnet: ' + (allChains.length - testnetCount) + ', testnet: ' + testnetCount)
   for (const [fam, count] of Object.entries(stats)) {
     console.log('  ' + fam + ': ' + count)
   }

--- a/tests/unit/v2/extract-chains.test.ts
+++ b/tests/unit/v2/extract-chains.test.ts
@@ -1,0 +1,203 @@
+/**
+ * extract-chains.test.ts — extract-chains.js 단위 테스트
+ *
+ * T-U-EXTRACT-01~09 (9개)
+ *
+ * scripts/extract-chains.js의 출력인 playground/chains.json을 검증하여
+ * chainIdentifier pivot / testnet inclusion / FAMILY_KNOWN_MAP 확장을 커버한다.
+ *
+ * m09-04-10: chainIdentifier pivot + testnet inclusion + FAMILY_KNOWN_MAP 확장
+ *
+ * 전략: 각 T-U-EXTRACT-01~07은 chains.json의 실제 내용으로 검증한다.
+ *       (extract-chains.js를 이미 실행하여 chains.json을 재생성한 상태)
+ *       T-U-EXTRACT-08/09는 전체 통계 sentinel을 검증한다.
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+
+const CONNECTOR_ROOT = path.resolve(__dirname, '../../..')
+const CHAINS_JSON_PATH = path.join(CONNECTOR_ROOT, 'playground', 'chains.json')
+
+// Load chains once for all tests
+const chains: any[] = JSON.parse(fs.readFileSync(CHAINS_JSON_PATH, 'utf8'))
+
+// ── T-U-EXTRACT-01: caip19-only entry → correct chainId and family ─────────────
+test('T-U-EXTRACT-01: caip19-only entry → chainId stripped of /slip44 suffix, family correct', () => {
+  // Ethereum mainnet: caip19 = 'eip155:1/slip44:60' → chainId = 'eip155:1'
+  const eth = chains.find((c: any) => c.chainId === 'eip155:1')
+  expect(eth).toBeDefined()
+  expect(eth.family).toBe('ethereum')
+  expect(eth.displayName).toBeTruthy()
+  // caip19 suffix stripped — no /slip44 in chainId
+  expect(eth.chainId).not.toContain('/slip44')
+  // XRPL mainnet (non-EVM caip19): xrpl:0/slip44:144 → xrpl:0
+  const xrp = chains.find((c: any) => c.chainId === 'xrpl:0')
+  expect(xrp).toBeDefined()
+  expect(xrp.family).toBe('xrp')
+})
+
+// ── T-U-EXTRACT-02: chainIdentifier (type=dcent) single-line ──────────────────
+test('T-U-EXTRACT-02: chainIdentifier dcent single-line → chainId = value (full string), family from namespace', () => {
+  // NEAR: chainIdentifier = { type: 'dcent', value: 'near:mainnet/slip44:397' }
+  const near = chains.find((c: any) => c.chainId === 'near:mainnet/slip44:397')
+  expect(near).toBeDefined()
+  expect(near.family).toBe('near')
+  expect(near.displayName).toBeTruthy()
+  expect(near.isTestnet).toBeUndefined()
+
+  // Verify multi-line block also works — Astar has multi-line chainIdentifier
+  const astar = chains.find((c: any) => c.chainId === 'polkadot:9eb76c5184c4ab8679d2d5d819fdf90b/slip44:810')
+  expect(astar).toBeDefined()
+  expect(astar.family).toBe('polkadot')
+  expect(astar.displayName).toBeTruthy()
+})
+
+// ── T-U-EXTRACT-02b: multi-line chainIdentifier block ─────────────────────────
+test('T-U-EXTRACT-02b: chainIdentifier multi-line block → chainId = value, correct family', () => {
+  // eCash has multi-line chainIdentifier in bitcoin-family.ts
+  const ecash = chains.find((c: any) => c.chainId === 'bip122:000000000019d6689c085ae165831e93/slip44:145')
+  expect(ecash).toBeDefined()
+  expect(ecash.family).toBe('bitcoin')
+  expect(ecash.displayName).toBe('eCash')
+
+  // Xahau also has single-line chainIdentifier
+  const xahau = chains.find((c: any) => c.chainId === 'xahau:mainnet/slip44:144')
+  expect(xahau).toBeDefined()
+  expect(xahau.family).toBe('xahau')
+})
+
+// ── T-U-EXTRACT-03: chainIdentifier (type=cip34) → family = cardano ───────────
+test('T-U-EXTRACT-03: chainIdentifier cip34 → family = cardano, CIP-1852 derivation path', () => {
+  // Cardano mainnet: chainIdentifier = { type: 'cip34', value: 'cip34:1-764824073' }
+  const ada = chains.find((c: any) => c.chainId === 'cip34:1-764824073')
+  expect(ada).toBeDefined()
+  expect(ada.family).toBe('cardano')
+  expect(ada.displayName).toBe('Cardano')
+  // CIP-1852 path: m/1852'/1815'/0'/0/0
+  expect(ada.defaultKeyPath).toBe("m/1852'/1815'/0'/0/0")
+  expect(ada.isTestnet).toBeUndefined()
+
+  // Cardano testnet: chainIdentifier = { type: 'cip34', value: 'cip34:0-2' }
+  const adaTest = chains.find((c: any) => c.chainId === 'cip34:0-2')
+  expect(adaTest).toBeDefined()
+  expect(adaTest.family).toBe('cardano')
+  expect(adaTest.isTestnet).toBe(true)
+})
+
+// ── T-U-EXTRACT-04: entry without caip19 AND without chainIdentifier → skipped ─
+test('T-U-EXTRACT-04: entry without caip19 or chainIdentifier should not appear in output', () => {
+  // TRON in other-networks.ts has no caip19 and no chainIdentifier
+  // It should only appear via TRON_STATIC fallback as 'tron:mainnet'
+  const tronEntries = chains.filter((c: any) => c.family === 'tron')
+  // TRON_STATIC provides tron:mainnet; TRX-TESTNET also via static
+  expect(tronEntries.length).toBeGreaterThanOrEqual(1)
+  // No entry should have undefined/empty chainId
+  const badEntries = chains.filter((c: any) => !c.chainId || c.chainId.trim() === '')
+  expect(badEntries.length).toBe(0)
+})
+
+// ── T-U-EXTRACT-05: testnet entry included, isTestnet field preserved ──────────
+test('T-U-EXTRACT-05: testnet entries are included with isTestnet=true field', () => {
+  // NEAR testnet should be present
+  const nearTest = chains.find((c: any) => c.chainId === 'near:testnet/slip44:397')
+  expect(nearTest).toBeDefined()
+  expect(nearTest.isTestnet).toBe(true)
+
+  // Constellation testnet should be present
+  const dagTest = chains.find((c: any) => c.chainId === 'constellation:testnet/slip44:1137')
+  expect(dagTest).toBeDefined()
+  expect(dagTest.isTestnet).toBe(true)
+
+  // Mainnet entries should not have isTestnet field
+  const ethMain = chains.find((c: any) => c.chainId === 'eip155:1')
+  expect(ethMain).toBeDefined()
+  expect(ethMain.isTestnet).toBeUndefined()
+})
+
+// ── T-U-EXTRACT-06: bitcoin variant with same chainId → deduped ───────────────
+test('T-U-EXTRACT-06: duplicate chainId (bitcoin variant) → only first entry in output', () => {
+  // DGB-SEGWIT shares chainId 'bip122:7497ea1b465eb39f1c8f507bc877078f/slip44:20' with DigiByte
+  // Only DigiByte (first) should appear
+  const dgbEntries = chains.filter((c: any) =>
+    c.chainId === 'bip122:7497ea1b465eb39f1c8f507bc877078f/slip44:20'
+  )
+  expect(dgbEntries.length).toBe(1)
+  // First entry wins — should be 'DigiByte' not 'DigiByte Segwit'
+  expect(dgbEntries[0].displayName).toBe('DigiByte')
+})
+
+// ── T-U-EXTRACT-07: new namespace → correct family mapping ────────────────────
+test('T-U-EXTRACT-07: all 5 new namespaces map to correct families', () => {
+  const expectedFamilyMap: Record<string, string> = {
+    'cip34:1-764824073':                      'cardano',
+    'near:mainnet/slip44:397':                'near',
+    'havah:mainnet/slip44:858':               'havah',
+    'xahau:mainnet/slip44:144':               'xahau',
+    'constellation:mainnet/slip44:1137':      'constellation',
+  }
+  for (const [chainId, expectedFamily] of Object.entries(expectedFamilyMap)) {
+    const entry = chains.find((c: any) => c.chainId === chainId)
+    expect(entry).toBeDefined()
+    expect(entry.family).toBe(expectedFamily)
+  }
+})
+
+// ── T-U-EXTRACT-08: chains.json total count sentinel ─────────────────────────
+test('T-U-EXTRACT-08: chains.json total entry count >= 150 (regression sentinel)', () => {
+  // m09-04-10: actual count is 154 (wm registry as of 2026-05-28)
+  // Sentinel set to 150 to allow for minor registry variations
+  expect(chains.length).toBeGreaterThanOrEqual(150)
+
+  // Verify all entries have required fields (T-I-SNAPSHOT-02)
+  for (const c of chains) {
+    expect(c.chainId).toBeTruthy()
+    expect(c.family).toBeTruthy()
+    expect(c.displayName).toBeTruthy()
+    expect(c.defaultKeyPath).toBeTruthy()
+  }
+
+  // Verify unique chainIds (T-I-SNAPSHOT-03)
+  const ids = new Set(chains.map((c: any) => c.chainId))
+  expect(ids.size).toBe(chains.length)
+
+  // All 5 new families present
+  const families = new Set(chains.map((c: any) => c.family))
+  expect(families.has('cardano')).toBe(true)
+  expect(families.has('near')).toBe(true)
+  expect(families.has('havah')).toBe(true)
+  expect(families.has('xahau')).toBe(true)
+  expect(families.has('constellation')).toBe(true)
+
+  // Bitcoin family expanded from 4 to >= 12
+  const btcEntries = chains.filter((c: any) => c.family === 'bitcoin')
+  expect(btcEntries.length).toBeGreaterThanOrEqual(12)
+})
+
+// ── T-U-EXTRACT-09: testnet inclusion (sibling parity parseFamilyTs) ──────────
+test('T-U-EXTRACT-09: testnet entries >= 30 (parseFamilyTs testnet inclusion working)', () => {
+  const testnets = chains.filter((c: any) => c.isTestnet === true)
+  // After m09-04-10 testnet inclusion, expect >= 30 testnet entries
+  expect(testnets.length).toBeGreaterThanOrEqual(30)
+
+  // All testnets must have valid shape
+  for (const c of testnets) {
+    expect(c.isTestnet).toBe(true)
+    expect(c.chainId).toBeTruthy()
+    expect(c.family).toBeTruthy()
+    expect(c.displayName).toBeTruthy()
+    expect(c.defaultKeyPath).toBeTruthy()
+  }
+
+  // New family testnets present
+  const cardanoTest = chains.find((c: any) => c.family === 'cardano' && c.isTestnet)
+  expect(cardanoTest).toBeDefined()
+  const nearTest = chains.find((c: any) => c.family === 'near' && c.isTestnet)
+  expect(nearTest).toBeDefined()
+  const havahTest = chains.find((c: any) => c.family === 'havah' && c.isTestnet)
+  expect(havahTest).toBeDefined()
+  const xahauTest = chains.find((c: any) => c.family === 'xahau' && c.isTestnet)
+  expect(xahauTest).toBeDefined()
+  const dagTest = chains.find((c: any) => c.family === 'constellation' && c.isTestnet)
+  expect(dagTest).toBeDefined()
+})


### PR DESCRIPTION
## 개요

m09-04-10: `refer-repos/dcent-wallet-models`의 모든 currency(mainnet + testnet, caip19 + chainIdentifier)를 playground에서 선택 가능하게 chains.json + presets.non-evm.json 커버리지를 확장한다.

**트리거**: m02-05-07/08 (wm bitcoin-family + other-networks chainIdentifier 추가)의 web-sdk ↔ web-connector 통합 검증.

Jira: [DC-2391](https://iotrust.atlassian.net/browse/DC-2391)
Epic child of: m09-04-00 (`epic/DC-2223_m09-04-connector-v2-cleanup`)

---

## 변경 내역

### `scripts/extract-chains.js` (~130 LOC 변경)
- `chainIdentifier` pivot 추가: single-line `{ type, value }` + multi-line block 모두 지원
- testnet 포함 (`isTestnet` skip 제거, `isTestnet: true` 필드를 출력에 보존)
- `FAMILY_KNOWN_MAP` 5개 신규 namespace 추가: `cip34→cardano`, `near`, `havah`, `xahau`, `constellation`
- `buildDefaultKeyPath` 함수 분리 + family-specific path (Cardano CIP-1852 `m/1852'/1815'/0'/0/0` 등)
- `parseFamilyJs`도 동일 chainIdentifier 지원 추가 (sibling parity)

### `playground/chains.json` (auto-generated, ~+450 LOC)
- 84 → **154개** (mainnet 100 + testnet 54)
- family별: bitcoin 4→16, 신규 cardano/near/havah/xahau/constellation 각 2개 추가

### `playground/presets.non-evm.json` (~+200 LOC)
- 10 → **18개** presets
- 신규: `ada-transfer`, `near-transfer`, `dot-transfer`, `xtz-transfer`, `atom-transfer`, `vet-transfer`, `dag-transfer`, `xahau-payment`
- 기존: bitcoin `applicableChainIds` 확장 (11개 fork 포함), xrp/hedera/stellar chainId 정합성 수정

### `package.json` (1줄)
- `lint` script에 `scripts/` 영구 포함 (R6 결정)

### `tests/unit/v2/extract-chains.test.ts` (신규, ~200 LOC)
- T-U-EXTRACT-01~09: 10개 테스트 (caip19, chainIdentifier single/multi-line, cip34, testnet, dedup, namespace map, count sentinel)

---

## wm + sdk Layer 2/3 격차 매트릭스

| Family | getAddress (Layer 1) | signTx (Layer 2/3) | 비고 |
|---|---|---|---|
| ethereum + 모든 EVM | ✅ | ✅ | 정상 |
| polkadot (DOT/Astar/Creditcoin) | ✅ | ✅ | 정상 |
| solana | ✅ | ✅ | 정상 |
| tron | ✅ | ✅ | 정상 |
| tezos | ✅ | ✅ | 정상 |
| xrpl (RIPPLE) | ✅ | signTx ✅ | signMessage -32601 |
| cosmos (BNB/ATOM/TX/HIPPO) | ✅ | ✅ (일부) | family handler coverage 가변 |
| **bitcoin + 모든 fork** | ✅ | ❌ -32601 | sdk FAMILY_METHOD_TRANSLATION 미등록 |
| **cardano** | ✅ | ❌ -32601 | wm/sdk 양쪽 미등록 |
| **near** | ✅ | ❌ -32601 | wm/sdk 양쪽 미등록 |
| **hedera** | ✅ | ❌ -32601 | wm/sdk 미등록 |
| **stellar** | ✅ | ❌ -32601 | wm/sdk 미등록 |
| **xahau** | ✅ | ❌ -32601 | wm/sdk 미등록 |
| **havah** | ✅ | ✅ (EVM path) | eip155 namespace 사용 시 |
| **constellation** | ✅ | ❌ -32601 | wm/sdk 미등록 |

> **Follow-up backlog**: 위 ❌ family들의 Layer 2/3 구현은 sdk + wm 별도 objective 필요.

---

## 자동 검증 결과

| 명령 | 결과 |
|---|---|
| #0 refer-repos chainIdentifier BLOCKER | ✅ PASS (bitcoin-family ≥13, other-networks ≥17) |
| #1 `node scripts/extract-chains.js` | ✅ PASS (154 chains 출력) |
| #2 chains.json count ≥150 + unique | ✅ PASS (154, unique) |
| #3 preset schema cross-check | ✅ PASS (18 presets OK) |
| #4 `npm run lint` | ✅ PASS (exit 0, 0 errors) |
| #5 extract-chains tests (10 passed) | ✅ PASS (T-U-EXTRACT-01~09 모두) |
| #6 `npm run build` | ✅ PASS |
| #7 `npm run unit-v2-e2e` | ✅ PASS |
| #8 manual HW smoke | ⏸ verification-exemption 적용 — USB D'CENT 디바이스 필요, CI 자동화 불가 |

> 사전 존재하는 `playground.signtx-evm.test.ts` T-U-EVM-01 실패 (count 16 vs 20)는 base branch에서도 동일하게 존재 — 본 objective 변경과 무관.

---

## PR 사이즈 예외

`pr-size-exception: "generated-code: chains.json은 extract-chains.js auto-gen (~+450 LOC), presets.non-evm.json은 schema-validated JSON fixture (~+200 LOC). 로직 리뷰 부담은 extract-chains.js 변경분(~130 LOC)에 집중."`