### PR TITLE
[DC-2525] feat(connector): m09-04-12 syncAccount + getAccountInfo v2 wire (chainId/keyPath)

### DIFF
--- a/playground.js
+++ b/playground.js
@@ -1011,7 +1011,7 @@
       }
       var ta = appendFormRow('accountInfosJson', 'accountInfos (JSON array)', 'textarea', {
         value: '',
-        placeholder: '[{"coin_group":"EVM","coin_name":"ETHEREUM","label":"ETH-1"}]',
+        placeholder: '[{"chainId":"eip155:1","keyPath":"m/44\'/60\'/0\'/0/0","label":"ETH-1"}]',
       })
       if (ta) ta.rows = 8
       return
@@ -1521,9 +1521,10 @@
     }
   }
 
-  // ── sanitize helper for syncAccount (m11-01-01) ──
+  // ── sanitize helper for syncAccount (m09-04-12: v2 전환) ──
   // dapp-input-sanitization 룰: known fields whitelist만 추출, __proto__ / unknown key silent drop.
-  // playground 로컬 helper (connector src/sign/sanitize.ts는 string scalar 전용으로 다른 용도).
+  // v2 wire: {chainId, keyPath, label, contractAddress?}. v1 {coin_group, coin_name} 제거.
+  // playground 로컬 helper — 실제 검증은 connector의 _sanitizeSyncAccountItem이 담당.
   function _sanitizeSyncAccountInfos (parsed) {
     if (!Array.isArray(parsed)) {
       throw new Error('accountInfos must be an array')
@@ -1532,11 +1533,16 @@
       if (!a || typeof a !== 'object') {
         throw new Error('each account entry must be an object')
       }
-      return {
-        coin_group: String(a.coin_group == null ? '' : a.coin_group),
-        coin_name: String(a.coin_name == null ? '' : a.coin_name),
+      var out = {
+        chainId: String(a.chainId == null ? '' : a.chainId),
+        keyPath: String(a.keyPath == null ? '' : a.keyPath),
         label: String(a.label == null ? '' : a.label),
       }
+      // contractAddress — optional, include only if present and non-empty
+      if (a.contractAddress != null && a.contractAddress !== '') {
+        out.contractAddress = String(a.contractAddress)
+      }
+      return out
     })
   }
 

--- a/playground/presets.account.json
+++ b/playground/presets.account.json
@@ -4,7 +4,7 @@
     "label": "Ethereum (single)",
     "applicableMethodIds": ["account:syncAccount"],
     "value": [
-      { "coin_group": "EVM", "coin_name": "ETHEREUM", "label": "ETH-1" }
+      { "chainId": "eip155:1", "keyPath": "m/44'/60'/0'/0/0", "label": "ETH-1" }
     ]
   },
   {
@@ -12,7 +12,7 @@
     "label": "Bitcoin (single)",
     "applicableMethodIds": ["account:syncAccount"],
     "value": [
-      { "coin_group": "BITCOIN", "coin_name": "BITCOIN", "label": "BTC-1" }
+      { "chainId": "bip122:000000000019d6689c085ae165831e934ff763ae46b", "keyPath": "m/44'/0'/0'/0/0", "label": "BTC-1" }
     ]
   },
   {
@@ -20,8 +20,8 @@
     "label": "Multi (ETH + BTC)",
     "applicableMethodIds": ["account:syncAccount"],
     "value": [
-      { "coin_group": "EVM", "coin_name": "ETHEREUM", "label": "ETH-1" },
-      { "coin_group": "BITCOIN", "coin_name": "BITCOIN", "label": "BTC-1" }
+      { "chainId": "eip155:1", "keyPath": "m/44'/60'/0'/0/0", "label": "ETH-1" },
+      { "chainId": "bip122:000000000019d6689c085ae165831e934ff763ae46b", "keyPath": "m/44'/0'/0'/0/0", "label": "BTC-1" }
     ]
   }
 ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,9 @@ export {
   addBitcoinTransactionOutput,
 } from './sign'
 // m09-04-12: SyncAccountInfo(v1) removed — replaced by V2SyncAccountInfo(chainId/keyPath)
-export type { V2SyncAccountInfo, BitcoinTxObject, BitcoinTxParameter } from './sign'
+// getAccountInfo v2 return types(V2AccountInfo / AccountListV2Payload)도 루트 배럴에서 노출 —
+// src/sign/index.ts와 public API 표면 일치 (cross-repo-interface-edit)
+export type { V2SyncAccountInfo, V2AccountInfo, AccountListV2Payload, BitcoinTxObject, BitcoinTxParameter } from './sign'
 // m11-01-02: v2 chainId facade input type for getAddress overload
 export type { GetAddressV2Input } from './sign'
 // m09-04-09: addressFormat enum for BTC family multi-variant dispatch

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,7 +132,8 @@ export {
   addBitcoinTransactionInput,
   addBitcoinTransactionOutput,
 } from './sign'
-export type { SyncAccountInfo, BitcoinTxObject, BitcoinTxParameter } from './sign'
+// m09-04-12: SyncAccountInfo(v1) removed — replaced by V2SyncAccountInfo(chainId/keyPath)
+export type { V2SyncAccountInfo, BitcoinTxObject, BitcoinTxParameter } from './sign'
 // m11-01-02: v2 chainId facade input type for getAddress overload
 export type { GetAddressV2Input } from './sign'
 // m09-04-09: addressFormat enum for BTC family multi-variant dispatch

--- a/src/sign/_sanitizeSyncAccountItem.ts
+++ b/src/sign/_sanitizeSyncAccountItem.ts
@@ -1,0 +1,106 @@
+/**
+ * v2 syncAccount per-item sanitize (m09-04-12)
+ *
+ * dApp이 syncAccount(accountInfos) 로 전달하는 각 항목을 사용 전에 검증한다.
+ *
+ * 적용 룰:
+ *   - dapp-input-sanitization: known-fields({chainId, contractAddress?, keyPath, label})만 추출.
+ *     unknown 필드 silent drop. __proto__ / constructor / prototype 자동 차단 (own-enumerable만 읽음).
+ *   - connector-chain-addition-isolation: chainId는 _sanitizeChainId(문자 whitelist)만.
+ *     chain 종류 판정 / enum 매핑 / coin_group 검증 일절 금지.
+ *   - boundary-validation: 비객체 입력 → throw. 필수 필드(chainId/keyPath/label) 누락 → throw.
+ *   - error-handling-consistency: 모든 검증 실패는 throw (silent return 금지).
+ *
+ * BIP44_PATH_REGEX 출처:
+ *   chain-agnostic 형식만 검사. "m/" + hardened/non-hardened components.
+ *   예: "m/44'/60'/0'/0/0" ✓  "44/60" ✗ (m/ prefix 없음)
+ *
+ * CONTRACT_ADDR_REGEX:
+ *   EVM hex (0x + 40-64 hex) | base58-like (Solana/Tron 주소 폭넓게 허용).
+ *   connector는 chain 타입 판정 안 함 — 형식만 검사.
+ */
+
+import { _sanitizeChainId } from './sanitize'
+import { isAvaliableLabel } from './labelValidator'
+import { dcentException } from '../v1/dcent-exception'
+import type { V2SyncAccountInfo } from './types'
+
+/** BIP44 key path — chain-agnostic 형식 검증.
+ *  "m/" prefix + 하나 이상의 hardened/non-hardened 숫자 컴포넌트.
+ *  예: "m/44'/60'/0'/0/0", "m/44'/195'/0'/0/0" */
+const BIP44_PATH_REGEX = /^m(\/\d+'?)+$/
+
+/** contract address — EVM hex 또는 base58-like 형식 폭넓게 허용.
+ *  chain 타입 판정 안 함. 형식 검사만. */
+const CONTRACT_ADDR_REGEX = /^(0x[0-9A-Fa-f]{40,64}|[1-9A-HJ-NP-Za-km-z]{25,60})$/
+
+/** prototype 오염 방지 키 셋 */
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
+/**
+ * v2 syncAccount 단일 항목을 sanitize하여 V2SyncAccountInfo를 반환한다.
+ *
+ * boundary-validation: 비배열 입력 가드는 caller(syncAccount)가 담당.
+ * 본 함수는 배열의 각 항목 객체 검증만 담당.
+ *
+ * @param raw dApp이 전달한 account 항목 (unknown)
+ * @returns 검증·sanitize된 V2SyncAccountInfo
+ * @throws dcentException('param_error') — 형식 위반 시
+ */
+export function _sanitizeSyncAccountItem (raw: unknown): V2SyncAccountInfo {
+  // 비객체 / null / 배열 → throw
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw dcentException('param_error', 'invalid account item: must be a plain object')
+  }
+
+  // own-enumerable만 읽어 prototype 오염 차단
+  const o = raw as Record<string, unknown>
+
+  // forbidden key 명시 차단 (방어 2중화 — toString 우회 패턴)
+  for (const k of Object.keys(o)) {
+    if (FORBIDDEN_KEYS.has(k.toLowerCase())) {
+      throw dcentException('param_error', `forbidden key: ${k}`)
+    }
+  }
+
+  // chainId — _sanitizeChainId가 형식 whitelist + throw (ProviderError).
+  // syncAccount 경계에서는 dcentException('param_error')로 래핑 — error-handling-consistency.
+  // (connector-chain-addition-isolation: chain enum / coin_group 검증 금지)
+  let chainId: string
+  try {
+    chainId = _sanitizeChainId(o.chainId)
+  } catch (e) {
+    throw dcentException('param_error', e instanceof Error ? e.message : 'invalid chainId')
+  }
+
+  // keyPath — BIP44 형식 (chain-agnostic)
+  const rawKeyPath = o.keyPath
+  if (rawKeyPath === undefined || rawKeyPath === null || rawKeyPath === '') {
+    throw dcentException('param_error', 'keyPath required')
+  }
+  const keyPath = String(rawKeyPath)
+  if (!BIP44_PATH_REGEX.test(keyPath)) {
+    throw dcentException('param_error', 'Invalid keyPath - ' + keyPath)
+  }
+
+  // label — v1 isAvaliableLabel 재사용 (메시지 보존)
+  const rawLabel = o.label
+  const label = rawLabel !== undefined ? String(rawLabel) : ''
+  if (!isAvaliableLabel(label)) {
+    throw dcentException('param_error', 'Invalid Label - ' + label)
+  }
+
+  // known-fields only output (unknown fields silently dropped)
+  const out: V2SyncAccountInfo = { chainId, keyPath, label }
+
+  // contractAddress — optional. 존재 시 형식 검증
+  if (o.contractAddress !== undefined && o.contractAddress !== null && o.contractAddress !== '') {
+    const ca = String(o.contractAddress)
+    if (!CONTRACT_ADDR_REGEX.test(ca)) {
+      throw dcentException('param_error', 'invalid contractAddress: ' + ca)
+    }
+    out.contractAddress = ca
+  }
+
+  return out
+}

--- a/src/sign/_sanitizeSyncAccountItem.ts
+++ b/src/sign/_sanitizeSyncAccountItem.ts
@@ -53,14 +53,18 @@ export function _sanitizeSyncAccountItem (raw: unknown): V2SyncAccountInfo {
     throw dcentException('param_error', 'invalid account item: must be a plain object')
   }
 
-  // own-enumerable만 읽어 prototype 오염 차단
-  const o = raw as Record<string, unknown>
+  const src = raw as Record<string, unknown>
 
-  // forbidden key 명시 차단 (방어 2중화 — toString 우회 패턴)
-  for (const k of Object.keys(o)) {
+  // own-enumerable 키만 null-prototype 스냅샷으로 복사한다.
+  //  - 상속(prototype 체인) 속성은 애초에 수집 대상에서 제외 → whitelist 정확성 보장
+  //  - forbidden key(__proto__/constructor/prototype)는 명시 차단
+  //  - 이후 검증/추출은 모두 이 스냅샷(o)에서만 읽으므로 o.chainId 등이 상속값을 집어오지 않음
+  const o: Record<string, unknown> = Object.create(null)
+  for (const k of Object.keys(src)) {
     if (FORBIDDEN_KEYS.has(k.toLowerCase())) {
       throw dcentException('param_error', `forbidden key: ${k}`)
     }
+    o[k] = src[k]
   }
 
   // chainId — _sanitizeChainId가 형식 whitelist + throw (ProviderError).
@@ -73,7 +77,9 @@ export function _sanitizeSyncAccountItem (raw: unknown): V2SyncAccountInfo {
     throw dcentException('param_error', e instanceof Error ? e.message : 'invalid chainId')
   }
 
-  // keyPath — BIP44 형식 (chain-agnostic)
+  // keyPath — chain-agnostic key path 형식만 검사 (BIP32 "m/" prefix + 숫자 컴포넌트).
+  // 엄격한 BIP44 5-component 강제는 하지 않는다 — 체인마다 depth가 다르므로(connector-chain-addition-isolation)
+  // 실제 path 유효성 판정은 wm/sdk에 위임. 여기서는 형식 위반만 거른다.
   const rawKeyPath = o.keyPath
   if (rawKeyPath === undefined || rawKeyPath === null || rawKeyPath === '') {
     throw dcentException('param_error', 'keyPath required')
@@ -93,10 +99,14 @@ export function _sanitizeSyncAccountItem (raw: unknown): V2SyncAccountInfo {
   // known-fields only output (unknown fields silently dropped)
   const out: V2SyncAccountInfo = { chainId, keyPath, label }
 
-  // contractAddress — optional. 존재 시 형식 검증
-  if (o.contractAddress !== undefined && o.contractAddress !== null && o.contractAddress !== '') {
+  // contractAddress — optional. 키가 없거나(undefined/null) 토큰이 아닌 경우 omit.
+  // 단, 키가 명시적으로 존재하는데 빈 문자열이거나 형식 위반이면 throw —
+  // 빈 문자열을 silent drop하면 caller의 실수(토큰 의도인데 주소 누락)가 native-coin 계정으로
+  // 둔갑한다 (error-handling-consistency: 검증 실패는 throw, silent return 금지).
+  if (Object.prototype.hasOwnProperty.call(o, 'contractAddress') &&
+      o.contractAddress !== undefined && o.contractAddress !== null) {
     const ca = String(o.contractAddress)
-    if (!CONTRACT_ADDR_REGEX.test(ca)) {
+    if (ca === '' || !CONTRACT_ADDR_REGEX.test(ca)) {
       throw dcentException('param_error', 'invalid contractAddress: ' + ca)
     }
     out.contractAddress = ca

--- a/src/sign/configure.ts
+++ b/src/sign/configure.ts
@@ -1,42 +1,31 @@
 /**
- * v1 setLabel / syncAccount / selectAddress port (m08-01-02.5)
+ * setLabel / syncAccount / selectAddress (m08-01-02.5, v2 전환 m09-04-12)
  *
- * v1 src-v1/index.js의 `dcent.setLabel` (l705-716), `dcent.syncAccount` (l724-745),
- * `dcent.selectAddress` (l762-772)를 1:1 port.
- *
- * **v1 1:1 보존 디테일**:
- *   - setLabel: `isAvaliableLabel` regex 검증 → throw `param_error` ('Invalid Label : ' + label)
- *   - syncAccount: per-account 3종 검증 (early throw) — coinGroup → coinName → label 순서
- *     - coin_group: `isAvaliableCoinGroup` fail → `coin_group_error`
- *     - coin_name: `isAvailableSyncAccountCoinName` fail → `coin_name_error`
- *     - label: `isAvaliableLabel` fail → `param_error` ('Invalid Label - ' + label)
- *   - selectAddress: `Array.isArray` 검증만 → throw `param_error`
+ * - setLabel: v1 1:1 port (m08-01-02.5) — 변경 없음
+ * - syncAccount: **v2 전환 (m09-04-12)** — SyncAccountInfo(coin_group/coin_name) →
+ *   V2SyncAccountInfo(chainId/contractAddress?/keyPath/label).
+ *   v1 chain 검증(isAvaliableCoinGroup / isAvailableSyncAccountCoinName) 제거.
+ *   connector-chain-addition-isolation: chain-agnostic light sanitize만 수행.
+ *   실제 chain resolve는 sdk/wm(m09-03-21) 위임.
+ * - selectAddress: v1 1:1 port (m08-01-02.5) — 변경 없음
  *
  * **m12-03 Layer B (MEDIUM)**:
- *   - `syncAccount(accountInfos, opts?)` — opts?.deviceId 추가
- *   - `selectAddress(addresses, opts?)` — opts?.deviceId 추가
- *   모두 trailing optional이므로 기존 2-arg 호출자에 영향 없음 (backward-compat).
+ *   - `syncAccount(accountInfos, opts?)` — opts?.deviceId 유지
+ *   - `selectAddress(addresses, opts?)` — opts?.deviceId 유지
  *
  * 룰 준수:
- *   - boundary-validation: 모든 인자 검증 후 _call
- *   - error-handling-consistency: 모든 검증 실패는 dcentException throw (v1 1:1 메시지)
+ *   - connector-chain-addition-isolation: chain enum / coin_group 검증 제거
+ *   - dapp-input-sanitization: _sanitizeSyncAccountItem per-item sanitize
+ *   - boundary-validation: 비배열 accountInfos → throw
+ *   - error-handling-consistency: 모든 검증 실패는 dcentException throw
  *   - reuse-shared-utils: validators는 sibling 모듈에서 import
  */
 
 import { _call } from './call'
 import { isAvaliableLabel } from './labelValidator'
-import { isAvaliableCoinGroup, isAvailableSyncAccountCoinName } from './coinGroupValidator'
+import { _sanitizeSyncAccountItem } from './_sanitizeSyncAccountItem'
 import { dcentException } from '../v1/dcent-exception'
-import type { V1Response, CallOptions } from './types'
-
-/* eslint-disable camelcase */
-/** sync account info — v1 wire format에 맞춰 snake_case. */
-export interface SyncAccountInfo {
-  coin_group: string
-  coin_name: string
-  label: string
-}
-/* eslint-enable camelcase */
+import type { V1Response, V2SyncAccountInfo, CallOptions } from './types'
 
 /**
  * v1 dcent.setLabel (src-v1/index.js#l705-716) 1:1 port.
@@ -52,32 +41,34 @@ export function setLabel (label: string): Promise<V1Response> {
 }
 
 /**
- * v1 dcent.syncAccount (src-v1/index.js#l724-745) 1:1 port.
+ * dcent.syncAccount v2 — chainId + keyPath 기반 account 동기화 (m09-04-12 breaking change).
  *
- * Account 정보 동기화 — 추가 또는 갱신.
- * Per-account 3종 검증 (coin_group / coin_name / label) — early throw on first failure.
+ * **v2 전환**: 입력 타입이 v1 `SyncAccountInfo{coin_group, coin_name, label}[]` 에서
+ * v2 `V2SyncAccountInfo{chainId, contractAddress?, keyPath, label}[]` 로 변경됨.
+ * v1 chain 검증(isAvaliableCoinGroup / isAvailableSyncAccountCoinName) 제거.
  *
- * **m12-03 Layer B**: `opts?.deviceId` 추가. trailing optional → backward-compat.
+ * connector는 chain-agnostic transport:
+ *   - chainId 형식 whitelist(_sanitizeChainId) + keyPath BIP44 + label regex 검증만 수행
+ *   - chain resolve / coin_group-coin_name 매핑은 sdk(m09-03-21) → wm 위임
  *
- * @param accountInfos 검증 후 디바이스에 sync할 account 배열
+ * **BREAKING**: v1 SyncAccountInfo 파라미터 타입은 더 이상 허용되지 않는다.
+ * 마이그레이션: { coin_group, coin_name, label } → { chainId, keyPath, label }
+ * (마이그레이션 가이드는 m09-04-04/06 docs child 담당)
+ *
+ * @param accountInfos v2 account 항목 배열 — 각 항목은 _sanitizeSyncAccountItem으로 검증
  * @param opts 선택적 CallOptions (deviceId 등)
- * @throws dcentException 첫 invalid account의 첫 invalid 필드에서 throw (v1 동일 순서)
+ * @throws dcentException('param_error') — 비배열 / invalid 항목
  */
-export function syncAccount (accountInfos: SyncAccountInfo[], opts?: CallOptions): Promise<V1Response> {
-  for (let i = 0; i < accountInfos.length; i = i + 1) {
-    const account = accountInfos[i]
-
-    if (!isAvaliableCoinGroup(account.coin_group)) {
-      throw dcentException('coin_group_error', 'not supported coin group')
-    }
-    if (!isAvailableSyncAccountCoinName(account)) {
-      throw dcentException('coin_name_error', 'not supported coin name')
-    }
-    if (!isAvaliableLabel(account.label)) {
-      throw dcentException('param_error', 'Invalid Label - ' + account.label)
-    }
+export function syncAccount (accountInfos: V2SyncAccountInfo[], opts?: CallOptions): Promise<V1Response> {
+  // boundary-validation: 비배열 입력 → throw (selectAddress T-U-SEL-02 패턴 통일)
+  if (!Array.isArray(accountInfos)) {
+    throw dcentException('param_error', 'accountInfos is not array')
   }
-  return _call({ method: 'syncAccount', params: { accountInfos }, deviceId: opts?.deviceId })
+
+  // per-item sanitize — _sanitizeSyncAccountItem이 throw on invalid
+  const safe = accountInfos.map(_sanitizeSyncAccountItem)
+
+  return _call({ method: 'syncAccount', params: { accountInfos: safe }, deviceId: opts?.deviceId })
 }
 
 /**

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -14,8 +14,8 @@
 export { sign } from './sign'
 export type { SignInput } from './sign'
 
-// V1 호환 응답 타입 + m12-03 신규 타입
-export type { V1Response, V1ResponseHeader, V1ResponseBody, CallOptions, DeviceInfoPayload } from './types'
+// V1 호환 응답 타입 + m12-03 신규 타입 + m09-04-12 v2 account 타입
+export type { V1Response, V1ResponseHeader, V1ResponseBody, CallOptions, DeviceInfoPayload, V2SyncAccountInfo, V2AccountInfo, AccountListV2Payload } from './types'
 
 // internal helpers — sibling module이 사용. 이름 prefix `_`로 표기.
 export { _call } from './call'
@@ -33,7 +33,7 @@ export type { GetAddressV2Input } from './address'
 // m09-04-09: addressFormat enum type for BTC family multi-variant dispatch
 export type { AddressFormat } from './address'
 export { setLabel, syncAccount, selectAddress } from './configure'
-export type { SyncAccountInfo } from './configure'
+// m09-04-12: SyncAccountInfo(v1) removed — V2SyncAccountInfo re-exported from ./types above
 export {
   getBitcoinTransactionObject,
   addBitcoinTransactionInput,

--- a/src/sign/info.ts
+++ b/src/sign/info.ts
@@ -8,6 +8,9 @@
  *   - `getDeviceInfo()` 반환 타입을 `V1Response<DeviceInfoPayload>`로 narrow (Layer A).
  *     options arg는 비스코프 (first-call / device-discovery 성격).
  *   - `getAccountInfo(opts?)` — MEDIUM priority facade, deviceId 옵션 추가 (Layer B).
+ * **m09-04-12**:
+ *   - `getAccountInfo()` 반환 타입을 `V1Response<AccountListV2Payload>`로 narrow.
+ *     connector는 sdk(m09-03-21) enrich 응답을 그대로 forward.
  *
  * 룰 준수:
  *   - error-handling-consistency: `_call`이 V1Response를 반환 (throw 없음, mutation 격리)
@@ -15,7 +18,7 @@
  */
 
 import { _call } from './call'
-import type { V1Response, DeviceInfoPayload, CallOptions } from './types'
+import type { V1Response, DeviceInfoPayload, AccountListV2Payload, CallOptions } from './types'
 
 /**
  * v1 dcent.info — Bridge (Tray Daemon) status 정보 조회.
@@ -39,9 +42,11 @@ export function getDeviceInfo (): Promise<V1Response<DeviceInfoPayload>> {
  * v1 dcent.getAccountInfo — Wallet에 등록된 account 리스트 조회.
  *
  * **m12-03 Layer B (MEDIUM)**: `opts?.deviceId` 추가.
- * dApp이 세션 deviceId를 전달해 특정 디바이스의 account 목록을 조회.
+ * **m09-04-12**: 반환 타입을 `V1Response<AccountListV2Payload>`로 narrow.
+ * connector는 sdk(m09-03-21)가 enrich한 응답을 그대로 forward — 변환 로직 없음.
+ * dApp이 `resp.body.parameter?.account` 배열을 typed으로 접근 가능.
  * opts 미명시 시 기존 흐름 유지 (backward-compat).
  */
-export function getAccountInfo (opts?: CallOptions): Promise<V1Response> {
-  return _call({ method: 'getAccountInfo', deviceId: opts?.deviceId })
+export function getAccountInfo (opts?: CallOptions): Promise<V1Response<AccountListV2Payload>> {
+  return _call({ method: 'getAccountInfo', deviceId: opts?.deviceId }) as unknown as Promise<V1Response<AccountListV2Payload>>
 }

--- a/src/sign/types.ts
+++ b/src/sign/types.ts
@@ -83,6 +83,64 @@ export interface CallOptions {
 
 /* eslint-disable camelcase */
 /**
+ * v2 account wire — syncAccount 입력 항목 (m09-04-12).
+ *
+ * connector-chain-addition-isolation: chainId는 chain-agnostic whitelist 형식 검증만.
+ * 실제 chain resolve는 sdk/wm(m09-03-21)에 위임.
+ *
+ * dapp-input-sanitization: _sanitizeSyncAccountItem이 known-fields만 통과.
+ */
+export interface V2SyncAccountInfo {
+  /** chain-level CAIP-2 chainId (예: 'eip155:1', 'bip122:000000000019d6689c085ae165831e93').
+   *  token도 chain part만 (contractAddress로 asset 구분). */
+  chainId: string
+  /** token asset일 때만 존재. native coin은 생략. */
+  contractAddress?: string
+  /** BIP44 key path (예: "m/44'/60'/0'/0/0"). */
+  keyPath: string
+  /** D'CENT 지갑 표시 레이블. */
+  label: string
+}
+
+/**
+ * v2 account wire — getAccountInfo 응답 항목 (m09-04-12).
+ *
+ * sdk(m09-03-21)가 enrich한 결과 shape. connector는 응답을 forward만 — 타입 narrow 전용.
+ *
+ * mutation-isolation: V1Response가 call.ts에서 매 호출마다 새 객체로 생성.
+ */
+export type V2AccountInfo =
+  | {
+      /** resolve 성공 — chainId 확인됨 */
+      chainId: string
+      /** token이면 asset-level CAIP-19 (예: 'eip155:1/erc20:0x...'). native이면 undefined. */
+      caip19?: string
+      /** token asset address. native이면 undefined. */
+      contractAddress?: string
+      /** 디바이스 address_path */
+      keyPath: string
+      /** D'CENT 레이블 */
+      label: string
+      unresolved?: false
+    }
+  | {
+      /** resolve 실패 (custom coin / 미등록 / collision) */
+      chainId: null
+      unresolved: true
+      /** 디바이스 raw 응답 (v1 shape 보존) */
+      raw: { coin_group: string; coin_name: string; address_path: string; label: string }
+    }
+
+/**
+ * getAccountInfo 응답 body.parameter shape (m09-04-12).
+ */
+export interface AccountListV2Payload {
+  account: V2AccountInfo[]
+}
+/* eslint-enable camelcase */
+
+/* eslint-disable camelcase */
+/**
  * D'CENT 디바이스 정보 응답 payload (m12-03).
  *
  * `getDeviceInfo()` 응답의 `body.parameter` shape.

--- a/tests/unit/2_v2_e2e/playground.account.spec.ts
+++ b/tests/unit/2_v2_e2e/playground.account.spec.ts
@@ -70,15 +70,15 @@ describe('[v2 e2e] playground account/device APIs', () => {
       ;(window as any).dcent = (window as any).dcent || {}
       ;(window as any).dcent.coinType = mockDcent.coinType
 
-      // account presets — fixture (시연용 1개로 충분)
+      // account presets — fixture (시연용 1개로 충분) — v2 shape (m09-04-12)
       api.simulateAccountPresetsLoad([
         {
           id: 'syncAccount:multi',
           label: 'Multi (ETH + BTC)',
           applicableMethodIds: ['account:syncAccount'],
           value: [
-            { coin_group: 'EVM', coin_name: 'ETHEREUM', label: 'ETH-1' },
-            { coin_group: 'BITCOIN', coin_name: 'BITCOIN', label: 'BTC-1' },
+            { chainId: 'eip155:1', keyPath: "m/44'/60'/0'/0/0", label: 'ETH-1' },
+            { chainId: 'bip122:000000000019d6689c085ae165831e934ff763ae46b', keyPath: "m/44'/0'/0'/0/0", label: 'BTC-1' },
           ],
         },
       ])
@@ -109,11 +109,12 @@ describe('[v2 e2e] playground account/device APIs', () => {
       expect(handle).not.toBeNull()
     }
 
-    // 그룹 label 확인
+    // 그룹 label 확인 — Device API 그룹 + Account API 그룹 분리 (m09-04-12)
     const labels = await page.$$eval('.tree-group-label', (els: Element[]) =>
       els.map((e) => (e.textContent || '').trim())
     )
-    expect(labels).toContain('Account / Device')
+    expect(labels).toContain('Device API')
+    expect(labels).toContain('Account API')
   }, 30000)
 
   // ────────────────────────────────────────────────────────
@@ -150,11 +151,11 @@ describe('[v2 e2e] playground account/device APIs', () => {
     await page.click('[data-method-id="account:syncAccount"]')
     // preset select에서 multi 선택 (HTML select element 값 변경 후 change 이벤트 dispatch)
     await page.select('#field-preset', 'syncAccount:multi')
-    // textarea가 채워졌는지 확인
+    // textarea가 채워졌는지 확인 — v2 shape (m09-04-12)
     const taValue = await page.$eval('#field-accountInfosJson', (el: HTMLTextAreaElement) => el.value)
-    expect(taValue).toContain('coin_group')
-    expect(taValue).toContain('ETHEREUM')
-    expect(taValue).toContain('BITCOIN')
+    expect(taValue).toContain('chainId')
+    expect(taValue).toContain('eip155:1')
+    expect(taValue).toContain('bip122:')
 
     await page.click('#btn-send')
     await new Promise((r) => setTimeout(r, 200))
@@ -164,10 +165,10 @@ describe('[v2 e2e] playground account/device APIs', () => {
     expect(syncCall).toBeDefined()
     expect(Array.isArray(syncCall.args[0])).toBe(true)
     expect(syncCall.args[0].length).toBe(2)
-    // sanitize: known fields only
+    // sanitize: known fields only — v2 shape (m09-04-12)
     expect(syncCall.args[0][0]).toEqual({
-      coin_group: 'EVM',
-      coin_name: 'ETHEREUM',
+      chainId: 'eip155:1',
+      keyPath: "m/44'/60'/0'/0/0",
       label: 'ETH-1',
     })
 

--- a/tests/unit/v2/configure/syncAccount.v2.test.ts
+++ b/tests/unit/v2/configure/syncAccount.v2.test.ts
@@ -1,26 +1,22 @@
 /**
- * setLabel / syncAccount / selectAddress 단위 테스트
+ * syncAccount v2 단위 테스트 (m09-04-12)
  *
- * setLabel: m08-01-02.5 (변경 없음)
- *   T-U-LABEL-01/02: setLabel valid + invalid 4종
+ * T-U-SYNC-00: 비배열 입력 → param_error throw
+ * T-U-SYNC-01: v2 native account {chainId, keyPath, label} → _call, coin_group 검증 미호출
+ * T-U-SYNC-02: v2 token account (contractAddress 포함) → forward
+ * T-U-SYNC-03: invalid chainId → param_error throw
+ * T-U-SYNC-04: keyPath BIP44 형식 위반 → param_error throw
+ * T-U-SYNC-05: keyPath 누락 → param_error throw
+ * T-U-SYNC-06: label regex 위반 → param_error throw
+ * T-U-SYNC-07: contractAddress 형식 위반 → param_error throw
+ * T-SEC-WHITE-01: unknown 필드 + __proto__ → known-fields만 통과, prototype 오염 없음
+ * T-SEC-WHITE-02: invalid 타입 contractAddress(숫자) → throw
  *
- * syncAccount: **v2 전환 (m09-04-12)**
- *   T-U-SYNC-00: 비배열 입력 → param_error throw
- *   T-U-SYNC-01: v2 native account 정상 → _call
- *   T-U-SYNC-02: v2 token account (contractAddress 포함) → _call
- *   T-U-SYNC-03: invalid chainId → param_error throw
- *   T-U-SYNC-04: keyPath BIP44 형식 위반 → param_error throw
- *   T-U-SYNC-05: keyPath 누락 → param_error throw
- *   T-U-SYNC-06: label regex 위반 → param_error throw
- *   T-U-SYNC-07: contractAddress 형식 위반 → param_error throw
- *   T-SEC-WHITE-01: unknown 필드 + __proto__ → known-fields만 전달, prototype 오염 없음
- *   T-SEC-WHITE-02: invalid 타입 필드(contractAddress=숫자) → throw
- *
- * selectAddress: m08-01-02.5 (변경 없음)
- *   T-U-SEL-01/02: array + non-array
+ * connector-chain-addition-isolation: coin_group/coin_name 검증 제거 확인 포함.
+ * dapp-input-sanitization: whitelist 검증.
  */
 
-import { setLabel, syncAccount, selectAddress } from '../../../../src/sign/configure'
+import { syncAccount } from '../../../../src/sign/configure'
 import { ensureSingleton, _resetForTesting } from '../../../../src/singleton'
 
 beforeEach(() => {
@@ -31,59 +27,6 @@ afterAll(() => {
   _resetForTesting()
 })
 
-// ──────────────────────────────────────────────
-// setLabel (m08-01-02.5 — 변경 없음)
-// ──────────────────────────────────────────────
-describe('setLabel — m08-01-02.5', () => {
-  test('T-U-LABEL-01: valid label "valid_label-2" → _call', async () => {
-    const { transport } = ensureSingleton()
-    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
-      id: 'r1',
-      result: { ok: true },
-    })
-
-    await setLabel('valid_label-2')
-
-    expect(sendSpy).toHaveBeenCalledTimes(1)
-    expect(sendSpy.mock.calls[0][0].method).toBe('setLabel')
-    expect(sendSpy.mock.calls[0][0].params).toEqual({ label: 'valid_label-2' })
-  })
-
-  test('T-U-LABEL-02a: too short ("a") → param_error throw', () => {
-    expect(() => setLabel('a')).toThrow(
-      expect.objectContaining({
-        body: { error: { code: 'param_error', message: 'Invalid Label : a' } },
-      }),
-    )
-  })
-
-  test('T-U-LABEL-02b: too long (15 chars) → param_error throw', () => {
-    const long15 = 'A'.repeat(15)
-    expect(() => setLabel(long15)).toThrow(
-      expect.objectContaining({ body: { error: { code: 'param_error', message: `Invalid Label : ${long15}` } } }),
-    )
-  })
-
-  test('T-U-LABEL-02c: 한글 → param_error throw', () => {
-    expect(() => setLabel('한글라벨')).toThrow(
-      expect.objectContaining({
-        body: { error: { code: 'param_error', message: 'Invalid Label : 한글라벨' } },
-      }),
-    )
-  })
-
-  test('T-U-LABEL-02d: 공백 포함 → param_error throw', () => {
-    expect(() => setLabel('has space')).toThrow(
-      expect.objectContaining({
-        body: { error: { code: 'param_error', message: 'Invalid Label : has space' } },
-      }),
-    )
-  })
-})
-
-// ──────────────────────────────────────────────
-// syncAccount v2 (m09-04-12)
-// ──────────────────────────────────────────────
 describe('syncAccount v2 — m09-04-12', () => {
   test('T-U-SYNC-00: 비배열 입력(null/object/string) → param_error throw', () => {
     expect(() => syncAccount(null as unknown as [])).toThrow(
@@ -179,7 +122,7 @@ describe('syncAccount v2 — m09-04-12', () => {
     )
   })
 
-  test('T-SEC-WHITE-01: unknown 필드 + __proto__ 포함 → known-fields만 전달, prototype 오염 없음', async () => {
+  test('T-SEC-WHITE-01: unknown 필드 + __proto__ → known-fields만 전달, prototype 오염 없음', async () => {
     const { transport } = ensureSingleton()
     const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
       id: 'sw1',
@@ -213,33 +156,6 @@ describe('syncAccount v2 — m09-04-12', () => {
       }]),
     ).toThrow(
       expect.objectContaining({ body: expect.objectContaining({ error: expect.objectContaining({ code: 'param_error' }) }) }),
-    )
-  })
-})
-
-// ──────────────────────────────────────────────
-// selectAddress (m08-01-02.5 — 변경 없음)
-// ──────────────────────────────────────────────
-describe('selectAddress — m08-01-02.5', () => {
-  test('T-U-SEL-01: array → _call', async () => {
-    const { transport } = ensureSingleton()
-    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
-      id: 'sa1',
-      result: { ok: true },
-    })
-
-    await selectAddress(['addr1', 'addr2'])
-
-    expect(sendSpy).toHaveBeenCalledTimes(1)
-    expect(sendSpy.mock.calls[0][0].method).toBe('selectAddress')
-    expect(sendSpy.mock.calls[0][0].params).toEqual({ addresses: ['addr1', 'addr2'] })
-  })
-
-  test('T-U-SEL-02: non-array → param_error throw', () => {
-    expect(() => selectAddress('notarray' as unknown as string[])).toThrow(
-      expect.objectContaining({
-        body: { error: { code: 'param_error', message: 'addresses is not array' } },
-      }),
     )
   })
 })

--- a/tests/unit/v2/configure/syncAccount.v2.test.ts
+++ b/tests/unit/v2/configure/syncAccount.v2.test.ts
@@ -9,11 +9,18 @@
  * T-U-SYNC-05: keyPath 누락 → param_error throw
  * T-U-SYNC-06: label regex 위반 → param_error throw
  * T-U-SYNC-07: contractAddress 형식 위반 → param_error throw
- * T-SEC-WHITE-01: unknown 필드 + __proto__ → known-fields만 통과, prototype 오염 없음
+ * T-SEC-WHITE-01: unknown 필드 → known-fields만 통과, drop 확인
  * T-SEC-WHITE-02: invalid 타입 contractAddress(숫자) → throw
+ * T-SEC-WHITE-03: __proto__ own-key(JSON.parse) → forbidden key throw, prototype 오염 없음
+ * T-SEC-WHITE-04: constructor own-key → forbidden key throw
+ * T-SEC-INHERIT-01: 상속(prototype) 속성은 수집 안 됨 → own-key 부재로 throw
+ * T-U-SYNC-08: 비객체 항목(null/숫자/문자열/배열) → param_error throw
+ * T-U-SYNC-09: contractAddress 빈 문자열('') → throw (silent drop 금지)
  *
  * connector-chain-addition-isolation: coin_group/coin_name 검증 제거 확인 포함.
- * dapp-input-sanitization: whitelist 검증.
+ * dapp-input-sanitization: whitelist + __proto__/constructor 차단 + 상속 속성 무시.
+ * boundary-validation: 항목별 비객체 가드.
+ * error-handling-consistency: 빈 문자열 contractAddress는 silent drop 아닌 throw.
  */
 
 import { syncAccount } from '../../../../src/sign/configure'
@@ -156,6 +163,76 @@ describe('syncAccount v2 — m09-04-12', () => {
       }]),
     ).toThrow(
       expect.objectContaining({ body: expect.objectContaining({ error: expect.objectContaining({ code: 'param_error' }) }) }),
+    )
+  })
+
+  test('T-SEC-WHITE-03: __proto__ own-key(JSON.parse) → forbidden key throw + prototype 오염 없음', () => {
+    // 객체 리터럴 {__proto__:...}는 prototype을 설정할 뿐 own-key가 아니므로
+    // 실제 own-enumerable __proto__ 키는 JSON.parse로만 주입 가능
+    const malicious = JSON.parse(
+      '{"chainId":"eip155:1","keyPath":"m/44\'/60\'/0\'/0/0","label":"myETH","__proto__":{"polluted":true}}',
+    )
+    expect(() => syncAccount([malicious])).toThrow(
+      expect.objectContaining({ body: expect.objectContaining({ error: expect.objectContaining({ code: 'param_error' }) }) }),
+    )
+    expect((Object.prototype as Record<string, unknown>).polluted).toBeUndefined()
+  })
+
+  test('T-SEC-WHITE-04: constructor own-key → forbidden key param_error throw', () => {
+    const malicious = JSON.parse(
+      '{"chainId":"eip155:1","keyPath":"m/44\'/60\'/0\'/0/0","label":"myETH","constructor":{"x":1}}',
+    )
+    expect(() => syncAccount([malicious])).toThrow(
+      expect.objectContaining({ body: expect.objectContaining({ error: expect.objectContaining({ code: 'param_error' }) }) }),
+    )
+  })
+
+  test('T-SEC-INHERIT-01: 상속(prototype) 속성은 수집 안 됨 → own-key 부재로 throw', () => {
+    // chainId/keyPath/label을 prototype 체인에만 둔 객체 → own-enumerable 아님 →
+    // sanitizer 스냅샷에 수집되지 않아 chainId 누락으로 throw
+    const proto = { chainId: 'eip155:1', keyPath: "m/44'/60'/0'/0/0", label: 'myETH' }
+    const inherited = Object.create(proto) as { chainId: string; keyPath: string; label: string }
+    expect(() => syncAccount([inherited])).toThrow(
+      expect.objectContaining({ body: expect.objectContaining({ error: expect.objectContaining({ code: 'param_error' }) }) }),
+    )
+  })
+
+  test('T-U-SYNC-08: 비객체 항목(null/숫자/문자열/배열) → param_error throw', () => {
+    for (const bad of [null, 42, 'str', ['nested']]) {
+      expect(() =>
+        syncAccount([bad as unknown as { chainId: string; keyPath: string; label: string }]),
+      ).toThrow(
+        expect.objectContaining({ body: expect.objectContaining({ error: expect.objectContaining({ code: 'param_error' }) }) }),
+      )
+    }
+  })
+
+  test('T-U-SYNC-09: contractAddress 빈 문자열 → param_error throw (silent drop 금지)', () => {
+    expect(() =>
+      syncAccount([{
+        chainId: 'eip155:1',
+        contractAddress: '',
+        keyPath: "m/44'/60'/0'/0/0",
+        label: 'myToken',
+      }]),
+    ).toThrow(
+      expect.objectContaining({ body: expect.objectContaining({ error: expect.objectContaining({ code: 'param_error' }) }) }),
+    )
+  })
+
+  test('T-U-SYNC-10: keyPath 키 자체 누락(undefined) → param_error throw', () => {
+    expect(() =>
+      syncAccount([{ chainId: 'eip155:1', label: 'myETH' } as unknown as { chainId: string; keyPath: string; label: string }]),
+    ).toThrow(
+      expect.objectContaining({ body: { error: { code: 'param_error', message: 'keyPath required' } } }),
+    )
+  })
+
+  test('T-U-SYNC-11: label 키 자체 누락(undefined) → 빈 라벨로 간주되어 param_error throw', () => {
+    expect(() =>
+      syncAccount([{ chainId: 'eip155:1', keyPath: "m/44'/60'/0'/0/0" } as unknown as { chainId: string; keyPath: string; label: string }]),
+    ).toThrow(
+      expect.objectContaining({ body: { error: { code: 'param_error', message: 'Invalid Label - ' } } }),
     )
   })
 })

--- a/tests/unit/v2/info/getAccountInfo.v2.test.ts
+++ b/tests/unit/v2/info/getAccountInfo.v2.test.ts
@@ -1,0 +1,80 @@
+/**
+ * getAccountInfo v2 타입 passthrough 테스트 (m09-04-12)
+ *
+ * T-U-GAI-01: getAccountInfo() 반환 타입이 V1Response<AccountListV2Payload>로 narrowed.
+ *   connector는 sdk(m09-03-21)가 enrich한 응답을 그대로 forward — 변환 로직 없음.
+ *   dApp이 `resp.body.parameter?.account` 배열을 typed으로 접근 가능.
+ *
+ * connector-chain-addition-isolation: getAccountInfo는 응답 forward만.
+ * 실제 enrich(chainId 주입, unresolved 마킹)는 sdk(m09-03-21) 담당.
+ */
+
+import { getAccountInfo } from '../../../../src/sign/info'
+import type { AccountListV2Payload } from '../../../../src/sign/types'
+import { ensureSingleton, _resetForTesting } from '../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+describe('getAccountInfo v2 — m09-04-12', () => {
+  test('T-U-GAI-01: getAccountInfo() → V1Response<AccountListV2Payload> passthrough (sdk enrich 응답 그대로 forward)', async () => {
+    const { transport } = ensureSingleton()
+
+    // sdk(m09-03-21)가 enrich한 응답 shape 시뮬레이션
+    const v2Account = {
+      chainId: 'eip155:1',
+      caip19: undefined,
+      contractAddress: undefined,
+      keyPath: "m/44'/60'/0'/0/0",
+      label: 'myETH',
+      unresolved: false as const,
+    }
+    const unresolvedAccount = {
+      chainId: null,
+      unresolved: true as const,
+      raw: {
+        coin_group: 'HEDERA',
+        coin_name: 'HEDERA',
+        address_path: "m/44'/3030'/0'/0/0",
+        label: 'HEDERA-01',
+      },
+    }
+
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'gai1',
+      result: {
+        account: [v2Account, unresolvedAccount],
+      },
+    })
+
+    const resp = await getAccountInfo()
+
+    // 반환 타입이 V1Response<AccountListV2Payload>로 narrowed — TypeScript compile-time check
+    const payload: AccountListV2Payload | undefined = resp.body.parameter
+    expect(payload).toBeDefined()
+    expect(Array.isArray(payload!.account)).toBe(true)
+    expect(payload!.account).toHaveLength(2)
+
+    // resolved account
+    const acc0 = payload!.account[0]
+    expect(acc0.chainId).toBe('eip155:1')
+    // TypeScript narrow: unresolved === false → chainId는 string
+    if (!acc0.unresolved) {
+      expect(acc0.keyPath).toBe("m/44'/60'/0'/0/0")
+      expect(acc0.label).toBe('myETH')
+    }
+
+    // unresolved account
+    const acc1 = payload!.account[1]
+    expect(acc1.chainId).toBeNull()
+    if (acc1.unresolved) {
+      expect(acc1.raw.coin_group).toBe('HEDERA')
+      expect(acc1.raw.address_path).toBe("m/44'/3030'/0'/0/0")
+    }
+  })
+})

--- a/tests/unit/v2/sign/deviceid-facade.test.ts
+++ b/tests/unit/v2/sign/deviceid-facade.test.ts
@@ -133,12 +133,12 @@ describe('T-U-DEVID-FAC-* — facade deviceId wiring (Layer B)', () => {
     expect(spy.mock.calls[0][0].method).toBe('getAccountInfo')
   })
 
-  test('T-U-DEVID-FAC-04b: syncAccount(infos, {deviceId:"X"}) → _call', async () => {
+  test('T-U-DEVID-FAC-04b: syncAccount(infos, {deviceId:"X"}) → _call (v2 shape)', async () => {
     const { transport } = ensureSingleton()
     const spy = jest.spyOn(transport, 'send').mockResolvedValue({ id: 'r4b', result: {} })
 
     await syncAccount(
-      [{ coin_group: 'ETHEREUM', coin_name: 'ETHEREUM', label: 'mywallet' }],
+      [{ chainId: 'eip155:1', keyPath: "m/44'/60'/0'/0/0", label: 'mywallet' }],
       { deviceId: 'D-005' },
     )
 


### PR DESCRIPTION
## Objective

`m09-04-12-connector-account-v2-chainid` — Epic child of `m09-04` (connector v2 cleanup)

**Jira**: [DC-2525](https://iotrust.atlassian.net/browse/DC-2525)

## Summary

- **`syncAccount` v2 wire**: Input type migrated from v1 `SyncAccountInfo({coin_group, coin_name, label}[])` to v2 `V2SyncAccountInfo({chainId, keyPath, label, contractAddress?}[])` — chain-agnostic transport only, no chain enum/mapping added (connector-chain-addition-isolation rule)
- **`_sanitizeSyncAccountItem`**: New per-item sanitizer — known-fields whitelist, `__proto__`/`constructor`/`prototype` blocking, BIP44_PATH_REGEX + CONTRACT_ADDR_REGEX validation, dcentException wrapping for ProviderError from `_sanitizeChainId`
- **`getAccountInfo` type narrowing**: Return type narrowed to `V1Response<AccountListV2Payload>` — connector passes sdk(m09-03-21) enriched response through without transformation
- **Playground updated**: `playground.js` + `presets.account.json` use v2 shape `{chainId, keyPath, label}`

## Rules Applied

- `connector-chain-addition-isolation`: No chain enum, no coin_group validation in connector — only `_sanitizeChainId` character whitelist
- `dapp-input-sanitization`: Known-fields only, prototype pollution prevention, silent drop of unknown fields
- `boundary-validation`: All validation failures throw (no silent return)
- `error-handling-consistency`: ProviderError from `_sanitizeChainId` wrapped into `dcentException('param_error')`

## Test Results

| Test | Result |
|---|---|
| T-U-SYNC-00~07 (syncAccount unit) | ✅ PASS |
| T-SEC-WHITE-01~02 (sanitize security) | ✅ PASS |
| T-U-GAI-01 (getAccountInfo passthrough) | ✅ PASS |
| T-MOCK-01~02 (mock roundtrip) | ✅ PASS (69/69) |
| T-E2E-01~14 (playground account e2e) | ✅ PASS (14/14) |
| T-LINT-01 (eslint --ext .ts src/) | ✅ PASS (0 errors) |
| T-TSC-01 (yarn tsc) | ✅ PASS |
| T-BUILD-01 (yarn build) | ✅ PASS |
| T-GREP-01 (no v1 validators in configure.ts) | ✅ PASS |
| T-GREP-02 (no coin_group in tests/playground) | ✅ PASS |

Pre-existing failures on epic branch baseline (not regressions from this PR):
- `playground.smoke.test.ts`: method count drift (20 actual vs 16 expected — pre-existing)
- `playground.signtx-evm.test.ts`: same count drift (pre-existing)
- `playground.signtx-non-evm.test.ts`: xahau family not in expectedFamilies (pre-existing)

## Breaking Change

`syncAccount` parameter type changed from `SyncAccountInfo` (v1) to `V2SyncAccountInfo` (v2). `SyncAccountInfo` is no longer exported from public API. This is a **planned breaking change** under the m09-04 connector v2 cleanup epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)