### PR TITLE
[DC-2701] m09-04-17~18: playground preset + transport 3-state + 연결 단위 setTransport

### DIFF
--- a/index-v2.html
+++ b/index-v2.html
@@ -269,7 +269,7 @@
   <div id="transport-selector">
     <label for="select-transport">Transport</label>
     <select id="select-transport" title="Per-call transport hint passed to dcent.sign()">
-      <option value="">auto (default)</option>
+      <option value="">(default)</option>
       <option value="hid">hid (WebHID)</option>
       <option value="ble">ble (WebBLE)</option>
     </select>

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "babel-eslint": "^10.1.0",
     "babel-jest": "^24.8.0",
     "babel-loader": "^8.0.6",
+    "bech32": "^1.1.4",
     "buffer": "^6.0.3",
     "caver-js": "^1.8.1",
     "clean-webpack-plugin": "^3.0.0",

--- a/playground.js
+++ b/playground.js
@@ -583,9 +583,11 @@
     return state._testDcent || window.dcent
   }
 
-  // ── Transport option helper (m09-04-03) ──
-  // #select-transport 값을 읽어 dcent.sign()의 transport 옵션으로 전달할 값 반환.
-  // '' (auto/default) → undefined (옵션 미전달 = 기존 동작 유지, backward compat)
+  // ── Transport option helper (m09-04-03, DC-2701 재정의) ──
+  // #select-transport 값을 읽어 dcent.setTransport()에 넘길 연결 단위 transport 힌트 반환.
+  // (DC-2701) transport는 sign per-call이 아니라 연결 단위 속성 — Connect 시점/드롭다운 변경 시
+  // dcent.setTransport(_getTransportOption())로 1회 설정한다 (handshake first-wins).
+  // '' (auto/default) → undefined (힌트 미설정 = sdk가 default 3-state 라우팅)
   // 'hid' | 'ble' → string 그대로 반환
   // connector-chain-addition-isolation: transport는 chain과 직교, chain-specific 분기 없음.
   function _getTransportOption () {
@@ -593,7 +595,7 @@
     if (!el) return undefined
     var val = el.value
     if (val === 'hid' || val === 'ble') return val
-    return undefined // '' → undefined: 옵션 미전달 (dcent.sign이 'auto' handshake 전송)
+    return undefined // '' → undefined: setTransport 미설정 = sdk default 3-state 라우팅 (DC-2701: 'auto' 폐기)
   }
 
   // ── Build Tree DOM ──
@@ -2463,12 +2465,10 @@
         // m09-04-01/DC-2221: NEW sign schema { method, chainId, payload } — OLD { chain, payload } 금지.
         // connector-chain-addition-isolation: bsChainId는 사용자 입력 그대로 pass-through (chain enum 없음).
         // b08-01: _unwrapV1Envelope이 success → body.parameter unwrap, failure → throw로 변환.
-        // m09-04-03: transport 옵션 — #select-transport 선택값. undefined이면 미전달 (backward compat).
-        var bsTransport = _getTransportOption()
         // m09-04-15: builder(getBitcoinTransactionObject/add*)가 v2 flat wire(BitcoinWireTransaction)를
         // 직접 생성하므로 변환 없이 그대로 송신. (unsupported txType/malformed 인자는 add* 시점에 throw됨.)
+        // DC-2701: transport는 연결 단위(dcent.setTransport) — sign per-call transport 미지원.
         var bsSignInput = { method: 'signTransaction', chainId: bsChainId, payload: { keyPath: bsKeyPath, transaction: builtTx } }
-        if (bsTransport !== undefined) bsSignInput.transport = bsTransport
         dcent.sign(bsSignInput).then(_unwrapV1Envelope).then(function (result) {
           appendLog({
             method: 'signTransaction',
@@ -2547,10 +2547,8 @@
     // method는 intent literal ('signMessage'), chainId(CAIP-19)는 top-level, payload에는 chainId 제거.
     var dcent = _getDcent()
     // b08-01: _unwrapV1Envelope이 success → body.parameter unwrap, failure → throw로 변환
-    // m09-04-03: transport 옵션 — #select-transport 선택값. undefined이면 미전달 (backward compat).
-    var smTransport = _getTransportOption()
+    // DC-2701: transport는 연결 단위(dcent.setTransport) — sign per-call transport 미지원.
     var smSignInput = { method: 'signMessage', chainId: chainId, payload: { keyPath: keyPath, message: message, meta: metaObj } }
-    if (smTransport !== undefined) smSignInput.transport = smTransport
     dcent.sign(smSignInput).then(_unwrapV1Envelope).then(function (result) {
       appendLog({
         method: 'signMessage',
@@ -2615,10 +2613,8 @@
     // sdk resolveChainId가 wallet-models registry로 currency 결정.
     var dcent = _getDcent()
     // b08-01: _unwrapV1Envelope이 success → body.parameter unwrap, failure → throw로 변환
-    // m09-04-03: transport 옵션 — #select-transport 선택값. undefined이면 미전달 (backward compat).
-    var evmTransport = _getTransportOption()
+    // DC-2701: transport는 연결 단위(dcent.setTransport) — sign per-call transport 미지원.
     var evmSignInput = { method: 'signTransaction', chainId: chainId, payload: { keyPath: keyPath, transaction: txObj } }
-    if (evmTransport !== undefined) evmSignInput.transport = evmTransport
     dcent.sign(evmSignInput).then(_unwrapV1Envelope).then(function (result) {
       appendLog({
         method: 'signTransaction',
@@ -2914,9 +2910,8 @@
       _btcSetStatus('build 실패 — 결과 로그 확인', true)
       return
     }
-    var transport = _getTransportOption()
+    // DC-2701: transport는 연결 단위(dcent.setTransport) — sign per-call transport 미지원.
     var signInput = { method: 'signTransaction', chainId: chainId, payload: { keyPath: keyPath, transaction: builtTx } }
-    if (transport !== undefined) signInput.transport = transport
     var req = { chainId: chainId, keyPath: keyPath, transaction: builtTx }
     _btcSetStatus('디바이스 서명 요청 중...', false)
     dcent.sign(signInput).then(_unwrapV1Envelope).then(function (result) {
@@ -2976,10 +2971,8 @@
     // bip122/solana/xrpl/cosmos/stellar/hedera 등 비-EVM도 동일 패턴. chains.json의 chainId가 이미 CAIP-19.
     var dcent = _getDcent()
     // b08-01: _unwrapV1Envelope이 success → body.parameter unwrap, failure → throw로 변환
-    // m09-04-03: transport 옵션 — #select-transport 선택값. undefined이면 미전달 (backward compat).
-    var nonEvmTransport = _getTransportOption()
+    // DC-2701: transport는 연결 단위(dcent.setTransport) — sign per-call transport 미지원.
     var nonEvmSignInput = { method: 'signTransaction', chainId: chainId, payload: { keyPath: keyPath, transaction: txObj } }
-    if (nonEvmTransport !== undefined) nonEvmSignInput.transport = nonEvmTransport
     dcent.sign(nonEvmSignInput).then(_unwrapV1Envelope).then(function (result) {
       appendLog({
         method: 'signTransaction',

--- a/playground.js
+++ b/playground.js
@@ -1955,6 +1955,23 @@
     onDisconnect()
   })
 
+  // (DC-2701) transport 드롭다운 변경 시 연결 단위 transport 갱신.
+  // 첫 호출(popup open) 전에 설정돼 있어야 적용됨(handshake first-wins). popup이 이미 열린 뒤
+  // 변경하면 다음 연결(Disconnect 후 재연결)부터 반영.
+  var selTransport = $('select-transport')
+  if (selTransport) {
+    selTransport.addEventListener('change', function () {
+      var d = _getDcent()
+      if (d && typeof d.setTransport === 'function') {
+        try {
+          d.setTransport(_getTransportOption())
+        } catch (e) {
+          appendLog({ method: 'setTransport', request: {}, response: { error: String(e) }, latencyMs: 0 })
+        }
+      }
+    })
+  }
+
   // m08-01-05: state listener는 connect/disconnect 사이클과 독립적으로 1회 등록
   // facade가 listener를 cached하므로 reset 후에도 자동 복구 (singleton.ts 동작)
   var _stateListenerRegistered = false
@@ -1989,6 +2006,12 @@
     // m08-01-05: facade가 transport/queue를 lazy 생성 — listener는 1회만 등록.
     // popup은 첫 sign / getDeviceInfo 호출 시 lazy하게 열린다.
     _ensureStateListener()
+
+    // (DC-2701) 연결 단위 transport — 현재 드롭다운 값을 첫 호출(popup open) 전에 등록한다.
+    // sign per-call 옵션이 아닌 dcent.setTransport()로 일원화. 첫 호출이 getDeviceInfo여도 적용됨.
+    if (typeof dcent.setTransport === 'function') {
+      dcent.setTransport(_getTransportOption())
+    }
 
     // state.device는 건드리지 않는다 — [getDeviceInfo] 버튼이 단일 책임자.
     state.connected = true

--- a/playground/presets.non-evm.json
+++ b/playground/presets.non-evm.json
@@ -310,10 +310,9 @@
     "label": "Cardano ADA transfer",
     "family": "cardano",
     "applicableChainIds": [
-      "cip34:1-764824073",
-      "cip34:0-2"
+      "cip34:1-764824073"
     ],
-    "note": "Minimal ADA payment — wm cardano wire-convert 기대 dApp-wire Shape 1 (senderAddress/receiverAddress/lovelaceToSend). lovelaceToSend는 BigNumber로 변환되어 prepareTransaction 정상 진입(이전 Shape 2 {sender,recipient,amount:string}는 wire-convert.js:142 pass-through로 빠져 transaction.amount.isZero() TypeError). 별개 preset ada-cbor-signtx(Shape 0, CIP-30 CBOR)와 분리 유지. self-send(addr 동일). 실서명 검증은 짝 m09-04-13(swproxy e2e)/HW smoke.",
+    "note": "Minimal ADA payment — wm cardano wire-convert 기대 dApp-wire Shape 1 (senderAddress/receiverAddress/lovelaceToSend). lovelaceToSend는 BigNumber로 변환되어 prepareTransaction 정상 진입(이전 Shape 2 {sender,recipient,amount:string}는 wire-convert.js:142 pass-through로 빠져 transaction.amount.isZero() TypeError). 별개 preset ada-cbor-signtx(Shape 0, CIP-30 CBOR)와 분리 유지. self-send(addr 동일). 실서명 검증은 짝 m09-04-13(swproxy e2e)/HW smoke. applicableChainIds는 mainnet(cip34:1-...) 단일 한정 — fixture가 mainnet addr1 주소이므로 testnet(cip34:0-2)은 별도 addr_test1 preset 후속(단일-체인 원칙).",
     "sourceUrl": "https://cips.cardano.org/cips/cip30/",
     "transaction": {
       "senderAddress": "addr1qy2z6xu9y07vkdnx26jq06l7jqnmhv8jh2v8sth47pltfq4vnv7mhjy7p2d3zf9p9xr2hq4wv3wgdl8p2c8kpv7lgfqcmfr7p",

--- a/playground/presets.non-evm.json
+++ b/playground/presets.non-evm.json
@@ -32,7 +32,9 @@
         {
           "txType": "p2pkh",
           "amount": 990000,
-          "addresses": ["1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"]
+          "addresses": [
+            "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
+          ]
         }
       ]
     }
@@ -311,14 +313,12 @@
       "cip34:1-764824073",
       "cip34:0-2"
     ],
-    "note": "Minimal ADA payment (wm-internal TransactionCommon — Shape 2 pass-through). Edit sender/recipient before send. ✅ wm 0.7.14: cardano signTransaction slot 등록됨(cardano/index.js) — 더 이상 -32601 아님(이전 노트 stale). dApp CIP-30 CBOR signTx는 ada-cbor-signtx preset, CIP-8/95 메시지 서명은 signData(wm signDataFromWire) 참조.",
+    "note": "Minimal ADA payment — wm cardano wire-convert 기대 dApp-wire Shape 1 (senderAddress/receiverAddress/lovelaceToSend). lovelaceToSend는 BigNumber로 변환되어 prepareTransaction 정상 진입(이전 Shape 2 {sender,recipient,amount:string}는 wire-convert.js:142 pass-through로 빠져 transaction.amount.isZero() TypeError). 별개 preset ada-cbor-signtx(Shape 0, CIP-30 CBOR)와 분리 유지. self-send(addr 동일). 실서명 검증은 짝 m09-04-13(swproxy e2e)/HW smoke.",
     "sourceUrl": "https://cips.cardano.org/cips/cip30/",
     "transaction": {
-      "type": "transfer",
-      "family": "cardano",
-      "sender": "addr1qy2z6xu9y07vkdnx26jq06l7jqnmhv8jh2v8sth47pltfq4vnv7mhjy7p2d3zf9p9xr2hq4wv3wgdl8p2c8kpv7lgfqcmfr7p",
-      "recipient": "addr1qy2z6xu9y07vkdnx26jq06l7jqnmhv8jh2v8sth47pltfq4vnv7mhjy7p2d3zf9p9xr2hq4wv3wgdl8p2c8kpv7lgfqcmfr7p",
-      "amount": "1000000"
+      "senderAddress": "addr1qy2z6xu9y07vkdnx26jq06l7jqnmhv8jh2v8sth47pltfq4vnv7mhjy7p2d3zf9p9xr2hq4wv3wgdl8p2c8kpv7lgfqcmfr7p",
+      "receiverAddress": "addr1qy2z6xu9y07vkdnx26jq06l7jqnmhv8jh2v8sth47pltfq4vnv7mhjy7p2d3zf9p9xr2hq4wv3wgdl8p2c8kpv7lgfqcmfr7p",
+      "lovelaceToSend": "1000000"
     }
   },
   {

--- a/playground/presets.rest.json
+++ b/playground/presets.rest.json
@@ -319,5 +319,245 @@
       "dependsOn": null,
       "nonce": "0x0"
     }
+  },
+  {
+    "id": "coreum-transfer",
+    "label": "Coreum CORE transfer",
+    "family": "cosmos",
+    "applicableChainIds": [
+      "cosmos:coreum-mainnet-1/slip44:990"
+    ],
+    "note": "Coreum CORE transfer — wm Amino SignDoc(MsgSend). denom ucore.  from/to=core1n9a7x46880h6qrtjmvwxrlgt0yprj7029k55sc(디바이스 self-send, atom 키 재인코딩). account_number/sequence는 sign 시 wm가 live REST로 덮어씀(placeholder '0'). applicableChainIds 단일-체인(1d4201c 가드). 실서명 검증은 짝 m09-04-13.",
+    "sourceUrl": "https://github.com/cosmos/cosmjs",
+    "transaction": {
+      "chain_id": "coreum-mainnet-1",
+      "account_number": "0",
+      "sequence": "0",
+      "fee": {
+        "amount": [
+          {
+            "denom": "ucore",
+            "amount": "5000"
+          }
+        ],
+        "gas": "200000"
+      },
+      "msgs": [
+        {
+          "type": "cosmos-sdk/MsgSend",
+          "value": {
+            "from_address": "core1n9a7x46880h6qrtjmvwxrlgt0yprj7029k55sc",
+            "to_address": "core1n9a7x46880h6qrtjmvwxrlgt0yprj7029k55sc",
+            "amount": [
+              {
+                "denom": "ucore",
+                "amount": "1000000"
+              }
+            ]
+          }
+        }
+      ],
+      "memo": ""
+    }
+  },
+  {
+    "id": "coreum-testnet-transfer",
+    "label": "Coreum Testnet CORE transfer",
+    "family": "cosmos",
+    "applicableChainIds": [
+      "cosmos:coreum-testnet-1/slip44:990"
+    ],
+    "note": "Coreum Testnet CORE transfer — wm Amino SignDoc(MsgSend). denom utestcore.  from/to=testcore1n9a7x46880h6qrtjmvwxrlgt0yprj702nz0flw(디바이스 self-send, atom 키 재인코딩). account_number/sequence는 sign 시 wm가 live REST로 덮어씀(placeholder '0'). applicableChainIds 단일-체인(1d4201c 가드). 실서명 검증은 짝 m09-04-13.",
+    "sourceUrl": "https://github.com/cosmos/cosmjs",
+    "transaction": {
+      "chain_id": "coreum-testnet-1",
+      "account_number": "0",
+      "sequence": "0",
+      "fee": {
+        "amount": [
+          {
+            "denom": "utestcore",
+            "amount": "5000"
+          }
+        ],
+        "gas": "200000"
+      },
+      "msgs": [
+        {
+          "type": "cosmos-sdk/MsgSend",
+          "value": {
+            "from_address": "testcore1n9a7x46880h6qrtjmvwxrlgt0yprj702nz0flw",
+            "to_address": "testcore1n9a7x46880h6qrtjmvwxrlgt0yprj702nz0flw",
+            "amount": [
+              {
+                "denom": "utestcore",
+                "amount": "1000000"
+              }
+            ]
+          }
+        }
+      ],
+      "memo": ""
+    }
+  },
+  {
+    "id": "hippo-transfer",
+    "label": "Hippo Protocol HP transfer",
+    "family": "cosmos",
+    "applicableChainIds": [
+      "cosmos:hippo-protocol-1/slip44:118"
+    ],
+    "note": "Hippo Protocol HP transfer — wm Amino SignDoc(MsgSend). denom ahp.  from/to=hippo1n9a7x46880h6qrtjmvwxrlgt0yprj7028s65fc(디바이스 self-send, atom 키 재인코딩). account_number/sequence는 sign 시 wm가 live REST로 덮어씀(placeholder '0'). applicableChainIds 단일-체인(1d4201c 가드). 실서명 검증은 짝 m09-04-13.",
+    "sourceUrl": "https://github.com/cosmos/cosmjs",
+    "transaction": {
+      "chain_id": "hippo-protocol-1",
+      "account_number": "0",
+      "sequence": "0",
+      "fee": {
+        "amount": [
+          {
+            "denom": "ahp",
+            "amount": "5000"
+          }
+        ],
+        "gas": "200000"
+      },
+      "msgs": [
+        {
+          "type": "cosmos-sdk/MsgSend",
+          "value": {
+            "from_address": "hippo1n9a7x46880h6qrtjmvwxrlgt0yprj7028s65fc",
+            "to_address": "hippo1n9a7x46880h6qrtjmvwxrlgt0yprj7028s65fc",
+            "amount": [
+              {
+                "denom": "ahp",
+                "amount": "1000000"
+              }
+            ]
+          }
+        }
+      ],
+      "memo": ""
+    }
+  },
+  {
+    "id": "hippo-testnet-transfer",
+    "label": "Hippo Protocol Testnet HP transfer",
+    "family": "cosmos",
+    "applicableChainIds": [
+      "cosmos:hippo-protocol-testnet-1/slip44:118"
+    ],
+    "note": "Hippo Protocol Testnet HP transfer — wm Amino SignDoc(MsgSend). denom ahp.  from/to=hippo1n9a7x46880h6qrtjmvwxrlgt0yprj7028s65fc(디바이스 self-send, atom 키 재인코딩). account_number/sequence는 sign 시 wm가 live REST로 덮어씀(placeholder '0'). applicableChainIds 단일-체인(1d4201c 가드). 실서명 검증은 짝 m09-04-13.",
+    "sourceUrl": "https://github.com/cosmos/cosmjs",
+    "transaction": {
+      "chain_id": "hippo-protocol-testnet-1",
+      "account_number": "0",
+      "sequence": "0",
+      "fee": {
+        "amount": [
+          {
+            "denom": "ahp",
+            "amount": "5000"
+          }
+        ],
+        "gas": "200000"
+      },
+      "msgs": [
+        {
+          "type": "cosmos-sdk/MsgSend",
+          "value": {
+            "from_address": "hippo1n9a7x46880h6qrtjmvwxrlgt0yprj7028s65fc",
+            "to_address": "hippo1n9a7x46880h6qrtjmvwxrlgt0yprj7028s65fc",
+            "amount": [
+              {
+                "denom": "ahp",
+                "amount": "1000000"
+              }
+            ]
+          }
+        }
+      ],
+      "memo": ""
+    }
+  },
+  {
+    "id": "astar-transfer",
+    "label": "Astar ASTR transfer",
+    "family": "polkadot",
+    "applicableChainIds": [
+      "polkadot:9eb76c5184c4ab8679d2d5d819fdf90b/slip44:810"
+    ],
+    "note": "Astar ASTR transfer — wm convertTransaction은 method/args[0]/args[1]만 소비(era/specVersion/blockHash/genesisHash는 wm가 live api로 재도출하므로 preset에서 생략 — sidechain에 mainnet identity auto-fill 방지, 1d4201c 가드). args[0]=SS58(prefix 5) 자기주소 self-send(ZaGqVp3GgGJjTC3nTF45vNfx8CYkmzbJRzpjRNgqa3NQ4r3, DOT 키 재인코딩), args[1]=Planck(decimals 18, 1 token=1e18). applicableChainIds 단일-체인. 실서명 검증은 짝 m09-04-13.",
+    "sourceUrl": "https://github.com/polkadot-js/api",
+    "transaction": {
+      "method": "balances.transfer",
+      "args": [
+        "ZaGqVp3GgGJjTC3nTF45vNfx8CYkmzbJRzpjRNgqa3NQ4r3",
+        "1000000000000000000"
+      ],
+      "era": "0x00",
+      "nonce": 0,
+      "tip": 0
+    }
+  },
+  {
+    "id": "shibuya-transfer",
+    "label": "Shibuya SBY transfer",
+    "family": "polkadot",
+    "applicableChainIds": [
+      "polkadot:ddb89643205c8fe1c79afeb31f48d50f/slip44:810"
+    ],
+    "note": "Shibuya SBY transfer — wm convertTransaction은 method/args[0]/args[1]만 소비(era/specVersion/blockHash/genesisHash는 wm가 live api로 재도출하므로 preset에서 생략 — sidechain에 mainnet identity auto-fill 방지, 1d4201c 가드). args[0]=SS58(prefix 5) 자기주소 self-send(ZaGqVp3GgGJjTC3nTF45vNfx8CYkmzbJRzpjRNgqa3NQ4r3, DOT 키 재인코딩), args[1]=Planck(decimals 18, 1 token=1e18). applicableChainIds 단일-체인. 실서명 검증은 짝 m09-04-13.",
+    "sourceUrl": "https://github.com/polkadot-js/api",
+    "transaction": {
+      "method": "balances.transfer",
+      "args": [
+        "ZaGqVp3GgGJjTC3nTF45vNfx8CYkmzbJRzpjRNgqa3NQ4r3",
+        "1000000000000000000"
+      ],
+      "era": "0x00",
+      "nonce": 0,
+      "tip": 0
+    }
+  },
+  {
+    "id": "creditcoin-transfer",
+    "label": "Creditcoin CTC transfer",
+    "family": "polkadot",
+    "applicableChainIds": [
+      "polkadot:6673c7e2c2b7bde45a60c71ef70d9c7c/slip44:354"
+    ],
+    "note": "Creditcoin CTC transfer — wm convertTransaction은 method/args[0]/args[1]만 소비(era/specVersion/blockHash/genesisHash는 wm가 live api로 재도출하므로 preset에서 생략 — sidechain에 mainnet identity auto-fill 방지, 1d4201c 가드). args[0]=SS58(prefix 42) 자기주소 self-send(5FhgQCqxVSdCWdADJ9nw4GDPs5VRnZHrHEVgViApyD3Qp1TZ, DOT 키 재인코딩), args[1]=Planck(decimals 18, 1 token=1e18). applicableChainIds 단일-체인. 실서명 검증은 짝 m09-04-13.",
+    "sourceUrl": "https://github.com/polkadot-js/api",
+    "transaction": {
+      "method": "balances.transfer",
+      "args": [
+        "5FhgQCqxVSdCWdADJ9nw4GDPs5VRnZHrHEVgViApyD3Qp1TZ",
+        "1000000000000000000"
+      ],
+      "era": "0x00",
+      "nonce": 0,
+      "tip": 0
+    }
+  },
+  {
+    "id": "creditcoin-testnet-transfer",
+    "label": "Creditcoin Testnet CTC transfer",
+    "family": "polkadot",
+    "applicableChainIds": [
+      "polkadot:8a2e8af69a7892d2e60a77e3df4e0fa0/slip44:354"
+    ],
+    "note": "Creditcoin Testnet CTC transfer — wm convertTransaction은 method/args[0]/args[1]만 소비(era/specVersion/blockHash/genesisHash는 wm가 live api로 재도출하므로 preset에서 생략 — sidechain에 mainnet identity auto-fill 방지, 1d4201c 가드). args[0]=SS58(prefix 42) 자기주소 self-send(5FhgQCqxVSdCWdADJ9nw4GDPs5VRnZHrHEVgViApyD3Qp1TZ, DOT 키 재인코딩), args[1]=Planck(decimals 18, 1 token=1e18). applicableChainIds 단일-체인. 실서명 검증은 짝 m09-04-13.",
+    "sourceUrl": "https://github.com/polkadot-js/api",
+    "transaction": {
+      "method": "balances.transfer",
+      "args": [
+        "5FhgQCqxVSdCWdADJ9nw4GDPs5VRnZHrHEVgViApyD3Qp1TZ",
+        "1000000000000000000"
+      ],
+      "era": "0x00",
+      "nonce": 0,
+      "tip": 0
+    }
   }
 ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ export { ErrorCode } from './error/ErrorCode'
 export { ProviderError } from './error/ProviderError'
 
 // === 새 named exports (m08-01-01) ===
-export { setTimeOutMs, setConnectionListener, popupWindowClose } from './lifecycle'
+export { setTimeOutMs, setConnectionListener, setTransport, popupWindowClose } from './lifecycle'
 export type { ConnectionListener } from './lifecycle'
 
 export {
@@ -168,6 +168,7 @@ const dcent = {
   // lifecycle
   setTimeOutMs: lifecycle.setTimeOutMs,
   setConnectionListener: lifecycle.setConnectionListener,
+  setTransport: lifecycle.setTransport,
   popupWindowClose: lifecycle.popupWindowClose,
   // enums
   coinType,

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -19,9 +19,11 @@
 import {
   _registerStateListener,
   _setPendingTimeout,
+  _setPendingTransport,
   resetSingleton,
   type StateListener,
 } from './singleton'
+import { _sanitizeTransportOption } from './sign/_sanitizeTransportOption'
 
 /** v1 호환 connection state listener 시그니처. singleton.ts의 StateListener와 동일. */
 export type ConnectionListener = StateListener
@@ -47,6 +49,24 @@ export function setTimeOutMs (timeOutMs: number): void {
  */
 export function setConnectionListener (listener: ConnectionListener): void {
   _registerStateListener(listener)
+}
+
+/**
+ * (DC-2701) `dcent.setTransport('hid' | 'ble')` — 연결 단위 transport 힌트.
+ *
+ * popup이 처음 열릴 때(첫 호출) sdk handshake로 송신되어 picker를 해당 transport로 고정한다:
+ *   - 'hid'      → USB 전용 picker + HID 자동연결
+ *   - 'ble'      → BLE 전용 picker (자동연결 불가, gesture 필요)
+ *   - undefined  → default. HID/BLE 둘 다 + HID 자동연결
+ *
+ * transport는 기기 연결 속성이므로 sign 메서드 per-call 옵션이 아닌 연결 단위로 둔다.
+ * **첫 호출 전에** 설정해야 적용된다(handshake first-wins). popup이 이미 열린 뒤 호출하면
+ * 다음 연결(popupWindowClose 후 재연결)부터 적용. transport 미생성 시 cache.
+ *
+ * @param transport 'hid' | 'ble' | undefined. invalid 값은 _sanitizeTransportOption이 throw.
+ */
+export function setTransport (transport: 'hid' | 'ble' | undefined): void {
+  _setPendingTransport(_sanitizeTransportOption(transport))
 }
 
 /**

--- a/src/sign/_sanitizeTransportOption.ts
+++ b/src/sign/_sanitizeTransportOption.ts
@@ -24,7 +24,7 @@ import { ErrorCode } from '../error/ErrorCode'
  * dApp이 dcent.sign 옵션으로 넘긴 transport 값을 sanitize.
  *
  * - 정상: 'hid' | 'ble' → 그대로 반환
- * - 미사용: undefined → undefined (toWireTransport에서 'auto'로 변환)
+ * - 미사용: undefined → undefined (toWireTransport에서 'hid'로 변환 — DC-2701)
  * - invalid: null / '' / 그 외 string / object → throw ProviderError(INVALID_PARAMS)
  *
  * @param transport dApp이 넘긴 transport 값 (unknown)
@@ -46,12 +46,21 @@ export function _sanitizeTransportOption (
  * sanitize 결과를 wire 값으로 변환.
  * handshake message body params.transport 동봉 시점에 호출.
  *
+ * (DC-2701) 'auto' 제거 + 3-state wire — dApp이 명시한 transport를 그대로 sdk로 전달한다.
+ * sdk가 3가지를 분기한다:
+ *   - 'hid'      → USB 전용 picker + HID 자동연결 (Case A/B)
+ *   - 'ble'      → BLE 전용 picker, 자동연결 안 함 (Case B)
+ *   - undefined  → default. HID/BLE 둘 다 picker + HID 자동연결 가능 (Case A/B)
+ *
+ * 미지정(undefined)을 'hid'로 coerce하지 않는다 — default와 명시 'hid'는 picker 옵션 노출이
+ * 다르므로(default=둘 다, hid=USB only) wire에서 구분되어야 한다.
+ *
  * - 'hid' → 'hid'
  * - 'ble' → 'ble'
- * - undefined → 'auto' (sdk picker UI fallback 신호)
+ * - undefined → undefined (default)
  */
 export function toWireTransport (
   sanitized: 'hid' | 'ble' | undefined,
-): 'hid' | 'ble' | 'auto' {
-  return sanitized ?? 'auto'
+): 'hid' | 'ble' | undefined {
+  return sanitized
 }

--- a/src/sign/call.ts
+++ b/src/sign/call.ts
@@ -42,12 +42,6 @@ export interface CallInput {
    * sign 외 read-only/lifecycle 메서드(getDeviceInfo / info 등)는 chainId가 없을 수 있어 optional.
    */
   chainId?: string
-  /**
-   * (m09-04-03) sanitize된 transport 힌트. PopupTransport의 setPendingTransport로 등록되어
-   * sdk handshake params.transport로 송신됨. popup lifecycle 단위 first-wins (audit R12).
-   * undefined 시 toWireTransport에서 'auto'로 변환 → sdk picker UI fallback.
-   */
-  transport?: 'hid' | 'ble'
   params?: Record<string, unknown>
 }
 
@@ -125,16 +119,8 @@ export async function _call (input: CallInput): Promise<V1Response> {
   const transport = _getTransport()
   const id = _genId()
 
-  // (m09-04-03) transport 힌트를 다음 handshake에 전달. popup lifecycle 단위 first-wins.
-  // setPendingTransport가 있는 transport(PopupTransport)에만 적용.
-  if (
-    'setPendingTransport' in transport &&
-    typeof (transport as { setPendingTransport?: unknown }).setPendingTransport === 'function'
-  ) {
-    ;(transport as { setPendingTransport: (t: 'hid' | 'ble' | undefined) => void }).setPendingTransport(
-      input.transport,
-    )
-  }
+  // (DC-2701) transport 힌트는 연결 단위 dcent.setTransport()가 singleton에 등록한다.
+  // _call은 더 이상 per-call transport를 다루지 않는다 (handshake first-wins).
 
   try {
     const envelope = await queue.enqueue(() =>

--- a/src/sign/sign.ts
+++ b/src/sign/sign.ts
@@ -27,7 +27,6 @@
 import { _call } from './call'
 import { _sanitizeMethod, _sanitizeChainId } from './sanitize'
 import { _validateSignPayload } from './_validateSignPayload'
-import { _sanitizeTransportOption } from './_sanitizeTransportOption'
 import type { V1Response } from './types'
 
 export type { SignPayload } from './_validateSignPayload'
@@ -49,20 +48,9 @@ export interface SignInput {
    * connector 경계에서 보장되는 contract는 `_validateSignPayload` 참조.
    */
   payload: Record<string, unknown>
-  /**
-   * (m09-04-03) per-call HW transport 힌트. 명시 시 sdk popup이 picker UI를 skip하고
-   * 해당 transport로 즉시 connect한다. 미명시 시 sdk picker UI fallback.
-   *
-   * - 'hid': WebHID 강제
-   * - 'ble': WebBLE 강제
-   * - undefined: sdk picker UI (기본)
-   *
-   * 같은 popup lifecycle 내 두 번째 호출의 transport 옵션은 silent ignore (first-wins).
-   * connector-chain-addition-isolation: transport는 chain과 직교 (모든 chain 공통).
-   *
-   * @throws ProviderError(INVALID_PARAMS) — invalid 값('webusb', null, '' 등)
-   */
-  transport?: 'hid' | 'ble'
+  // (DC-2701) per-call transport 옵션 제거 — transport는 기기 연결 속성이므로 연결 단위
+  // `dcent.setTransport('hid'|'ble')`로 일원화(lifecycle). handshake first-wins라 per-call
+  // 옵션은 두 번째 호출부터 무시되어 오해를 유발했음.
 }
 
 /**
@@ -108,12 +96,10 @@ export async function sign (input: SignInput): Promise<V1Response> {
   const safeMethod = _sanitizeMethod(input.method)
   const safeChainId = _sanitizeChainId(input.chainId)
   _validateSignPayload(safeChainId, input.payload)
-  // (m09-04-03) transport 옵션 sanitize — 'hid' | 'ble' | undefined (INVALID_PARAMS throw 가능)
-  const safeTransport = _sanitizeTransportOption(input.transport)
+  // (DC-2701) transport는 연결 단위 dcent.setTransport()로 분리 — sign per-call 옵션 제거.
   return _call({
     method: safeMethod,
     chainId: safeChainId,
     params: input.payload,
-    transport: safeTransport,
   })
 }

--- a/src/transport/PopupTransport.ts
+++ b/src/transport/PopupTransport.ts
@@ -452,12 +452,13 @@ export class PopupTransport implements MessageTransport {
         timer,
       })
 
-      // (m09-04-03) pendingTransport를 toWireTransport로 변환하여 항상 동봉 (undefined → 'auto').
-      // sdk가 'auto'를 받으면 picker UI fallback, 'hid'/'ble'를 받으면 즉시 connect.
+      // (m09-04-03 / DC-2701) pendingTransport를 toWireTransport로 변환하여 동봉 (3-state).
+      // (DC-2701) 'auto' 제거 — 미지정(undefined)은 default로 sdk에 그대로 전달한다. sdk가
+      // 'hid'(USB only + auto) / 'ble'(BLE only, no auto) / undefined(둘 다 + auto)로 분기.
       const handshakeParams: {
         version: string
         clientName: string
-        transport: 'hid' | 'ble' | 'auto'
+        transport?: 'hid' | 'ble'
       } = {
         version: this.protocolVersion,
         clientName: 'connector',

--- a/tests/unit/v2/lifecycle.test.ts
+++ b/tests/unit/v2/lifecycle.test.ts
@@ -16,9 +16,12 @@
 import {
   setTimeOutMs,
   setConnectionListener,
+  setTransport,
   popupWindowClose,
 } from '../../../src/lifecycle'
 import { ensureSingleton, _resetForTesting } from '../../../src/singleton'
+import { ProviderError } from '../../../src/error/ProviderError'
+import { ErrorCode } from '../../../src/error/ErrorCode'
 
 beforeEach(() => {
   _resetForTesting()
@@ -71,6 +74,42 @@ describe('lifecycle — setTimeOutMs', () => {
 
     expect(setSpy).toHaveBeenCalledWith(8888)
     expect(setSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('lifecycle — setTransport (DC-2701, 연결 단위 transport)', () => {
+  test('T-ST-LC-01: 싱글톤 미생성 상태에서 setTransport("ble") → 다음 ensureSingleton에서 pendingTransport 적용', () => {
+    setTransport('ble')
+
+    const { transport } = ensureSingleton()
+    expect((transport as unknown as { pendingTransport: unknown }).pendingTransport).toBe('ble')
+  })
+
+  test('T-ST-LC-02: 싱글톤 생성 후 setTransport("hid") → 즉시 transport.setPendingTransport', () => {
+    const { transport } = ensureSingleton()
+    const setSpy = jest.spyOn(transport, 'setPendingTransport')
+
+    setTransport('hid')
+
+    expect(setSpy).toHaveBeenCalledWith('hid')
+  })
+
+  test('T-ST-LC-03: setTransport(undefined) → pendingTransport undefined (default)', () => {
+    setTransport('ble')
+    setTransport(undefined)
+    const { transport } = ensureSingleton()
+    expect((transport as unknown as { pendingTransport: unknown }).pendingTransport).toBeUndefined()
+  })
+
+  test('T-ST-LC-04: setTransport(invalid) → ProviderError(INVALID_PARAMS) throw', () => {
+    expect(() => setTransport('webusb' as never)).toThrow(ProviderError)
+    let caught: unknown
+    try {
+      setTransport('' as never)
+    } catch (e) {
+      caught = e
+    }
+    expect((caught as ProviderError).code).toBe(ErrorCode.INVALID_PARAMS)
   })
 })
 

--- a/tests/unit/v2/playground.signtx-non-evm.test.ts
+++ b/tests/unit/v2/playground.signtx-non-evm.test.ts
@@ -1059,3 +1059,36 @@ describe('누락보강 5 family — signTx/getAddress 도달성', () => {
     })
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T-U-CARDANO-01 (m09-04-17): ada-transfer preset — wm dApp-wire Shape 1 가드
+// 현재 Shape 2(sender/recipient/amount:string)는 wire-convert.js:142 pass-through로 빠져
+// prepareTransaction에서 transaction.amount.isZero() TypeError → Shape 1로 정정.
+// ada-cbor-signtx(Shape 0)와는 별개 preset 유지.
+// ─────────────────────────────────────────────────────────────────────────────
+it('T-U-CARDANO-01: ada-transfer가 dApp-wire Shape 1 보유 + Shape 2 키 미보유', () => {
+  const presetsPath = path.resolve(__dirname, '../../../playground/presets.non-evm.json')
+  const presets: any[] = JSON.parse(fs.readFileSync(presetsPath, 'utf8'))
+
+  const ada = presets.find((p) => p.id === 'ada-transfer')
+  expect(ada).toBeDefined()
+  expect(ada.family).toBe('cardano')
+
+  const tx = ada.transaction
+  // Shape 1 키 보유
+  expect(tx).toHaveProperty('senderAddress')
+  expect(tx).toHaveProperty('receiverAddress')
+  expect(tx).toHaveProperty('lovelaceToSend')
+  expect(typeof tx.lovelaceToSend).toBe('string')
+  // self-send
+  expect(tx.receiverAddress).toBe(tx.senderAddress)
+  // Shape 2 키 미보유 (pass-through 분기 회피 회귀 가드)
+  expect(tx).not.toHaveProperty('sender')
+  expect(tx).not.toHaveProperty('recipient')
+  expect(tx).not.toHaveProperty('amount')
+
+  // ada-cbor-signtx(Shape 0)는 별개 preset으로 유지 (병합/중복 금지)
+  const adaCbor = presets.find((p) => p.id === 'ada-cbor-signtx')
+  expect(adaCbor).toBeDefined()
+  expect(adaCbor.transaction).toHaveProperty('txCbor')
+})

--- a/tests/unit/v2/playground.signtx-non-evm.test.ts
+++ b/tests/unit/v2/playground.signtx-non-evm.test.ts
@@ -912,14 +912,17 @@ it('T-DATA-02: presets applicableChainIds ⊆ chains.json chainIds', () => {
   const chainsPath = path.resolve(__dirname, '../../../playground/chains.json')
   const evmPresetsPath = path.resolve(__dirname, '../../../playground/presets.evm.json')
   const nonEvmPresetsPath = path.resolve(__dirname, '../../../playground/presets.non-evm.json')
+  const restPresetsPath = path.resolve(__dirname, '../../../playground/presets.rest.json')
 
   const chains: any[] = JSON.parse(fs.readFileSync(chainsPath, 'utf8'))
   const evmPresets: any[] = JSON.parse(fs.readFileSync(evmPresetsPath, 'utf8'))
   const nonEvmPresets: any[] = JSON.parse(fs.readFileSync(nonEvmPresetsPath, 'utf8'))
+  // m09-04-17: rest preset(cosmos/polkadot 형제망)도 chains.json 멤버십 가드에 포함 (cross-review F4)
+  const restPresets: any[] = JSON.parse(fs.readFileSync(restPresetsPath, 'utf8'))
 
   const chainIds = new Set(chains.map((c: any) => c.chainId))
 
-  ;[...evmPresets, ...nonEvmPresets].forEach((p: any) => {
+  ;[...evmPresets, ...nonEvmPresets, ...restPresets].forEach((p: any) => {
     p.applicableChainIds.forEach((c: string) => {
       expect(chainIds.has(c)).toBe(true)
     })
@@ -1080,8 +1083,12 @@ it('T-U-CARDANO-01: ada-transfer가 dApp-wire Shape 1 보유 + Shape 2 키 미�
   expect(tx).toHaveProperty('receiverAddress')
   expect(tx).toHaveProperty('lovelaceToSend')
   expect(typeof tx.lovelaceToSend).toBe('string')
-  // self-send
+  // self-send + mainnet addr1 주소
   expect(tx.receiverAddress).toBe(tx.senderAddress)
+  expect(tx.senderAddress.startsWith('addr1')).toBe(true)
+  // 단일-체인: mainnet(cip34:1-...)만 — fixture가 mainnet addr1 주소이므로 testnet(cip34:0-2) 미포함
+  // (cross-review F1: mainnet 주소를 testnet에 노출하던 chain-incorrect scope 제거)
+  expect(ada.applicableChainIds).toEqual(['cip34:1-764824073'])
   // Shape 2 키 미보유 (pass-through 분기 회피 회귀 가드)
   expect(tx).not.toHaveProperty('sender')
   expect(tx).not.toHaveProperty('recipient')

--- a/tests/unit/v2/playground.signtx-rest.test.ts
+++ b/tests/unit/v2/playground.signtx-rest.test.ts
@@ -13,6 +13,25 @@
  */
 import * as fs from 'fs'
 import * as path from 'path'
+import * as bech32 from 'bech32'
+import { base58 } from '@scure/base'
+
+// SS58 디코드 헬퍼 (선례: tests/unit/1_bridge_test/18_coin.polkadot.sign.spec.js)
+// prefix < 64 (Astar=5, Creditcoin=42)는 ss58Length=1 → prefix=decoded[0]
+function decodeSs58(addr: string): { prefix: number; pubkey: Uint8Array } {
+  const decoded = base58.decode(addr)
+  const ss58Length = decoded[0] & 0b0100_0000 ? 2 : 1
+  const prefix = decoded[0] // <64 prefix 한정 (본 테스트 대상 5/42)
+  const pubkey = decoded.slice(ss58Length, ss58Length + 32)
+  return { prefix, pubkey }
+}
+// bech32 20-byte data(hash160) 추출
+function bech32Data(addr: string): Uint8Array {
+  return Uint8Array.from(bech32.fromWords(bech32.decode(addr).words))
+}
+function bytesEq(a: Uint8Array, b: Uint8Array): boolean {
+  return a.length === b.length && a.every((v, i) => v === b[i])
+}
 
 // ── Playground 로드 helper ──────────────────────────────────────────────────
 function loadPlayground(): void {
@@ -258,6 +277,9 @@ it('T-U-REST-COSMOS-01: cosmos 형제망 preset 필드/bech32 prefix/단일-체�
     { id: 'hippo-transfer', chainId: 'cosmos:hippo-protocol-1/slip44:118', chain_id: 'hippo-protocol-1', prefix: 'hippo', denom: 'ahp' },
     { id: 'hippo-testnet-transfer', chainId: 'cosmos:hippo-protocol-testnet-1/slip44:118', chain_id: 'hippo-protocol-testnet-1', prefix: 'hippo', denom: 'ahp' },
   ]
+  // 레퍼런스 atom-transfer의 20-byte 키 데이터 (self-key 재인코딩 invariant 검증용)
+  const atomRef = SAMPLE_REST_PRESETS.find((x: any) => x.id === 'atom-transfer')
+  const atomData = bech32Data(atomRef.transaction.msgs[0].value.from_address)
   cases.forEach((c) => {
     const p = SAMPLE_REST_PRESETS.find((x: any) => x.id === c.id)
     expect(p).toBeDefined()
@@ -268,7 +290,10 @@ it('T-U-REST-COSMOS-01: cosmos 형제망 preset 필드/bech32 prefix/단일-체�
     expect(tx.chain_id).toBe(c.chain_id)
     const msg = tx.msgs[0]
     expect(msg.type).toBe('cosmos-sdk/MsgSend')
-    expect(msg.value.from_address.startsWith(`${c.prefix}1`)).toBe(true)
+    // bech32 디코드: HRP prefix가 정확히 일치 + 20-byte 데이터가 atom 레퍼런스와 동일(self-key 재인코딩)
+    const dec = bech32.decode(msg.value.from_address)
+    expect(dec.prefix).toBe(c.prefix)
+    expect(bytesEq(bech32Data(msg.value.from_address), atomData)).toBe(true)
     // self-send
     expect(msg.value.to_address).toBe(msg.value.from_address)
     expect(msg.value.amount[0].denom).toBe(c.denom)
@@ -281,11 +306,14 @@ it('T-U-REST-COSMOS-01: cosmos 형제망 preset 필드/bech32 prefix/단일-체�
 // ─────────────────────────────────────────────────────────────────────────────
 it('T-U-REST-POLKADOT-01: polkadot 형제망 preset method/args/SS58/단일-체인(1d4201c 가드)', () => {
   const cases = [
-    { id: 'astar-transfer', chainId: 'polkadot:9eb76c5184c4ab8679d2d5d819fdf90b/slip44:810' },
-    { id: 'shibuya-transfer', chainId: 'polkadot:ddb89643205c8fe1c79afeb31f48d50f/slip44:810' },
-    { id: 'creditcoin-transfer', chainId: 'polkadot:6673c7e2c2b7bde45a60c71ef70d9c7c/slip44:354' },
-    { id: 'creditcoin-testnet-transfer', chainId: 'polkadot:8a2e8af69a7892d2e60a77e3df4e0fa0/slip44:354' },
+    { id: 'astar-transfer', chainId: 'polkadot:9eb76c5184c4ab8679d2d5d819fdf90b/slip44:810', ss58: 5 },
+    { id: 'shibuya-transfer', chainId: 'polkadot:ddb89643205c8fe1c79afeb31f48d50f/slip44:810', ss58: 5 },
+    { id: 'creditcoin-transfer', chainId: 'polkadot:6673c7e2c2b7bde45a60c71ef70d9c7c/slip44:354', ss58: 42 },
+    { id: 'creditcoin-testnet-transfer', chainId: 'polkadot:8a2e8af69a7892d2e60a77e3df4e0fa0/slip44:354', ss58: 42 },
   ]
+  // 레퍼런스 dot-transfer의 pubkey (self-key 재인코딩 invariant 검증용)
+  const dotRef = SAMPLE_REST_PRESETS.find((x: any) => x.id === 'dot-transfer')
+  const dotPubkey = decodeSs58(dotRef.transaction.args[0]).pubkey
   cases.forEach((c) => {
     const p = SAMPLE_REST_PRESETS.find((x: any) => x.id === c.id)
     expect(p).toBeDefined()
@@ -295,12 +323,13 @@ it('T-U-REST-POLKADOT-01: polkadot 형제망 preset method/args/SS58/단일-체�
     expect(tx.method).toBe('balances.transfer')
     expect(Array.isArray(tx.args)).toBe(true)
     expect(tx.args.length).toBe(2)
-    // args[0] = SS58 자기주소 (길이 46~50자 plausible SS58)
+    // args[0] = SS58 자기주소: 디코드하여 network prefix 정확 일치 + pubkey가 dot 레퍼런스와 동일(self-key 재인코딩)
     expect(typeof tx.args[0]).toBe('string')
-    expect(tx.args[0].length).toBeGreaterThanOrEqual(46)
-    expect(tx.args[0].length).toBeLessThanOrEqual(50)
-    // args[1] = Planck 금액 문자열
-    expect(typeof tx.args[1]).toBe('string')
+    const ss58 = decodeSs58(tx.args[0])
+    expect(ss58.prefix).toBe(c.ss58)
+    expect(bytesEq(ss58.pubkey, dotPubkey)).toBe(true)
+    // args[1] = Planck 금액 문자열 (decimals 18 → 1e18)
+    expect(tx.args[1]).toBe('1000000000000000000')
     // dead chain-specific 필드 생략 (sidechain에 mainnet identity auto-fill 방지)
     expect(tx).not.toHaveProperty('genesisHash')
     expect(tx).not.toHaveProperty('specVersion')

--- a/tests/unit/v2/playground.signtx-rest.test.ts
+++ b/tests/unit/v2/playground.signtx-rest.test.ts
@@ -239,3 +239,96 @@ it('T-U-REST-05: preset 부재 family chain 노드는 트리에 노출되되 tex
   expect(formFields).not.toBeNull()
   expect(formFields!.textContent).toContain('No presets available')
 })
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T-U-REST-COUNT (m09-04-17): presets.rest.json entry count ≥ 기존(12) + cosmos 4 + polkadot 4 = 20
+// 하한 단언만 — 정확-count 금지(9fe0b71이 T-U-REST-04를 정확→≥로 완화한 것을 역행하지 않도록)
+// ─────────────────────────────────────────────────────────────────────────────
+it('T-U-REST-COUNT: presets.rest.json entry count ≥ 20 (기존 12 + cosmos 4 + polkadot 4)', () => {
+  expect(SAMPLE_REST_PRESETS.length).toBeGreaterThanOrEqual(20)
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T-U-REST-COSMOS-01 (m09-04-17): cosmos 형제망 4개 preset — 필드 + bech32 prefix + 단일-체인 정합
+// ─────────────────────────────────────────────────────────────────────────────
+it('T-U-REST-COSMOS-01: cosmos 형제망 preset 필드/bech32 prefix/단일-체인(1d4201c 가드)', () => {
+  const cases = [
+    { id: 'coreum-transfer', chainId: 'cosmos:coreum-mainnet-1/slip44:990', chain_id: 'coreum-mainnet-1', prefix: 'core', denom: 'ucore' },
+    { id: 'coreum-testnet-transfer', chainId: 'cosmos:coreum-testnet-1/slip44:990', chain_id: 'coreum-testnet-1', prefix: 'testcore', denom: 'utestcore' },
+    { id: 'hippo-transfer', chainId: 'cosmos:hippo-protocol-1/slip44:118', chain_id: 'hippo-protocol-1', prefix: 'hippo', denom: 'ahp' },
+    { id: 'hippo-testnet-transfer', chainId: 'cosmos:hippo-protocol-testnet-1/slip44:118', chain_id: 'hippo-protocol-testnet-1', prefix: 'hippo', denom: 'ahp' },
+  ]
+  cases.forEach((c) => {
+    const p = SAMPLE_REST_PRESETS.find((x: any) => x.id === c.id)
+    expect(p).toBeDefined()
+    expect(p.family).toBe('cosmos')
+    // 단일-체인 한정 (mainnet payload sidechain auto-fill 회귀 방지)
+    expect(p.applicableChainIds).toEqual([c.chainId])
+    const tx = p.transaction
+    expect(tx.chain_id).toBe(c.chain_id)
+    const msg = tx.msgs[0]
+    expect(msg.type).toBe('cosmos-sdk/MsgSend')
+    expect(msg.value.from_address.startsWith(`${c.prefix}1`)).toBe(true)
+    // self-send
+    expect(msg.value.to_address).toBe(msg.value.from_address)
+    expect(msg.value.amount[0].denom).toBe(c.denom)
+    expect(tx.fee.amount[0].denom).toBe(c.denom)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T-U-REST-POLKADOT-01 (m09-04-17): polkadot 형제망 4개 preset — method/args/SS58/단일-체인 정합
+// ─────────────────────────────────────────────────────────────────────────────
+it('T-U-REST-POLKADOT-01: polkadot 형제망 preset method/args/SS58/단일-체인(1d4201c 가드)', () => {
+  const cases = [
+    { id: 'astar-transfer', chainId: 'polkadot:9eb76c5184c4ab8679d2d5d819fdf90b/slip44:810' },
+    { id: 'shibuya-transfer', chainId: 'polkadot:ddb89643205c8fe1c79afeb31f48d50f/slip44:810' },
+    { id: 'creditcoin-transfer', chainId: 'polkadot:6673c7e2c2b7bde45a60c71ef70d9c7c/slip44:354' },
+    { id: 'creditcoin-testnet-transfer', chainId: 'polkadot:8a2e8af69a7892d2e60a77e3df4e0fa0/slip44:354' },
+  ]
+  cases.forEach((c) => {
+    const p = SAMPLE_REST_PRESETS.find((x: any) => x.id === c.id)
+    expect(p).toBeDefined()
+    expect(p.family).toBe('polkadot')
+    expect(p.applicableChainIds).toEqual([c.chainId])
+    const tx = p.transaction
+    expect(tx.method).toBe('balances.transfer')
+    expect(Array.isArray(tx.args)).toBe(true)
+    expect(tx.args.length).toBe(2)
+    // args[0] = SS58 자기주소 (길이 46~50자 plausible SS58)
+    expect(typeof tx.args[0]).toBe('string')
+    expect(tx.args[0].length).toBeGreaterThanOrEqual(46)
+    expect(tx.args[0].length).toBeLessThanOrEqual(50)
+    // args[1] = Planck 금액 문자열
+    expect(typeof tx.args[1]).toBe('string')
+    // dead chain-specific 필드 생략 (sidechain에 mainnet identity auto-fill 방지)
+    expect(tx).not.toHaveProperty('genesisHash')
+    expect(tx).not.toHaveProperty('specVersion')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T-U-REST-SCOPE-01 (m09-04-17): 신규 형제망 preset 전체 — payload chain 식별자 ↔ applicableChainIds 1:1
+// (mismatch 0, commit 1d4201c 회귀 가드 — mainnet payload가 sidechain에 auto-fill되는 버그 방지)
+// ─────────────────────────────────────────────────────────────────────────────
+it('T-U-REST-SCOPE-01: 신규 cosmos/polkadot preset payload 식별자 ↔ applicableChainIds 1:1 (mismatch 0)', () => {
+  const newIds = [
+    'coreum-transfer', 'coreum-testnet-transfer', 'hippo-transfer', 'hippo-testnet-transfer',
+    'astar-transfer', 'shibuya-transfer', 'creditcoin-transfer', 'creditcoin-testnet-transfer',
+  ]
+  newIds.forEach((id) => {
+    const p = SAMPLE_REST_PRESETS.find((x: any) => x.id === id)
+    expect(p).toBeDefined()
+    // 모든 신규 preset은 단일-체인 한정
+    expect(p.applicableChainIds.length).toBe(1)
+    if (p.family === 'cosmos') {
+      // payload chain_id가 applicableChainIds의 chain 세그먼트와 1:1 일치
+      const chainSeg = p.applicableChainIds[0].split('/')[0].split(':')[1]
+      expect(p.transaction.chain_id).toBe(chainSeg)
+    } else {
+      // polkadot: chain-specific dead 필드를 생략하여 mismatch 벡터 자체를 제거
+      expect(p.transaction).not.toHaveProperty('genesisHash')
+      expect(p.transaction).not.toHaveProperty('blockHash')
+    }
+  })
+})

--- a/tests/unit/v2/sign/transport-option.test.ts
+++ b/tests/unit/v2/sign/transport-option.test.ts
@@ -6,18 +6,19 @@
  *
  * T-U-01: transport: 'hid' → handshake params.transport === 'hid'
  * T-U-02: transport: 'ble' → handshake params.transport === 'ble'
- * T-U-03: transport 미명시 → handshake params.transport === 'auto'
+ * T-U-03: transport 미명시 → handshake params.transport === 'hid' (DC-2701: 'auto' 제거, HID 기본)
  * T-U-04: transport: 'webusb' → throw ProviderError(INVALID_PARAMS)
  * T-U-05: transport: null / '' / {} → throw ProviderError(INVALID_PARAMS)
  * T-U-06: 두 번째 sign 호출 transport는 silent ignore (first-wins)
- * T-U-07: toWireTransport 단위 — 'hid'→'hid', 'ble'→'ble', undefined→'auto'
+ * T-U-07: toWireTransport 단위 — 'hid'→'hid', 'ble'→'ble', undefined→'hid' (DC-2701)
  * T-BC-01: 기존 sign({method, chainId, payload}) 호출 회귀 0
  * T-BC-02: sdk가 transport 미파싱 시 silent ignore + 정상 응답 반환 (race-safe mock)
  * T-BC-03: 구 sdk transport 힌트 수신 후 PROTOCOL_VERSION_MISMATCH(5007) 미발생 회귀
- * T-BC-04: 옵션 미명시 시 handshake params keys — transport 필드 항상 포함(==='auto')
+ * T-BC-04: 옵션 미명시 시 handshake params keys — transport 필드 항상 포함(==='hid')
  */
 
 import { sign } from '../../../../src/sign/sign'
+import { setTransport } from '../../../../src/lifecycle'
 import { _sanitizeTransportOption, toWireTransport } from '../../../../src/sign/_sanitizeTransportOption'
 import { PopupTransport } from '../../../../src/transport/PopupTransport'
 import { ensureSingleton, _resetForTesting } from '../../../../src/singleton'
@@ -124,8 +125,10 @@ describe('toWireTransport — unit', () => {
     expect(toWireTransport('ble')).toBe('ble')
   })
 
-  test('T-U-07c: undefined → "auto"', () => {
-    expect(toWireTransport(undefined)).toBe('auto')
+  test('T-U-07c: undefined → undefined (DC-2701: default 3-state — hid로 coerce 안 함)', () => {
+    // default(미지정)는 sdk에서 "HID/BLE 둘 다 picker + HID 자동연결 가능"으로 처리된다.
+    // 명시 'hid'(USB only)와 구분되어야 하므로 undefined를 'hid'로 coerce하지 않는다.
+    expect(toWireTransport(undefined)).toBeUndefined()
   })
 })
 
@@ -266,8 +269,8 @@ describe('PopupTransport — handshake transport 동봉', () => {
     expect(hsParams.transport).toBe('ble')
   })
 
-  test('T-U-03: transport 미명시 → handshake params.transport === "auto"', async () => {
-    // setPendingTransport 호출 없음 (pendingTransport === undefined → 'auto')
+  test('T-U-03: transport 미명시 → handshake params.transport === undefined (DC-2701: default 3-state)', async () => {
+    // setPendingTransport 호출 없음 (pendingTransport === undefined → default, sdk가 둘 다 picker)
     const sendPromise = transport.send({ id: 'req3', method: 'signTransaction', params: {} })
     await flushHandshake()
     dispatchResponse(DEFAULT_ORIGIN, { id: 'req3', result: { header: { version: '1.0', status: 'success' }, body: { command: 'signTransaction' } } })
@@ -278,10 +281,10 @@ describe('PopupTransport — handshake transport 동봉', () => {
     )
     expect(hsCall).toBeDefined()
     const hsParams = (hsCall![0] as { params: { transport: unknown } }).params
-    expect(hsParams.transport).toBe('auto')
+    expect(hsParams.transport).toBeUndefined()
   })
 
-  test('T-BC-04: 옵션 미명시 시 handshake params에 transport 필드 항상 포함 (==="auto")', async () => {
+  test('T-BC-04: 옵션 미명시 시 handshake params.transport === undefined (default)', async () => {
     const sendPromise = transport.send({ id: 'req4', method: 'getDeviceInfo', params: {} })
     await flushHandshake()
     dispatchResponse(DEFAULT_ORIGIN, { id: 'req4', result: { header: { version: '1.0', status: 'success' }, body: { command: 'getDeviceInfo' } } })
@@ -292,9 +295,8 @@ describe('PopupTransport — handshake transport 동봉', () => {
     )
     expect(hsCall).toBeDefined()
     const hsParams = (hsCall![0] as { params: Record<string, unknown> }).params
-    // transport 필드가 항상 존재해야 함
-    expect(Object.keys(hsParams)).toContain('transport')
-    expect(hsParams.transport).toBe('auto')
+    // (DC-2701) 미명시는 default — transport는 undefined로 동봉된다 (hid coerce 안 함)
+    expect(hsParams.transport).toBeUndefined()
     // 기존 필드들도 그대로 있어야 함
     expect(hsParams.clientName).toBe('connector')
     expect(typeof hsParams.version).toBe('string')
@@ -371,15 +373,10 @@ describe('sign() — transport option throw + backward compat', () => {
     jest.restoreAllMocks()
   })
 
-  test('T-U-04: sign({transport: "webusb"}) → throws ProviderError(INVALID_PARAMS)', async () => {
+  test('T-ST-01 (DC-2701): setTransport("webusb") → throws ProviderError(INVALID_PARAMS)', () => {
     let caught: unknown
     try {
-      await sign({
-        method: 'signTransaction',
-        chainId: 'eip155:1',
-        payload: { keyPath: "m/44'/60'/0'/0/0" },
-        transport: 'webusb' as never,
-      })
+      setTransport('webusb' as never)
     } catch (e) {
       caught = e
     }
@@ -387,20 +384,47 @@ describe('sign() — transport option throw + backward compat', () => {
     expect((caught as ProviderError).code).toBe(ErrorCode.INVALID_PARAMS)
   })
 
-  test('T-U-05-sign: sign({transport: null}) → throws ProviderError(INVALID_PARAMS)', async () => {
+  test('T-ST-02 (DC-2701): setTransport(null) → throws ProviderError(INVALID_PARAMS)', () => {
     let caught: unknown
     try {
-      await sign({
-        method: 'signTransaction',
-        chainId: 'eip155:1',
-        payload: { keyPath: "m/44'/60'/0'/0/0" },
-        transport: null as never,
-      })
+      setTransport(null as never)
     } catch (e) {
       caught = e
     }
     expect(caught instanceof ProviderError).toBe(true)
     expect((caught as ProviderError).code).toBe(ErrorCode.INVALID_PARAMS)
+  })
+
+  test('T-ST-03 (DC-2701): setTransport("ble") 후 첫 handshake에 transport="ble" 동봉', async () => {
+    setTransport('ble')
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'st03',
+      result: {
+        header: { version: '1.0', status: 'success' as const },
+        body: { command: 'signTransaction' },
+      },
+    })
+    await sign({ method: 'signTransaction', chainId: 'eip155:1', payload: { keyPath: "m/44'/60'/0'/0/0" } })
+
+    const hsCall = sendSpy.mock.calls.find(
+      (c) => (c[0] as { method?: unknown })?.method === '_handshake',
+    )
+    // handshake가 send 경로를 안 타는 mock이면 pendingTransport로 검증
+    expect((transport as unknown as { pendingTransport: unknown }).pendingTransport).toBe('ble')
+    void hsCall
+  })
+
+  test('T-ST-04 (DC-2701): setTransport("hid") → pendingTransport "hid"', () => {
+    setTransport('hid')
+    const { transport } = ensureSingleton()
+    expect((transport as unknown as { pendingTransport: unknown }).pendingTransport).toBe('hid')
+  })
+
+  test('T-ST-05 (DC-2701): setTransport(undefined) → pendingTransport undefined (default)', () => {
+    setTransport(undefined)
+    const { transport } = ensureSingleton()
+    expect((transport as unknown as { pendingTransport: unknown }).pendingTransport).toBeUndefined()
   })
 
   test('T-BC-01: 기존 sign({method, chainId, payload}) 호출 — transport 미명시 → 회귀 0', async () => {
@@ -424,8 +448,8 @@ describe('sign() — transport option throw + backward compat', () => {
     expect(resp.header.status).toBe('success')
   })
 
-  test('T-BC-02: sdk가 transport 미파싱 시 (m09-03-03 미SHIPPED) — silent ignore + 정상 응답', async () => {
-    // sdk가 transport 필드를 무시하고 정상 응답을 반환하는 시나리오 mock
+  test('T-BC-02 (DC-2701): setTransport("hid") 후 sign — sdk가 transport 무시해도 정상 응답', async () => {
+    setTransport('hid')
     const { transport } = ensureSingleton()
     jest.spyOn(transport, 'send').mockResolvedValue({
       id: 'bc02',
@@ -439,16 +463,14 @@ describe('sign() — transport option throw + backward compat', () => {
       method: 'signTransaction',
       chainId: 'eip155:1',
       payload: { keyPath: "m/44'/60'/0'/0/0" },
-      transport: 'hid',
     })
 
-    // sdk가 transport를 무시해도 정상 응답
     expect(resp.header.status).toBe('success')
     expect(resp.body.parameter?.signed_tx).toBe('0xsigned')
   })
 
-  test('T-BC-03: transport 힌트 수신 후 PROTOCOL_VERSION_MISMATCH(5007) 미발생 회귀', async () => {
-    // sdk가 transport 필드를 받고도 PROTOCOL_VERSION_MISMATCH를 던지지 않는 시나리오 mock
+  test('T-BC-03 (DC-2701): setTransport 후 PROTOCOL_VERSION_MISMATCH(5007) 미발생 회귀', async () => {
+    setTransport('hid')
     const { transport } = ensureSingleton()
     jest.spyOn(transport, 'send').mockResolvedValue({
       id: 'bc03',
@@ -458,16 +480,13 @@ describe('sign() — transport option throw + backward compat', () => {
       },
     })
 
-    // transport 힌트 있어도 정상 응답 반환 — PROTOCOL_VERSION_MISMATCH 없음
     const resp = await sign({
       method: 'signTransaction',
       chainId: 'eip155:1',
       payload: { keyPath: "m/44'/60'/0'/0/0" },
-      transport: 'hid',
     })
 
     expect(resp.header.status).toBe('success')
-    // PROTOCOL_VERSION_MISMATCH(5007) 에러가 없음을 확인
     expect(resp.body.error?.code).not.toBe('protocol_version_mismatch')
   })
 })

--- a/tests/unit/v2/sign/transport-option.test.ts
+++ b/tests/unit/v2/sign/transport-option.test.ts
@@ -395,24 +395,41 @@ describe('sign() — transport option throw + backward compat', () => {
     expect((caught as ProviderError).code).toBe(ErrorCode.INVALID_PARAMS)
   })
 
-  test('T-ST-03 (DC-2701): setTransport("ble") 후 첫 handshake에 transport="ble" 동봉', async () => {
-    setTransport('ble')
-    const { transport } = ensureSingleton()
-    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
-      id: 'st03',
-      result: {
-        header: { version: '1.0', status: 'success' as const },
-        body: { command: 'signTransaction' },
-      },
-    })
-    await sign({ method: 'signTransaction', chainId: 'eip155:1', payload: { keyPath: "m/44'/60'/0'/0/0" } })
+  test('T-ST-03 (DC-2701 F6 cross-review): setTransport("ble") → 첫 handshake params.transport === "ble" (실제 wire end-to-end)', async () => {
+    // (F6) 기존 T-ST-03은 transport.send를 통째로 mock해 실제 _handshake가 방출되지 않았고
+    // pendingTransport(내부 상태)만 검증했다 → setTransport→handshake wire seam이 미검증. 공개
+    // setTransport 진입점이 실제 handshake 메시지 params.transport로 흐르는지(singleton 포함)
+    // real postMessage 하네스(T-U-01~03 동일 패턴)로 end-to-end 검증한다.
+    jest.useFakeTimers()
+    const mockPopup = makeMockPopup()
+    const openSpy = jest
+      .spyOn(window, 'open')
+      .mockImplementation(() => mockPopup as unknown as Window)
+    // singleton popUpUrl = 'http://localhost:5173' → 같은 origin으로 handshake auto-respond.
+    installHandshakeAutoRespond(mockPopup, 'http://localhost:5173')
+    try {
+      setTransport('ble') // 공개 API → singleton _pendingTransport
+      const { transport } = ensureSingleton()
+      const sendPromise = transport.send({ id: 'st03', method: 'signTransaction', params: {} })
+      await flushHandshake()
+      dispatchResponse('http://localhost:5173', {
+        id: 'st03',
+        result: { header: { version: '1.0', status: 'success' }, body: { command: 'signTransaction' } },
+      })
+      await sendPromise
 
-    const hsCall = sendSpy.mock.calls.find(
-      (c) => (c[0] as { method?: unknown })?.method === '_handshake',
-    )
-    // handshake가 send 경로를 안 타는 mock이면 pendingTransport로 검증
-    expect((transport as unknown as { pendingTransport: unknown }).pendingTransport).toBe('ble')
-    void hsCall
+      const hsCall = mockPopup.postMessage.mock.calls.find(
+        (c: unknown[]) => (c[0] as { method?: unknown })?.method === '_handshake',
+      )
+      expect(hsCall).toBeDefined()
+      expect((hsCall![0] as { params: { transport: unknown } }).params.transport).toBe('ble')
+    } finally {
+      await ensureSingleton().transport.close().catch(() => {})
+      jest.useRealTimers()
+      openSpy.mockRestore()
+      uninstallReadyAutoRespond()
+      _resetForTesting()
+    }
   })
 
   test('T-ST-04 (DC-2701): setTransport("hid") → pendingTransport "hid"', () => {

--- a/tests/unit/v2/transport/PopupTransport.test.ts
+++ b/tests/unit/v2/transport/PopupTransport.test.ts
@@ -486,11 +486,11 @@ describe('PopupTransport', () => {
         (c: unknown[]) => (c[0] as { method?: string })?.method === '_handshake',
       )
       expect(handshakeCalls.length).toBe(1)
-      const handshakeMsg = handshakeCalls[0][0] as { id: string; method: string; params: { version: string; clientName: string; transport: string } }
+      const handshakeMsg = handshakeCalls[0][0] as { id: string; method: string; params: { version: string; clientName: string; transport: string | undefined } }
       expect(handshakeMsg.id.startsWith('_handshake_')).toBe(true)
       expect(handshakeMsg.method).toBe('_handshake')
-      // m09-04-03: transport 필드가 항상 포함됨 (옵션 미명시 시 'auto')
-      expect(handshakeMsg.params).toEqual({ version: '2.0', clientName: 'connector', transport: 'auto' })
+      // m09-04-03 / DC-2701: 옵션 미명시 → default(transport undefined). sdk가 둘 다 picker + HID auto.
+      expect(handshakeMsg.params).toEqual({ version: '2.0', clientName: 'connector', transport: undefined })
       expect(handshakeCalls[0][1]).toBe(DEFAULT_ORIGIN)
 
       await transport.close()

--- a/yarn.lock
+++ b/yarn.lock
@@ -3588,7 +3588,7 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bech32@1.1.4:
+bech32@1.1.4, bech32@^1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==


### PR DESCRIPTION
## ⚠️ 확장 스코프 (DC-2701 transport unification)

이 PR은 원래 **m09-04-17**(playground preset)였으나, 같은 DC-2701 dogfooding 중 transport 처리 일원화 작업이 **같은 epic child 브랜치에 누적**되었다 (커밋 `b5351b0`).

### 추가 objective
- **m09-04-18-connector-remove-auto-transport** (fix) — 원래 "default→'hid'"였으나 sdk 3-state 대응으로 확장.

### transport 3-state + 연결 단위 setTransport (sign per-call 제거)
- `toWireTransport` **3-state**: `default`→`undefined`(sdk가 둘 다 picker + HID auto), `'hid'`→USB only, `'ble'`→BLE only. 미지정을 `'hid'`로 coerce하지 않음(default와 명시 hid 구분).
- **`dcent.setTransport('hid'|'ble'|undefined)`** 신규 (lifecycle, connection-level). `setTimeOutMs`처럼 popup 생성 전 cache → 첫 handshake에 적용(`singleton._setPendingTransport`).
- `sign()`/`call.ts`의 **per-call transport 옵션 제거**. handshake first-wins라 두 번째 호출부터 무시되어 "매번 바꿀 수 있다"는 오해 유발 → 기기 연결 속성이므로 연결 단위로 통일.
- playground: 드롭다운 변경/Connect 시 `dcent.setTransport()` 자동 호출 (getDeviceInfo 등 첫 호출이 transport 없이 popup을 default로 여는 문제 해소).

> sdk 짝: handshake `params.transport` 3-state 라우팅 + `forcedKind` picker — `dcent-web-sdk` PR #118. (cross-repo-interface-edit)

### 검증 (확장분 포함)
- `tsc --noEmit` ✅ 0 / `jest unit-v2` ✅ **615 passed** (+setTransport 테스트) / `yarn build-dev` ✅ / `yarn lint` ✅ 0 errors.

### ⏭ 머지 전 게이트
epic 브랜치라 CI/리뷰봇 미트리거 → **local-cross-review-loop**(Codex↔Claude) 미수행 상태. ready/머지 전 수행 예정.

---

## (원본) m09-04-17 — playground preset

## Objective
`m09-04-17-playground-preset-gaps-cardano-cosmos-polkadot` · Jira **DC-2704** (Sub-task of epic DC-2223)

connector v2 playground signTransaction preset 보강 — cardano shape 오류 정정 + cosmos/polkadot 형제망 preset 8개 신규.

## 변경 요약
| 영역 | 내용 |
|---|---|
| **cardano** | `ada-transfer`를 wm-internal **Shape 2**(`sender`/`recipient`/`amount:string` → `prepareTransaction`에서 `transaction.amount.isZero()` TypeError) → dApp-wire **Shape 1**(`senderAddress`/`receiverAddress`/`lovelaceToSend`)로 정정. `ada-cbor-signtx`(Shape 0)와 분리 유지. |
| **cosmos +4** | Coreum(+testnet), Hippo(+testnet) — atom-transfer Amino SignDoc 복제 |
| **polkadot +4** | Astar, Shibuya, Creditcoin(+testnet) — dot-transfer 복제 |
| **tests +5** | T-U-CARDANO-01 / T-U-REST-COSMOS-01 / POLKADOT-01 / SCOPE-01 / COUNT(≥20) |

## 체인별 testable / node-dep
| chain | chainId | testable(shape) | sign 실행 |
|---|---|---|---|
| Coreum (+testnet) | `cosmos:coreum-mainnet-1/slip44:990` (+testnet) | ✅ Amino, denom `ucore`/`utestcore`, prefix `core`/`testcore` | node-dep (wm가 account/sequence live REST 덮어씀) |
| Hippo (+testnet) | `cosmos:hippo-protocol-1/slip44:118` (+testnet) | ✅ Amino, denom `ahp`, prefix `hippo` | node-dep |
| Astar / Shibuya | `polkadot:9eb76c…` / `polkadot:ddb896…` (slip44:810) | ✅ `balances.transfer`, SS58 `5`, dec 18 | node-dep (wm가 nonce/era/fee 재도출) |
| Creditcoin (+testnet) | `polkadot:6673c7…` / `polkadot:8a2e8a…` (slip44:354) | ✅ SS58 `42`, dec 18 | node-dep |
| ~~Binance Beacon~~ | `cosmos:Binance-Chain-Tigris/Ganges` | ❌ **제외** | wm `binance` family에 sign 경로 부재(account-only, BNB Beacon sunset) |

## 검증 (정적/shape-only)
- `npx jest --config jest.v2.config.js --runInBand` → **608/608 passed** (603 + 5 신규)
- `npx tsc --noEmit` → **exit 0** (신규 .ts 테스트 type 게이트)
- `yarn lint` → **0 errors** (19 warnings는 `scripts/extract-chains.js` pre-existing, 본 PR 미변경)
- diff: 4 files, +247/-7 (preset JSON 데이터, `pr-size-exception` 불요, < 600 LOC)

## 설계 노트
- 모든 chain 상수(denom/decimals/SS58/bech32 prefix)는 **wm 0.7.14 oracle**(sdk node_modules) 확정. self-send 주소는 device 키 재인코딩(asset-risk 0, 유효 bech32/SS58).
- 신규 preset 전부 `applicableChainIds` **단일-체인** + polkadot dead 필드(genesisHash/specVersion) 생략 — commit `1d4201c`(sidechain mainnet-payload auto-fill) 회귀 가드. `T-U-REST-SCOPE-01`이 강제.
- `T-U-REST-COUNT`은 **하한 단언(≥20)** — `9fe0b71`의 정확→≥ 완화 보존.
- 실서명 round-trip은 짝 **m09-04-13**(swproxy e2e) / HW smoke 담당 (connector wm 미설치 → 구조적으로 shape-only).
- pre-audit 2-pass 통과 (CRITICAL/WARN 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

