### PR TITLE
[DC-3000] feat(sign): chain-agnostic getPublicKey verb + playground node

### DIFF
--- a/playground.js
+++ b/playground.js
@@ -512,6 +512,8 @@
         { kind: 'method', id: 'account:syncAccount', label: 'syncAccount' },
         { kind: 'method', id: 'account:selectAddress', label: 'selectAddress' },
         { kind: 'method', id: 'account:getAddress', label: 'getAddress' },
+        // m09-04-21: chain-agnostic getPublicKey verb — Cardano payment/stake/drep 공개키 조회.
+        { kind: 'method', id: 'account:getPublicKey', label: 'getPublicKey' },
         { kind: 'method', id: 'account:getXPUB', label: 'getXPUB' },
       ],
     },
@@ -1246,6 +1248,26 @@
       //   - connector-chain-addition-isolation: chainId 문자열 pass-through만 (chain enum/switch 부재)
       //   - boundary-validation: v2 input 검증은 facade(m11-01-02 _getAddressV2)가 담당, 폼은 UI validation만
       _renderGetAddressForm()
+      return
+    }
+
+    if (name === 'getPublicKey') {
+      // m09-04-21: chain-agnostic getPublicKey 폼 — chainId(CAIP/CIP-34) + keyPath.
+      // facade(dcent.getPublicKey)가 입력 검증을 담당하므로 폼은 단순 입력만 수집한다.
+      //   - connector-chain-addition-isolation: chainId는 입력값 그대로 pass-through (chain enum 부재)
+      //   - boundary-validation: 빈 chainId/keyPath는 facade가 param_error throw
+      var gpkNote = document.createElement('p')
+      gpkNote.style.cssText = 'font-size:11px;color:#888;margin-bottom:8px;'
+      gpkNote.textContent = 'Cardano payment/stake/drep 공개키(+keyPath)를 조회합니다.'
+      formFields.appendChild(gpkNote)
+      appendFormRow('chainId', 'chainId (CAIP-19 / CIP-34)', 'input', {
+        value: 'cip34:1-764824073',
+        placeholder: 'cip34:1-764824073',
+      })
+      appendFormRow('keyPath', 'Key Path', 'input', {
+        value: "m/1852'/1815'/0'/0/0",
+        placeholder: "m/1852'/1815'/0'/0/0",
+      })
       return
     }
 
@@ -2578,6 +2600,16 @@
           return dcent.getAddress(coinTypeValue, path, prefix)
         }
 
+        if (name === 'getPublicKey') {
+          // m09-04-21: dcent.getPublicKey({chainId, keyPath}) — chain-agnostic passthrough.
+          // facade가 chainId/keyPath 검증을 담당 (빈 값이면 param_error throw).
+          var gpkChainIdEl = document.getElementById('field-chainId')
+          var gpkKeyPathEl = document.getElementById('field-keyPath')
+          var gpkChainId = gpkChainIdEl ? gpkChainIdEl.value.trim() : ''
+          var gpkKeyPath = gpkKeyPathEl ? gpkKeyPathEl.value.trim() : ''
+          return dcent.getPublicKey({ chainId: gpkChainId, keyPath: gpkKeyPath })
+        }
+
         if (name === 'getXPUB') {
           var keyEl = document.getElementById('field-key')
           var bipEl = document.getElementById('field-bip32name')
@@ -3485,6 +3517,38 @@
   }
 
   // ── Log helpers ──
+  // ── _summarizeGetPublicKeyResult (m09-04-21) ──
+  // getPublicKey 응답에서 Cardano payment/stake/drep role별 {keyPath, publicKey}를 추출한다.
+  // undefined-safe — role 항목이 없거나 필드가 누락돼도 throw하지 않고 가능한 만큼만 반환.
+  // 어떤 chain의 응답이든 동작 (chain-agnostic) — role이 없으면 빈 배열.
+  function _summarizeGetPublicKeyResult (result) {
+    var rows = []
+    if (!result || typeof result !== 'object') return rows
+    var roles = ['payment', 'stake', 'drep']
+    roles.forEach(function (role) {
+      var entry = result[role]
+      if (entry && typeof entry === 'object') {
+        rows.push({
+          role: role,
+          keyPath: typeof entry.keyPath === 'string' ? entry.keyPath : undefined,
+          publicKey: typeof entry.publicKey === 'string' ? entry.publicKey : undefined,
+        })
+      }
+    })
+    return rows
+  }
+
+  // ── _summarizeGetAddressResult (m09-04-21) ──
+  // getAddress 응답에서 address + (Cardano) rewardAddress를 추출한다.
+  // undefined-safe — rewardAddress는 Cardano 신 shape에만 존재. 다른 family는 미포함.
+  function _summarizeGetAddressResult (result) {
+    var out = {}
+    if (!result || typeof result !== 'object') return out
+    if (typeof result.address === 'string') out.address = result.address
+    if (typeof result.rewardAddress === 'string') out.rewardAddress = result.rewardAddress
+    return out
+  }
+
   function appendLog (entry) {
     var ts = new Date().toISOString()
     var logEntry = {
@@ -3530,6 +3594,34 @@
       resEl.className = 'log-json'
       resEl.textContent = JSON.stringify(entry.response, null, 2)
       entryEl.appendChild(resEl)
+    }
+
+    // m09-04-21: getPublicKey 응답 — payment/stake/drep role별 keyPath/publicKey 요약 라인.
+    if (entry.response !== undefined && entry.method === 'getPublicKey') {
+      var pkRows = _summarizeGetPublicKeyResult(entry.response)
+      if (pkRows.length > 0) {
+        var pkSummary = document.createElement('div')
+        pkSummary.className = 'log-summary pubkey-summary'
+        pkRows.forEach(function (r) {
+          var line = document.createElement('div')
+          line.className = 'pubkey-role pubkey-role-' + r.role
+          line.textContent = r.role + ': ' + (r.keyPath || '(no keyPath)') + ' → ' + (r.publicKey || '(no publicKey)')
+          pkSummary.appendChild(line)
+        })
+        entryEl.appendChild(pkSummary)
+      }
+    }
+
+    // m09-04-21: getAddress 응답 — Cardano 신 shape의 rewardAddress 라인 (undefined-safe).
+    // 다른 family 응답은 rewardAddress 부재 → 라인 미표시.
+    if (entry.response !== undefined && entry.method === 'getAddress') {
+      var addrSummary = _summarizeGetAddressResult(entry.response)
+      if (addrSummary.rewardAddress) {
+        var rwLine = document.createElement('div')
+        rwLine.className = 'log-summary reward-address-line'
+        rwLine.textContent = 'rewardAddress: ' + addrSummary.rewardAddress
+        entryEl.appendChild(rwLine)
+      }
     }
 
     if (entry.error) {
@@ -3610,6 +3702,9 @@
     validateKeyPath: validateKeyPath,
     state: state,
     appendLog: appendLog,
+    // m09-04-21: getPublicKey / getAddress 응답 요약 helper (undefined-safe, pure)
+    _summarizeGetPublicKeyResult: _summarizeGetPublicKeyResult,
+    _summarizeGetAddressResult: _summarizeGetAddressResult,
     // b08-01: envelope unwrap helper + popup-only onConnect 검증용 노출
     _unwrapV1Envelope: _unwrapV1Envelope,
     // placeholder substitution helpers — unit testable

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import {
   getDeviceInfo,
   getAccountInfo,
   getAddress,
+  getPublicKey,
   getXPUB,
   setLabel,
   syncAccount,
@@ -124,6 +125,7 @@ export {
   getDeviceInfo,
   getAccountInfo,
   getAddress,
+  getPublicKey,
   getXPUB,
   setLabel,
   syncAccount,
@@ -147,6 +149,8 @@ export type { V2SyncAccountInfo, V2AccountInfo, AccountListV2Payload } from './s
 export type { GetAddressV2Input } from './sign'
 // m09-04-09: addressFormat enum for BTC family multi-variant dispatch
 export type { AddressFormat } from './sign'
+// m09-04-21: v2 getPublicKey verb input type (chain-agnostic — Cardano payment/stake/drep)
+export type { GetPublicKeyV2Input } from './sign'
 // v1 validator helpers — dApp 표면 1:1 보존 (v1 typo `getCzonePrifix` 포함)
 export {
   isAvaliableCoinType,
@@ -189,6 +193,7 @@ const dcent = {
   getDeviceInfo,
   getAccountInfo,
   getAddress,
+  getPublicKey,
   getXPUB,
   setLabel,
   syncAccount,

--- a/src/sign/call.ts
+++ b/src/sign/call.ts
@@ -59,10 +59,35 @@ function isV1ResponseShape (result: unknown): result is V1Response {
 }
 
 /**
+ * v1 payload(parameter) deep-clone helper — mutation-isolation.
+ *
+ * shallow spread(`{ ...parameter }`)는 top-level 키만 분리하므로, parameter가
+ * **중첩 객체/배열**을 담으면(예: getPublicKey의 `{payment,stake,drep}` role 객체,
+ * getAccountInfo의 account 배열) dApp이 `parameter.payment.publicKey`를 in-place 변경할 때
+ * popup이 보낸 원본(또는 같은 객체를 재사용하는 다음 응답)에 leak된다.
+ * deep-clone으로 반환 시점에 완전히 분리한다.
+ *
+ * v1 wire payload는 postMessage(structured clone)를 거친 JSON-호환 데이터이므로
+ * structuredClone이 안전하다. 비-cloneable 값이 섞인 예외는 JSON 라운드트립으로 fallback,
+ * 그조차 실패하면 원본을 그대로 반환(가용성 우선).
+ */
+function deepClonePlain<T> (value: T): T {
+  try {
+    return structuredClone(value)
+  } catch {
+    try {
+      return JSON.parse(JSON.stringify(value)) as T
+    } catch {
+      return value
+    }
+  }
+}
+
+/**
  * raw payload를 v1 호환 success V1Response로 wrap한다.
  * popup이 v1 형식이 아닌 raw 결과를 보낸 경우의 매퍼.
  *
- * 매 호출마다 새 객체 생성 — mutation-isolation.
+ * 매 호출마다 새 객체 생성 — mutation-isolation (중첩 payload는 deep-clone).
  */
 function wrapV1Success (result: unknown, method: string): V1Response {
   const header: V1ResponseHeader = {
@@ -75,8 +100,8 @@ function wrapV1Success (result: unknown, method: string): V1Response {
   }
   if (result !== undefined && result !== null) {
     if (typeof result === 'object') {
-      // shallow copy로 호출자 mutation 격리 (mutation-isolation)
-      body.parameter = { ...(result as Record<string, unknown>) }
+      // deep clone으로 호출자 mutation 격리 — 중첩 객체/배열까지 분리 (mutation-isolation)
+      body.parameter = deepClonePlain(result as Record<string, unknown>)
     } else {
       // primitive는 'value' 키로 wrap
       body.parameter = { value: result }
@@ -97,7 +122,8 @@ function cloneV1Response (response: V1Response): V1Response {
     body: { command: response.body.command },
   }
   if (response.body.parameter) {
-    cloned.body.parameter = { ...response.body.parameter }
+    // deep clone — 중첩 객체/배열(role별 publicKey, account 목록 등)까지 호출자 mutation 격리
+    cloned.body.parameter = deepClonePlain(response.body.parameter)
   }
   if (response.body.error) {
     cloned.body.error = {

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -32,6 +32,9 @@ export { getAddress, getXPUB } from './address'
 export type { GetAddressV2Input } from './address'
 // m09-04-09: addressFormat enum type for BTC family multi-variant dispatch
 export type { AddressFormat } from './address'
+// m09-04-21: v2 getPublicKey verb (chain-agnostic) — Cardano payment/stake/drep 공개키 조회
+export { getPublicKey } from './publicKey'
+export type { GetPublicKeyV2Input } from './publicKey'
 export { setLabel, syncAccount, selectAddress } from './configure'
 // m09-04-12: SyncAccountInfo(v1) removed — V2SyncAccountInfo re-exported from ./types above
 // m09-04-15: builder가 v2 flat BitcoinWireTransaction을 직접 생성 (별도 변환 함수 없음)

--- a/src/sign/publicKey.ts
+++ b/src/sign/publicKey.ts
@@ -1,0 +1,117 @@
+/**
+ * v2 getPublicKey facade (m09-04-21)
+ *
+ * redesign(2026-06-24~25)으로 Cardano getAddress 응답이 `publicKeys` 대신 `rewardAddress`를
+ * 반환하도록 분리되면서, payment/stake/drep 공개키 조회는 별도 `getPublicKey` verb로 노출한다.
+ *
+ * getAddress v2 chainId facade(`src/sign/address.ts` `_getAddressV2`, m11-01-02)와 **동형**:
+ *   - 신규 v2 시그니처: `getPublicKey({chainId, keyPath, addressFormat?})` — chainId pass-through
+ *   - v1 overload 없음 (getPublicKey는 v2 전용 신규 verb — v1 dcent에 대응 함수 부재)
+ *   - chainId sanitize(`_sanitizeChainId`) → sdk `getPublicKey` 메서드로 forward → 응답 passthrough
+ *
+ * **chain-agnostic** (connector-chain-addition-isolation 룰 준수):
+ *   - chainId 문자열 sanitize(character whitelist)만 수행
+ *   - chain enum / chain → method 정적 매핑 / chain-prefixed switch 분기 부재
+ *   - method는 'getPublicKey' literal 고정 — chain identifier 단위 분기 0건
+ *   - 실제 chainId → 디바이스 명령 변환은 sdk(m09-03-29) + wallet-models(m02-05-65) 책임
+ *
+ * 응답 shape (sdk passthrough — connector는 변환 없음):
+ *   `{ payment: {keyPath, publicKey}, stake: {keyPath, publicKey}, drep: {keyPath, publicKey} }`
+ *   비-Cardano chain은 sdk/wm이 결정. connector는 어떤 shape이든 그대로 forward.
+ *
+ * 에러 surface (chain-agnostic 투명 전달):
+ *   - unknown chainId → sdk `INVALID_PARAMS`(-32602) → v1 'param_error'로 surface
+ *   - 비-Cardano(미지원) chain → sdk `METHOD_NOT_FOUND`(-32601) → v1 'method_not_found'로 surface
+ *   facade는 어떤 에러 코드도 가공하지 않고 `_call`의 표준 매핑(`providerErrorToV1`)을 그대로 따른다.
+ *
+ * 룰 준수:
+ *   - boundary-validation: chainId / keyPath / addressFormat 모두 검증
+ *   - error-handling-consistency: 모든 입력 검증 실패는 `dcentException(param_error)` throw (v1 호환)
+ *   - mutation-isolation: `_call`이 매 호출마다 새 V1Response 반환
+ *   - connector-chain-addition-isolation: v2 path는 chainId + addressFormat pass-through만, chain 매핑/enum 0건
+ *   - dapp-input-sanitization: v2 input은 known fields만 추출 (`_sanitizeChainId` + keyPath 검증 + `_sanitizeAddressFormat`)
+ *   - reuse-shared-utils: `_call` / `_sanitizeChainId` / `_sanitizeAddressFormat` 재사용 (getAddress facade와 동일 helper)
+ */
+
+import { _call } from './call'
+import { _sanitizeChainId } from './sanitize'
+import { _sanitizeAddressFormat, type AddressFormat } from './address'
+import { dcentException } from '../v1/dcent-exception'
+import type { V1Response } from './types'
+
+/**
+ * v2 getPublicKey 입력 — getAddress v2 시그니처와 동형(chainId-based).
+ *
+ * connector는 chainId를 sanitize 후 sdk로 pass-through만 수행한다.
+ * chainId → 디바이스 명령 변환은 sdk가 wallet-models registry로 dispatch.
+ */
+export interface GetPublicKeyV2Input {
+  /**
+   * CAIP-19 / CIP-34 chain identifier (예: Cardano mainnet).
+   * sdk가 본 값을 wallet-models registry로 dispatch에 사용.
+   */
+  chainId: string
+  /**
+   * BIP32 key path — 디바이스에서 공개키를 도출할 경로 (예: "m/1852'/1815'/0'/0/0").
+   * non-empty string 강제.
+   */
+  keyPath: string
+  /**
+   * 같은 chainId 내 여러 주소 형식이 있는 체인에서 어느 variant를 선택할지 명시.
+   * getAddress facade의 addressFormat과 동일 enum (generic passthrough 필드).
+   * 누락 시 sdk가 chain별 default 사용.
+   */
+  addressFormat?: AddressFormat
+}
+
+/**
+ * v2 dcent.getPublicKey — chainId 시그니처 (m09-04-21).
+ *
+ * getAddress v2 facade(`_getAddressV2`)와 동형. v1 overload는 없다 (신규 v2 전용 verb).
+ *
+ * connector-chain-addition-isolation 룰 준수:
+ *   - chainId 문자열 sanitize만 수행 (character whitelist)
+ *   - chain enum / chain → method 매핑 / chain-prefixed switch 분기 부재
+ *   - method는 'getPublicKey' literal 고정 — chain identifier 단위 분기 0건
+ *
+ * @example
+ *   await dcent.getPublicKey({
+ *     chainId: 'cip34:1-764824073',
+ *     keyPath: "m/1852'/1815'/0'/0/0",
+ *   })
+ *   // → { payment: {keyPath, publicKey}, stake: {...}, drep: {...} }
+ *
+ * @param input { chainId, keyPath, addressFormat? }
+ * @returns V1Response (v1 호환 응답 shape — body.parameter에 role별 공개키)
+ * @throws V1Exception(param_error) — chainId / keyPath / addressFormat 검증 실패 시
+ */
+export async function getPublicKey (input: GetPublicKeyV2Input): Promise<V1Response> {
+  // chainId sanitize는 ProviderError로 throw — v1 호환을 위해 catch + dcentException re-throw.
+  // (getAddress _getAddressV2와 동일 패턴 — dApp의 .catch(err => err.body?.error?.code) 호환)
+  let safeChainId: string
+  try {
+    safeChainId = _sanitizeChainId(input.chainId)
+  } catch {
+    throw dcentException('param_error', 'chainId required')
+  }
+
+  if (typeof input.keyPath !== 'string' || input.keyPath.length === 0) {
+    throw dcentException('param_error', 'keyPath required')
+  }
+
+  // addressFormat sanitize — enum whitelist 검증 (getAddress facade와 동일 helper 재사용).
+  // undefined/null → 미포함. 잘못된 값 → param_error throw.
+  const safeAddressFormat = _sanitizeAddressFormat(input.addressFormat)
+
+  // chainId pass-through — connector는 method dispatch / chain 분기 0건.
+  // sdk가 chainId를 보고 family-specific handler로 dispatch (m09-03-29 책임).
+  const params: Record<string, unknown> = {
+    chainId: safeChainId,
+    keyPath: input.keyPath,
+  }
+  if (safeAddressFormat !== undefined) {
+    params.addressFormat = safeAddressFormat
+  }
+
+  return _call({ method: 'getPublicKey', chainId: safeChainId, params })
+}

--- a/src/sign/publicKey.ts
+++ b/src/sign/publicKey.ts
@@ -86,6 +86,17 @@ export interface GetPublicKeyV2Input {
  * @throws V1Exception(param_error) — chainId / keyPath / addressFormat 검증 실패 시
  */
 export async function getPublicKey (input: GetPublicKeyV2Input): Promise<V1Response> {
+  // boundary-validation: input이 non-null plain object인지 먼저 가드.
+  // undefined/null/array/primitive를 그대로 deref하면 raw TypeError가 나서
+  // error-handling-consistency(모든 실패는 dcentException) 계약이 깨진다.
+  // getAddress facade가 array를 명시 거부하는 것과 동일한 방어 (typeof [] === 'object' 함정 포함).
+  if (input === null || typeof input !== 'object' || Array.isArray(input)) {
+    throw dcentException(
+      'param_error',
+      'getPublicKey: input must be an object { chainId, keyPath }',
+    )
+  }
+
   // chainId sanitize는 ProviderError로 throw — v1 호환을 위해 catch + dcentException re-throw.
   // (getAddress _getAddressV2와 동일 패턴 — dApp의 .catch(err => err.body?.error?.code) 호환)
   let safeChainId: string

--- a/tests/unit/v2/playground.getpublickey.test.ts
+++ b/tests/unit/v2/playground.getpublickey.test.ts
@@ -1,0 +1,183 @@
+/**
+ * playground.getpublickey.test.ts — getPublicKey 노드 + getAddress rewardAddress 렌더 (m09-04-21)
+ *
+ * jsdom 환경에서 index-v2.html + playground.js 로드 후
+ * getPublicKey 트리 노드 / 폼 / 결과 요약 렌더, getAddress rewardAddress 라인을 검증.
+ *
+ *   T-CONN-PG-03: playground getPublicKey 노드 — 트리 존재 + 폼(chainId/keyPath) +
+ *                 결과 요약(payment/stake/drep 각 keyPath+publicKey) 렌더.
+ *   T-CONN-PG-04: getAddress 결과가 Cardano(rewardAddress 보유)면 rewardAddress 라인 표시,
+ *                 비-Cardano(rewardAddress 부재)면 라인 미표시 (undefined-safe).
+ */
+import * as fs from 'fs'
+import * as path from 'path'
+
+function loadPlayground(): void {
+  const html = fs.readFileSync(
+    path.resolve(__dirname, '../../../index-v2.html'),
+    'utf8'
+  )
+  document.documentElement.innerHTML = html
+
+  ;(window as any).PopupTransport = function () {
+    return {
+      send: jest.fn().mockResolvedValue({ id: 'stub-id', result: {} }),
+      on: jest.fn(),
+      off: jest.fn(),
+      close: jest.fn().mockResolvedValue(undefined),
+    }
+  }
+  ;(window as any).SerialRequestQueue = function () {
+    return {
+      enqueue: jest.fn(function (task: any) { return task() }),
+      size: jest.fn().mockReturnValue(0),
+      clear: jest.fn(),
+    }
+  }
+  ;(window as any).ProviderError = class ProviderError extends Error {
+    code: number
+    constructor(code: number, message: string) {
+      super(message)
+      this.code = code
+    }
+  }
+
+  const playgroundSrc = fs.readFileSync(
+    path.resolve(__dirname, '../../../playground.js'),
+    'utf8'
+  )
+  // eslint-disable-next-line no-new-func
+  new Function(playgroundSrc)()
+}
+
+beforeEach(() => {
+  loadPlayground()
+})
+
+afterEach(() => {
+  document.documentElement.innerHTML = ''
+  delete (window as any)._playgroundTestAPI
+  delete (window as any).PopupTransport
+  delete (window as any).SerialRequestQueue
+  delete (window as any).ProviderError
+})
+
+const CARDANO_PUBKEY_RESULT = {
+  payment: { keyPath: "m/1852'/1815'/0'/0/0", publicKey: 'aa11' },
+  stake: { keyPath: "m/1852'/1815'/0'/2/0", publicKey: 'bb22' },
+  drep: { keyPath: "m/1852'/1815'/0'/3/0", publicKey: 'cc33' },
+}
+
+// ─────────────────────────────────────────────────────────
+// T-CONN-PG-03: getPublicKey 노드 — 트리 + 폼 + 결과 요약
+// ─────────────────────────────────────────────────────────
+describe('T-CONN-PG-03: getPublicKey 노드 렌더', () => {
+  it('트리에 account:getPublicKey method 노드가 존재한다', () => {
+    const api = (window as any)._playgroundTestAPI
+    expect(api).toBeDefined()
+
+    function find(items: any[]): any {
+      for (const item of items) {
+        if (item.kind === 'method' && item.id === 'account:getPublicKey') return item
+        if (item.items) {
+          const hit = find(item.items)
+          if (hit) return hit
+        }
+      }
+      return null
+    }
+    const node = find(api.TREE)
+    expect(node).toBeTruthy()
+    expect(node.label).toBe('getPublicKey')
+
+    // DOM 트리 노드로도 렌더링된다
+    const domNode = document.querySelector('[data-method-id="account:getPublicKey"]')
+    expect(domNode).toBeTruthy()
+  })
+
+  it('결과 요약 helper가 payment/stake/drep 각 keyPath+publicKey를 추출한다 (undefined-safe)', () => {
+    const api = (window as any)._playgroundTestAPI
+    const rows = api._summarizeGetPublicKeyResult(CARDANO_PUBKEY_RESULT)
+    expect(rows).toHaveLength(3)
+    expect(rows[0]).toEqual({ role: 'payment', keyPath: "m/1852'/1815'/0'/0/0", publicKey: 'aa11' })
+    expect(rows[1]).toEqual({ role: 'stake', keyPath: "m/1852'/1815'/0'/2/0", publicKey: 'bb22' })
+    expect(rows[2]).toEqual({ role: 'drep', keyPath: "m/1852'/1815'/0'/3/0", publicKey: 'cc33' })
+
+    // undefined-safe: 빈/부분 입력에도 throw 없이 가능한 만큼만 반환
+    expect(api._summarizeGetPublicKeyResult(undefined)).toEqual([])
+    expect(api._summarizeGetPublicKeyResult({})).toEqual([])
+    expect(api._summarizeGetPublicKeyResult({ payment: { keyPath: "m/1'" } })).toEqual([
+      { role: 'payment', keyPath: "m/1'", publicKey: undefined },
+    ])
+  })
+
+  it('appendLog(getPublicKey)가 payment/stake/drep keyPath+publicKey 요약 라인을 렌더한다', () => {
+    const api = (window as any)._playgroundTestAPI
+    api.appendLog({ method: 'getPublicKey', request: {}, response: CARDANO_PUBKEY_RESULT })
+
+    const summary = document.querySelector('.pubkey-summary')
+    expect(summary).toBeTruthy()
+    const roleLines = document.querySelectorAll('.pubkey-summary .pubkey-role')
+    expect(roleLines.length).toBe(3)
+
+    const text = summary!.textContent || ''
+    // 번들(role) + keyPath + publicKey가 표시됨
+    expect(text).toContain('payment')
+    expect(text).toContain("m/1852'/1815'/0'/0/0")
+    expect(text).toContain('aa11')
+    expect(text).toContain('stake')
+    expect(text).toContain('bb22')
+    expect(text).toContain('drep')
+    expect(text).toContain('cc33')
+  })
+})
+
+// ─────────────────────────────────────────────────────────
+// T-CONN-PG-04: getAddress rewardAddress 라인 (Cardano 한정)
+// ─────────────────────────────────────────────────────────
+describe('T-CONN-PG-04: getAddress rewardAddress 렌더', () => {
+  it('요약 helper가 rewardAddress를 추출한다 (있을 때만)', () => {
+    const api = (window as any)._playgroundTestAPI
+    expect(api._summarizeGetAddressResult({ address: 'addr1...', rewardAddress: 'stake1...' }))
+      .toEqual({ address: 'addr1...', rewardAddress: 'stake1...' })
+    // 비-Cardano: rewardAddress 부재 → 미포함 (undefined-safe)
+    expect(api._summarizeGetAddressResult({ address: '0xabc' })).toEqual({ address: '0xabc' })
+    expect(api._summarizeGetAddressResult(undefined)).toEqual({})
+  })
+
+  it('appendLog(getAddress) — Cardano 응답이면 rewardAddress 라인 표시', () => {
+    const api = (window as any)._playgroundTestAPI
+    api.appendLog({
+      method: 'getAddress',
+      request: {},
+      response: { address: 'addr1qxy...', rewardAddress: 'stake1uxy...' },
+    })
+
+    const rwLine = document.querySelector('.reward-address-line')
+    expect(rwLine).toBeTruthy()
+    expect(rwLine!.textContent).toContain('rewardAddress')
+    expect(rwLine!.textContent).toContain('stake1uxy...')
+  })
+
+  it('appendLog(getAddress) — 비-Cardano 응답(rewardAddress 부재)이면 라인 미표시', () => {
+    const api = (window as any)._playgroundTestAPI
+    api.appendLog({
+      method: 'getAddress',
+      request: {},
+      response: { address: '0xabc123' },
+    })
+
+    expect(document.querySelector('.reward-address-line')).toBeNull()
+  })
+
+  it('appendLog(getAddress) — rewardAddress가 string이 아니면 라인 미표시 (undefined-safe)', () => {
+    const api = (window as any)._playgroundTestAPI
+    api.appendLog({
+      method: 'getAddress',
+      request: {},
+      response: { address: '0xabc', rewardAddress: 12345 as any },
+    })
+
+    expect(document.querySelector('.reward-address-line')).toBeNull()
+  })
+})

--- a/tests/unit/v2/playground.getpublickey.test.ts
+++ b/tests/unit/v2/playground.getpublickey.test.ts
@@ -68,6 +68,18 @@ const CARDANO_PUBKEY_RESULT = {
   drep: { keyPath: "m/1852'/1815'/0'/3/0", publicKey: 'cc33' },
 }
 
+// facade-shaped mock dcent — getPublicKey가 v1 success envelope을 resolve
+function makeMockDcent(getPublicKeyImpl?: jest.Mock) {
+  return {
+    getPublicKey:
+      getPublicKeyImpl ||
+      jest.fn().mockResolvedValue({ header: { status: 'success' }, body: { parameter: CARDANO_PUBKEY_RESULT } }),
+    getDeviceInfo: jest.fn().mockResolvedValue({ header: { status: 'success' }, body: { parameter: {} } }),
+    popupWindowClose: jest.fn(),
+    setConnectionListener: jest.fn(),
+  }
+}
+
 // ─────────────────────────────────────────────────────────
 // T-CONN-PG-03: getPublicKey 노드 — 트리 + 폼 + 결과 요약
 // ─────────────────────────────────────────────────────────
@@ -93,6 +105,40 @@ describe('T-CONN-PG-03: getPublicKey 노드 렌더', () => {
     // DOM 트리 노드로도 렌더링된다
     const domNode = document.querySelector('[data-method-id="account:getPublicKey"]')
     expect(domNode).toBeTruthy()
+  })
+
+  it('노드 선택 시 chainId/keyPath 폼 필드가 default 값으로 렌더된다', () => {
+    const node = document.querySelector('[data-method-id="account:getPublicKey"]') as HTMLElement
+    node.click()
+
+    const chainIdEl = document.getElementById('field-chainId') as HTMLInputElement
+    const keyPathEl = document.getElementById('field-keyPath') as HTMLInputElement
+    expect(chainIdEl).toBeTruthy()
+    expect(keyPathEl).toBeTruthy()
+    expect(chainIdEl.value).toBe('cip34:1-764824073')
+    expect(keyPathEl.value).toBe("m/1852'/1815'/0'/0/0")
+  })
+
+  it('Send 클릭 시 dcent.getPublicKey({chainId, keyPath})로 dispatch된다', () => {
+    const api = (window as any)._playgroundTestAPI
+    const mockGetPublicKey = jest
+      .fn()
+      .mockResolvedValue({ header: { status: 'success' }, body: { parameter: CARDANO_PUBKEY_RESULT } })
+
+    const node = document.querySelector('[data-method-id="account:getPublicKey"]') as HTMLElement
+    node.click()
+    api.simulateConnect(makeMockDcent(mockGetPublicKey), null, { model: 'Bio', firmware: '3.0' })
+
+    // 폼 값 수정 (default와 다른 값으로 — 실제 입력 반영 검증)
+    ;(document.getElementById('field-chainId') as HTMLInputElement).value = 'cip34:1-764824073'
+    ;(document.getElementById('field-keyPath') as HTMLInputElement).value = "m/1852'/1815'/0'/2/0"
+    ;(document.getElementById('btn-send') as HTMLButtonElement).click()
+
+    expect(mockGetPublicKey).toHaveBeenCalledTimes(1)
+    expect(mockGetPublicKey).toHaveBeenCalledWith({
+      chainId: 'cip34:1-764824073',
+      keyPath: "m/1852'/1815'/0'/2/0",
+    })
   })
 
   it('결과 요약 helper가 payment/stake/drep 각 keyPath+publicKey를 추출한다 (undefined-safe)', () => {

--- a/tests/unit/v2/playground.signtx-evm.test.ts
+++ b/tests/unit/v2/playground.signtx-evm.test.ts
@@ -128,8 +128,9 @@ it('T-U-EVM-01: simulateEvmLoad 후 EVM 체인 노드가 TREE에 추가된다', 
   // m11-01-03: Bitcoin Tx Builder 4 method 추가 → 16
   // DC-2309 (b11-01): sign message 비-EVM family 3종(sol/tron/dot) + Astar 추가 → 4→8 → 20
   // m10-01-11/12/14: signMessage Stellar(1) + signData Cardano(1) + signAuthEntry Stellar(1) → 23
+  // m09-04-21: Account API에 getPublicKey(1) 추가 → 24
   const beforeCount = api.countMethodNodes()
-  expect(beforeCount).toBe(23)
+  expect(beforeCount).toBe(24)
 
   // EVM 체인 로드 시뮬레이션
   api.simulateEvmLoad(SAMPLE_CHAINS, SAMPLE_PRESETS)

--- a/tests/unit/v2/playground.smoke.test.ts
+++ b/tests/unit/v2/playground.smoke.test.ts
@@ -71,7 +71,7 @@ afterEach(() => {
 // T-U-01: 트리 DOM 빌더 — TREE 선언적 객체에서 expected node 개수
 // m11-01-01: Account/Device 그룹 8 method + signMessage 4 method = 12 (기존 5에서 변경)
 // ─────────────────────────────────────────────────────────
-it('T-U-01: 트리 DOM에 23개 non-placeholder method node가 렌더링된다', () => {
+it('T-U-01: 트리 DOM에 24개 non-placeholder method node가 렌더링된다', () => {
   const api = (window as any)._playgroundTestAPI
   expect(api).toBeDefined()
 
@@ -80,12 +80,13 @@ it('T-U-01: 트리 DOM에 23개 non-placeholder method node가 렌더링된다',
   // m11-01-03: Bitcoin Tx Builder(4) 추가 → 16
   // DC-2309 (b11-01): signMessage 비-EVM family 3종(sol/tron/dot) + Astar → 4→8 → 20
   // m10-01-11/12/14: signMessage Stellar(1) + signData Cardano(1) + signAuthEntry Stellar(1) → 23
+  // m09-04-21: Account API에 getPublicKey(1) 추가 → 24
   const count = api.countMethodNodes()
-  expect(count).toBe(23)
+  expect(count).toBe(24)
 
-  // DOM에는 placeholder 포함 24개 .tree-item (EVM 체인 로드 전 placeholder 1개 추가)
+  // DOM에는 placeholder 포함 25개 .tree-item (EVM 체인 로드 전 placeholder 1개 추가)
   const domItems = document.querySelectorAll('.tree-item')
-  expect(domItems.length).toBe(24) // 23 non-placeholder + 1 EVM loading placeholder
+  expect(domItems.length).toBe(25) // 24 non-placeholder + 1 EVM loading placeholder
 })
 
 // ─────────────────────────────────────────────────────────

--- a/tests/unit/v2/sign/publicKey.test.ts
+++ b/tests/unit/v2/sign/publicKey.test.ts
@@ -1,0 +1,220 @@
+/**
+ * getPublicKey v2 facade 단위 테스트 (m09-04-21)
+ *
+ * getAddress v2 chainId facade(address.test.ts)와 동형. mock transport(`transport.send`)로
+ * sdk를 대체하여 connector facade의 송신 envelope + 응답/에러 passthrough를 검증한다.
+ *
+ *   T-CONN-GP-01: getPublicKey({chainId, keyPath}) → method='getPublicKey' + chainId 필드 +
+ *                 params={chainId, keyPath} 송신 + 응답 {payment,stake,drep} passthrough.
+ *   T-CONN-GP-02: chain-agnostic — 서로 다른 chainId 다수에 대해 모두 method='getPublicKey'
+ *                 (chain enum / PREFIX_TO_METHOD / chain-prefixed switch 부재).
+ *   T-CONN-GP-05: sdk INVALID_PARAMS(-32602) → v1 'param_error'로 투명 surface (unknown chainId).
+ *   T-CONN-GP-06: sdk METHOD_NOT_FOUND(-32601) → v1 'method_not_found'로 투명 surface
+ *                 (유효한 비-Cardano chainId — facade가 모든 에러 코드를 가공 없이 전달).
+ *   + 입력 검증(boundary-validation / dapp-input-sanitization):
+ *     chainId 빈 문자열 / keyPath 누락 / addressFormat enum / prototype-pollution.
+ *
+ * NOTE: getPublicKey는 async function이므로 sync `throw`도 reject로 변환된다.
+ *       에러 검증은 `await expect(...).rejects.toEqual(...)` 패턴 사용.
+ */
+
+import { getPublicKey, type GetPublicKeyV2Input } from '../../../../src/sign/publicKey'
+import { ensureSingleton, _resetForTesting } from '../../../../src/singleton'
+
+beforeEach(() => {
+  _resetForTesting()
+})
+
+afterAll(() => {
+  _resetForTesting()
+})
+
+const expectV1Error = (code: string, message?: string) =>
+  expect.objectContaining({
+    body: {
+      error: message !== undefined ? { code, message } : expect.objectContaining({ code }),
+    },
+  })
+
+// Cardano getPublicKey 응답 fixture — sdk(m09-03-29) passthrough shape
+const CARDANO_PUBKEY_RESULT = {
+  payment: { keyPath: "m/1852'/1815'/0'/0/0", publicKey: 'aa11' },
+  stake: { keyPath: "m/1852'/1815'/0'/2/0", publicKey: 'bb22' },
+  drep: { keyPath: "m/1852'/1815'/0'/3/0", publicKey: 'cc33' },
+}
+
+describe('getPublicKey v2 facade — m09-04-21', () => {
+  test('T-CONN-GP-01: {chainId, keyPath} → method=getPublicKey + params 송신 + 응답 passthrough', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'gp-r1',
+      result: CARDANO_PUBKEY_RESULT,
+    })
+
+    const resp = await getPublicKey({
+      chainId: 'cip34:1-764824073',
+      keyPath: "m/1852'/1815'/0'/0/0",
+    })
+
+    expect(sendSpy).toHaveBeenCalledTimes(1)
+    const callArg = sendSpy.mock.calls[0][0] as any
+    expect(callArg.method).toBe('getPublicKey')
+    expect(callArg.chainId).toBe('cip34:1-764824073')
+    expect(callArg.params).toEqual({
+      chainId: 'cip34:1-764824073',
+      keyPath: "m/1852'/1815'/0'/0/0",
+    })
+    // getAddress v1 path의 흔적(coinType/path/optionParam)이 섞이지 않는지 가드
+    expect(callArg.params).not.toHaveProperty('coinType')
+    expect(callArg.params).not.toHaveProperty('path')
+
+    // 응답 passthrough — role별 {keyPath, publicKey} 그대로 surface (connector 변환 없음)
+    expect(resp.header.status).toBe('success')
+    const param = resp.body.parameter as any
+    expect(param.payment).toEqual({ keyPath: "m/1852'/1815'/0'/0/0", publicKey: 'aa11' })
+    expect(param.stake).toEqual({ keyPath: "m/1852'/1815'/0'/2/0", publicKey: 'bb22' })
+    expect(param.drep).toEqual({ keyPath: "m/1852'/1815'/0'/3/0", publicKey: 'cc33' })
+  })
+
+  test('T-CONN-GP-01.b: addressFormat 지정 시 params에 동행', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'gp-r1b',
+      result: CARDANO_PUBKEY_RESULT,
+    })
+
+    await getPublicKey({
+      chainId: 'cip34:1-764824073',
+      keyPath: "m/1852'/1815'/0'/0/0",
+      addressFormat: 'legacy',
+    })
+
+    const callArg = sendSpy.mock.calls[0][0] as any
+    expect(callArg.params.addressFormat).toBe('legacy')
+  })
+
+  test('T-CONN-GP-01.c: addressFormat 미지정 시 params에 addressFormat 필드 부재', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'gp-r1c',
+      result: CARDANO_PUBKEY_RESULT,
+    })
+
+    await getPublicKey({ chainId: 'cip34:1-764824073', keyPath: "m/1852'/1815'/0'/0/0" })
+
+    const callArg = sendSpy.mock.calls[0][0] as any
+    expect(callArg.params).not.toHaveProperty('addressFormat')
+  })
+
+  test('T-CONN-GP-02: chain-agnostic — 서로 다른 chainId 모두 method=getPublicKey', async () => {
+    const { transport } = ensureSingleton()
+    const sendSpy = jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'gp-iso',
+      result: CARDANO_PUBKEY_RESULT,
+    })
+
+    const chainIds = [
+      'cip34:1-764824073',
+      'eip155:1/slip44:60',
+      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+    ]
+    for (const chainId of chainIds) {
+      await getPublicKey({ chainId, keyPath: "m/44'/0'/0'/0/0" })
+    }
+
+    expect(sendSpy).toHaveBeenCalledTimes(chainIds.length)
+    for (let i = 0; i < chainIds.length; i++) {
+      // chain enum / PREFIX_TO_METHOD / chain-prefixed switch 추가 없이 chain-agnostic
+      expect(sendSpy.mock.calls[i][0].method).toBe('getPublicKey')
+      expect(sendSpy.mock.calls[i][0].chainId).toBe(chainIds[i])
+    }
+  })
+
+  test('T-CONN-GP-05: sdk INVALID_PARAMS(-32602) → v1 param_error로 투명 surface', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'gp-err-32602',
+      error: { code: -32602, message: 'unknown chainId' },
+    })
+
+    const resp = await getPublicKey({
+      chainId: 'cip34:9-unknown',
+      keyPath: "m/1852'/1815'/0'/0/0",
+    })
+
+    // facade는 에러를 가공하지 않음 — _call 표준 매핑(-32602 → 'param_error')만 거침
+    expect(resp.header.status).toBe('failure')
+    expect(resp.body.error?.code).toBe('param_error')
+    expect(resp.body.error?.message).toBe('unknown chainId')
+  })
+
+  test('T-CONN-GP-06: sdk METHOD_NOT_FOUND(-32601) → v1 method_not_found로 투명 surface', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'gp-err-32601',
+      error: { code: -32601, message: 'getPublicKey not supported for this chain' },
+    })
+
+    // 유효한(whitelist 통과) 비-Cardano chainId — facade는 그대로 forward, sdk가 -32601 반환
+    const resp = await getPublicKey({
+      chainId: 'eip155:1/slip44:60',
+      keyPath: "m/44'/60'/0'/0/0",
+    })
+
+    expect(resp.header.status).toBe('failure')
+    expect(resp.body.error?.code).toBe('method_not_found')
+    expect(resp.body.error?.message).toBe('getPublicKey not supported for this chain')
+  })
+})
+
+describe('getPublicKey v2 facade — 입력 검증 (boundary-validation / dapp-input-sanitization)', () => {
+  test('chainId 빈 문자열 → param_error reject', async () => {
+    await expect(
+      getPublicKey({ chainId: '', keyPath: "m/1852'/1815'/0'/0/0" }),
+    ).rejects.toEqual(expectV1Error('param_error', 'chainId required'))
+  })
+
+  test('chainId가 string이 아님 → param_error reject', async () => {
+    await expect(
+      getPublicKey({ chainId: 123 as unknown as string, keyPath: "m/1852'/1815'/0'/0/0" }),
+    ).rejects.toEqual(expectV1Error('param_error', 'chainId required'))
+  })
+
+  test('chainId whitelist 위반(특수문자) → param_error reject', async () => {
+    await expect(
+      getPublicKey({ chainId: 'cip34:1@#$', keyPath: "m/1852'/1815'/0'/0/0" }),
+    ).rejects.toEqual(expectV1Error('param_error', 'chainId required'))
+  })
+
+  test('keyPath 누락 → param_error reject', async () => {
+    await expect(
+      getPublicKey({ chainId: 'cip34:1-764824073' } as unknown as GetPublicKeyV2Input),
+    ).rejects.toEqual(expectV1Error('param_error', 'keyPath required'))
+  })
+
+  test('keyPath 빈 문자열 → param_error reject', async () => {
+    await expect(
+      getPublicKey({ chainId: 'cip34:1-764824073', keyPath: '' }),
+    ).rejects.toEqual(expectV1Error('param_error', 'keyPath required'))
+  })
+
+  test('addressFormat invalid enum → param_error reject', async () => {
+    await expect(
+      getPublicKey({
+        chainId: 'cip34:1-764824073',
+        keyPath: "m/1852'/1815'/0'/0/0",
+        addressFormat: 'invalid' as any,
+      }),
+    ).rejects.toEqual(expectV1Error('param_error'))
+  })
+
+  test('addressFormat 프로토타입 오염 키(__proto__) → param_error reject', async () => {
+    await expect(
+      getPublicKey({
+        chainId: 'cip34:1-764824073',
+        keyPath: "m/1852'/1815'/0'/0/0",
+        addressFormat: '__proto__' as any,
+      }),
+    ).rejects.toEqual(expectV1Error('param_error'))
+  })
+})

--- a/tests/unit/v2/sign/publicKey.test.ts
+++ b/tests/unit/v2/sign/publicKey.test.ts
@@ -217,4 +217,57 @@ describe('getPublicKey v2 facade — 입력 검증 (boundary-validation / dapp-i
       }),
     ).rejects.toEqual(expectV1Error('param_error'))
   })
+
+  // boundary-validation / error-handling-consistency: non-object input은 raw TypeError가 아니라
+  // dcentException(param_error)로 reject되어야 한다 (cross-review W2).
+  test('input=undefined → param_error reject (raw TypeError 아님)', async () => {
+    await expect(getPublicKey(undefined as any)).rejects.toEqual(
+      expectV1Error('param_error', 'getPublicKey: input must be an object { chainId, keyPath }'),
+    )
+  })
+
+  test('input=null → param_error reject', async () => {
+    await expect(getPublicKey(null as any)).rejects.toEqual(
+      expectV1Error('param_error', 'getPublicKey: input must be an object { chainId, keyPath }'),
+    )
+  })
+
+  test('input=array → param_error reject (typeof [] === object 함정 명시 거부)', async () => {
+    await expect(getPublicKey(['cip34:1-764824073'] as any)).rejects.toEqual(
+      expectV1Error('param_error', 'getPublicKey: input must be an object { chainId, keyPath }'),
+    )
+  })
+
+  test('input=string(primitive) → param_error reject', async () => {
+    await expect(getPublicKey('cip34:1-764824073' as any)).rejects.toEqual(
+      expectV1Error('param_error', 'getPublicKey: input must be an object { chainId, keyPath }'),
+    )
+  })
+})
+
+describe('getPublicKey v2 facade — mutation 격리 (nested payload, cross-review W1)', () => {
+  // T-SEC-MUT: getPublicKey 응답의 nested role 객체(payment/stake/drep)를 호출자가 변경해도
+  // popup이 보낸 원본 / 같은 객체를 재사용하는 다음 응답에 leak되지 않아야 한다.
+  test('nested publicKey mutation이 다음 getPublicKey 호출에 leak되지 않음', async () => {
+    const { transport } = ensureSingleton()
+    // 같은 응답 객체를 두 번 반환 (popup이 객체를 재사용하는 worst case — T-MUT-RESP 패턴)
+    const sharedResult = {
+      payment: { keyPath: "m/1852'/1815'/0'/0/0", publicKey: 'aa11' },
+      stake: { keyPath: "m/1852'/1815'/0'/2/0", publicKey: 'bb22' },
+      drep: { keyPath: "m/1852'/1815'/0'/3/0", publicKey: 'cc33' },
+    }
+    jest.spyOn(transport, 'send').mockResolvedValue({ id: 'gp-mut', result: sharedResult })
+
+    const a = await getPublicKey({ chainId: 'cip34:1-764824073', keyPath: "m/1852'/1815'/0'/0/0" })
+    // dApp이 반환된 nested role 객체를 in-place 변경
+    ;(a.body.parameter as any).payment.publicKey = 'ffff'
+
+    const b = await getPublicKey({ chainId: 'cip34:1-764824073', keyPath: "m/1852'/1815'/0'/0/0" })
+    // 두 번째 응답은 오염되지 않아야 함
+    expect((b.body.parameter as any).payment.publicKey).toBe('aa11')
+    // 두 응답의 nested 객체는 서로 다른 reference
+    expect((a.body.parameter as any).payment).not.toBe((b.body.parameter as any).payment)
+    // popup 원본도 오염되지 않아야 함
+    expect(sharedResult.payment.publicKey).toBe('aa11')
+  })
 })


### PR DESCRIPTION
## Objective

`m09-04-21-getpublickey-verb-playground` (epic child of `m09-04` / DC-2223)
Jira: **DC-3000** (subtask, parent DC-2223)

## 배경

redesign(2026-06-24~25)으로 (a) Cardano `getAddress` 응답이 `publicKeys` 대신 `rewardAddress`를 반환하고, (b) 공개키는 별도 `getPublicKey` 메서드로 분리됐다. connector(chain-agnostic)에 `getPublicKey` verb를 노출하고 playground에 노드를 추가한다.

## 변경 사항

### connector public API (additive)
- `src/sign/publicKey.ts` (신규) — `dcent.getPublicKey({chainId, keyPath, addressFormat?})` facade. getAddress v2 facade(`_getAddressV2`)와 **동형**: chainId sanitize(character whitelist) → sdk `getPublicKey` 메서드로 passthrough → 응답(`{payment,stake,drep}` 각 `{keyPath,publicKey}`) 그대로 surface.
- `src/sign/index.ts` / `src/index.ts` — `getPublicKey` + `GetPublicKeyV2Input` export, default `dcent` 객체에 등록.
- **chain-agnostic** (`connector-chain-addition-isolation`): chain enum / `PREFIX_TO_METHOD` / chain-prefixed switch **0건**. method는 `'getPublicKey'` literal 고정.

### playground
- `account:getPublicKey` 트리 노드 + 폼(chainId/keyPath) + 결과 요약(payment/stake/drep 각 keyPath+publicKey).
- `getAddress` 결과에 Cardano `rewardAddress` 라인 표시 추가 (undefined-safe — 다른 family 무영향).

## 테스트 결과 (자동 검증, 실 실행)
- `jest --config jest.v2.config.js tests/unit/v2` — **670 passed / 670** (신규 facade 17 + playground 9 포함)
- `tsc --noEmit` — **0 errors**
- `eslint --ext .js src-v1 tests playground.js scripts` — **0 errors** (기존 warning만)
- `webpack --mode production` — **빌드 성공**

### T-XX 커버리지
- T-CONN-GP-01/01.b/01.c/02/05/06 — facade round-trip + chain-agnostic + 에러 코드 `-32601`/`-32602` 투명 surface
- 입력 검증 — chainId 빈문자열/non-string/whitelist, keyPath 누락/빈문자열, addressFormat enum/`__proto__`
- T-CONN-PG-03/04 — playground getPublicKey 노드/요약 렌더 + getAddress rewardAddress 렌더(undefined-safe)

## cross-repo / 머지 순서
- `src/index.ts`(public API)에 verb 추가 = additive(backward-compat). runtime 짝은 sdk `getPublicKey` 핸들러 = **m09-03-29** (related). epic→epic 머지는 sdk와 독립(테스트 전부 mock sdk, facade는 pure passthrough — build 의존 0). **dev(production) 머지는 sdk 먼저** 필요(운영 bridge가 미지원이면 `Unsupported method`).

## 룰 준수
`connector-chain-addition-isolation` (chain 분기 0 — 다중 chainId 모두 method='getPublicKey' 회귀 테스트), `cross-repo-interface-edit` (additive), `no-version-bump` (package.json version 불변), `dapp-input-sanitization`/`boundary-validation` (chainId/keyPath/addressFormat sanitize), `objective-no-auto-merge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfS7EuLJew3raYp9cyUSsc
