### PR TITLE
[DC-3043] m09-04-22: playground signData/signAuthEntry preset + 다체인 token preset + PopupTransport timeout

### DIFF
--- a/playground.js
+++ b/playground.js
@@ -1860,14 +1860,42 @@
   // BIP-173 bech32 charset. Cardano는 길이 제한 없는 변형이라 checksum 검증 생략(getAddress 신뢰).
   // 반환: hex string (실패 시 '').
   var _BECH32_CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l'
+  var _BECH32_GEN = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3]
+  // BIP-173 polymod — checksum 검증용 (Cardano는 길이 제한 없는 bech32 변형).
+  function _bech32Polymod (values) {
+    var chk = 1
+    for (var i = 0; i < values.length; i++) {
+      var top = chk >>> 25
+      chk = (((chk & 0x1ffffff) << 5) >>> 0) ^ values[i]
+      for (var j = 0; j < 5; j++) {
+        if ((top >> j) & 1) chk ^= _BECH32_GEN[j]
+      }
+      chk = chk >>> 0
+    }
+    return chk >>> 0
+  }
+  function _bech32HrpExpand (hrp) {
+    var ret = []
+    var k
+    for (k = 0; k < hrp.length; k++) ret.push(hrp.charCodeAt(k) >> 5)
+    ret.push(0)
+    for (k = 0; k < hrp.length; k++) ret.push(hrp.charCodeAt(k) & 31)
+    return ret
+  }
+  function _bech32VerifyChecksum (hrp, words) {
+    return _bech32Polymod(_bech32HrpExpand(hrp).concat(words)) === 1
+  }
   function _cardanoBech32ToHex (addr) {
     if (typeof addr !== 'string' || !addr) return ''
     var s = addr.trim()
     // Cardano bech32 HRP: addr / addr_test / stake / stake_test / drep ...
     if (/^(addr|stake|drep)(_test)?1[0-9ac-hj-np-z]+$/i.test(s)) {
+      // BIP-173: mixed-case 금지 (전부 소문자 또는 전부 대문자만 허용).
+      if (s !== s.toLowerCase() && s !== s.toUpperCase()) return ''
       var lower = s.toLowerCase()
       var pos = lower.lastIndexOf('1')
       if (pos < 1) return ''
+      var hrp = lower.slice(0, pos)
       var dataPart = lower.slice(pos + 1)
       var words = []
       for (var i = 0; i < dataPart.length; i++) {
@@ -1876,6 +1904,8 @@
         words.push(v)
       }
       if (words.length < 6) return ''
+      // BIP-173 checksum 검증 (체크섬 word 포함 전체로) — 실패 시 거부 (typo/corruption 차단).
+      if (!_bech32VerifyChecksum(hrp, words)) return ''
       words = words.slice(0, words.length - 6) // 마지막 6 word = checksum 제거
       var acc = 0
       var bits = 0

--- a/playground.js
+++ b/playground.js
@@ -780,19 +780,21 @@
         message: 'Hello Stellar!',
       },
     ],
-    // m09-04-22: signData-family(index-based) preset — 값은 shape 시연용 placeholder.
-    // 실서명 정합(CIP-8 CBOR / Soroban XDR 유효성)은 HW smoke 담당 (verification-exemption).
+    // m09-04-22-fix: signData preset은 payload만 제공 — address는 반드시 디바이스 소유 주소여야
+    // 하고 hex 형태이므로 📡 getAddress 버튼으로 채운다 (static 주소는 ownership mismatch로 거부됨).
     'signData:ada:cip8': [
       {
-        label: 'Cardano CIP-8 payment (자리표시자 — 디바이스 실계정 self payment 주소로 교체 가능)',
-        address: 'addr1qxy2lpan99fcnhhyj...replace-with-device-payment-address',
+        label: 'Cardano CIP-8 payload (address는 📡 getAddress로 채우세요)',
         payload: '48656c6c6f2043617264616e6f', // "Hello Cardano" utf8→hex (CIP-8 opaque sign bytes)
       },
     ],
+    // m09-04-22-fix: 유효한 SorobanAuthorizationEntry XDR 샘플 (@stellar/stellar-sdk 오프라인 생성,
+    // roundtrip 검증). 더미 컨트랙트/nonce — 온체인 실제 auth는 아니지만 shape 유효 →
+    // 디바이스가 파싱+서명 가능. 진짜 통합 테스트는 실제 dApp의 authEntry로 교체.
     'signAuthEntry:xlm:soroban': [
       {
-        label: 'Stellar Soroban auth entry (자리표시자 — base64 XDR로 교체 가능)',
-        authEntry: 'AAAAAQAAAAA...replace-with-real-soroban-authorization-entry-xdr',
+        label: 'Stellar Soroban auth entry (유효 샘플 XDR — 디바이스 파싱/서명용)',
+        authEntry: 'AAAAAQAAAAAAAAAAc3b96I5M1hzA+ylKF4az8dBh9fLxyldGX6qTIhG5RtYAAAAAB1vNFQAehIAAAAABAAAAAAAAAAE/DDS/k60NmXHQTMyQ9wVRHIOKrZc0pKL7DXoD/H/omgAAAAh0cmFuc2ZlcgAAAAIAAAASAAAAAAAAAABzdv3ojkzWHMD7KUoXhrPx0GH18vHKV0ZfqpMiEblG1gAAAAoAAAAAAAAAAAAAAAAAAAABAAAAAA==',
       },
     ],
   }
@@ -1812,7 +1814,7 @@
     var smFamily = (allChainsMap[methodDef.chainId] || {}).family
     var smChainIdEl = appendFormRow('chainId', 'Chain ID (CAIP-19)', 'input', {
       value: methodDef.chainId,
-      datalist: _chainIdOptions(smFamily),
+      datalist: _chainIdOptions(smFamily, _signMsgExcludeUnsupported(smFamily)),
     })
 
     // keyPath — chainId 변경 시 자동으로 그 chain의 defaultKeyPath로 갱신
@@ -1851,11 +1853,57 @@
     })
   }
 
+  // ── _cardanoBech32ToHex (m09-04-22-fix) ──
+  // Cardano bech32 주소(addr1.../addr_test1.../stake1.../drep1...)를 raw 바이트 hex로 디코드한다.
+  // wm signCardanoData가 address를 hexToBytes로 처리(≥28 bytes 요구)하므로, getAddress의
+  // bech32 응답을 hex로 변환해야 signData가 동작한다. 입력이 이미 hex면(0x optional) 정규화만.
+  // BIP-173 bech32 charset. Cardano는 길이 제한 없는 변형이라 checksum 검증 생략(getAddress 신뢰).
+  // 반환: hex string (실패 시 '').
+  var _BECH32_CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l'
+  function _cardanoBech32ToHex (addr) {
+    if (typeof addr !== 'string' || !addr) return ''
+    var s = addr.trim()
+    // Cardano bech32 HRP: addr / addr_test / stake / stake_test / drep ...
+    if (/^(addr|stake|drep)(_test)?1[0-9ac-hj-np-z]+$/i.test(s)) {
+      var lower = s.toLowerCase()
+      var pos = lower.lastIndexOf('1')
+      if (pos < 1) return ''
+      var dataPart = lower.slice(pos + 1)
+      var words = []
+      for (var i = 0; i < dataPart.length; i++) {
+        var v = _BECH32_CHARSET.indexOf(dataPart.charAt(i))
+        if (v === -1) return ''
+        words.push(v)
+      }
+      if (words.length < 6) return ''
+      words = words.slice(0, words.length - 6) // 마지막 6 word = checksum 제거
+      var acc = 0
+      var bits = 0
+      var hex = ''
+      for (var j = 0; j < words.length; j++) {
+        acc = (acc << 5) | words[j]
+        bits += 5
+        while (bits >= 8) {
+          bits -= 8
+          var b = (acc >> bits) & 0xff
+          hex += (b < 16 ? '0' : '') + b.toString(16)
+        }
+      }
+      return hex
+    }
+    // 이미 hex — 0x 제거 후 그대로 (짝수 길이 hex만)
+    var hexCandidate = s.replace(/^0x/i, '')
+    if (/^[0-9a-f]+$/i.test(hexCandidate) && hexCandidate.length % 2 === 0) {
+      return hexCandidate.toLowerCase()
+    }
+    return ''
+  }
+
   // ── _signDataGetAddressClick (m09-04-22-fix) ──
-  // signData 폼의 chainId/keyPath로 dcent.getAddress 호출 → 응답 address(payment)를 field-address에 채운다.
-  // Cardano getAddress 응답은 { address, rewardAddress? } (m09-04-21) — payment 주소(address)를 사용.
-  // signTransaction sender-resolver와 동일 패턴. 기존 헬퍼(_summarizeGetAddressResult/_unwrapV1Envelope/
-  // appendLog/normalizeError/_getDcent) 재사용 (reuse-shared-utils).
+  // signData 폼의 chainId/keyPath로 dcent.getAddress 호출 → 응답 payment 주소(bech32)를
+  // hex로 변환하여 field-address에 채운다 (signData는 hex address 요구).
+  // Connect 게이트 적용 — Send와 일관되게 state.connected 필요 (facade 직접 호출 우회 방지).
+  // 기존 헬퍼(_summarizeGetAddressResult/_unwrapV1Envelope/appendLog/normalizeError/_getDcent) 재사용.
   function _signDataGetAddressClick (chainIdEl, keyPathEl, hintEl) {
     var chainId = chainIdEl ? chainIdEl.value.trim() : ''
     var keyPath = keyPathEl ? keyPathEl.value.trim() : ''
@@ -1864,6 +1912,10 @@
         hintEl.textContent = msg
         hintEl.style.color = isErr ? '#c00' : '#888'
       }
+    }
+    if (!state.connected) {
+      setHint('먼저 상단 [Connect]로 연결하세요', true)
+      return
     }
     if (!chainId || !keyPath) {
       setHint('chainId / keyPath 필요', true)
@@ -1884,10 +1936,15 @@
         setHint('getAddress 응답에서 address 추출 실패', true)
         return
       }
+      var hex = _cardanoBech32ToHex(address)
+      if (!hex) {
+        setHint('주소 hex 변환 실패: ' + address, true)
+        return
+      }
       var addrEl = document.getElementById('field-address')
-      if (addrEl) addrEl.value = address
+      if (addrEl) addrEl.value = hex
       appendLog({ method: 'getAddress', request: req, response: result, latencyMs: Date.now() - startMs })
-      setHint('✅ ' + address, false)
+      setHint('✅ ' + hex.slice(0, 16) + '… (payment hex)', false)
     }).catch(function (err) {
       appendLog({ method: 'getAddress', request: req, error: normalizeError(err), latencyMs: Date.now() - startMs })
       setHint('getAddress 실패 — 결과 로그 확인', true)
@@ -2388,16 +2445,25 @@
   // ── chainId datalist 옵션 빌더 ──
   // family가 지정되면 같은 family의 chain들만, 없으면 전체 allChainsMap을 옵션으로 제공.
   // 사용자가 직접 chainId를 타이핑하거나 dropdown에서 선택할 수 있다.
-  function _chainIdOptions (family) {
+  // excludeFn(cid, entry) → true면 datalist에서 제외 (선택적).
+  function _chainIdOptions (family, excludeFn) {
     var options = []
     if (!allChainsMap) return options
     Object.keys(allChainsMap).forEach(function (cid) {
       var entry = allChainsMap[cid]
       if (!entry) return
       if (family && entry.family !== family) return
+      if (typeof excludeFn === 'function' && excludeFn(cid, entry)) return
       options.push({ value: cid, label: entry.displayName })
     })
     return options
+  }
+
+  // m09-04-22-fix: signMessage에서 polkadot relay(slip44:354)는 미지원(wm isParaChain 가드 throw).
+  // datalist 자동완성에서 relay chainId를 제외한다 (paraChain=Astar 등만 노출).
+  function _signMsgExcludeUnsupported (family) {
+    if (family !== 'polkadot') return null
+    return function (cid) { return cid.indexOf('slip44:354') !== -1 }
   }
 
   // chainId input의 변경(타이핑/datalist 선택)을 keyPath input의 defaultKeyPath로 동기화.
@@ -3806,6 +3872,8 @@
     // m09-04-21: getPublicKey / getAddress 응답 요약 helper (undefined-safe, pure)
     _summarizeGetPublicKeyResult: _summarizeGetPublicKeyResult,
     _summarizeGetAddressResult: _summarizeGetAddressResult,
+    // m09-04-22-fix: Cardano bech32→hex (signData address hex 변환) 회귀 테스트용 노출
+    _cardanoBech32ToHex: _cardanoBech32ToHex,
     // b08-01: envelope unwrap helper + popup-only onConnect 검증용 노출
     _unwrapV1Envelope: _unwrapV1Envelope,
     // placeholder substitution helpers — unit testable

--- a/playground.js
+++ b/playground.js
@@ -1889,6 +1889,8 @@
           hex += (b < 16 ? '0' : '') + b.toString(16)
         }
       }
+      // bech32 padding 검증: 남은 bits<5 && leftover bit이 0이어야 유효 (malformed data 거부)
+      if (bits >= 5 || ((acc << (8 - bits)) & 0xff) !== 0) return ''
       return hex
     }
     // 이미 hex — 0x 제거 후 그대로 (짝수 길이 hex만)
@@ -1937,8 +1939,8 @@
         return
       }
       var hex = _cardanoBech32ToHex(address)
-      if (!hex) {
-        setHint('주소 hex 변환 실패: ' + address, true)
+      if (!hex || hex.length < 56) {
+        setHint('주소 hex 변환 실패/길이부족(≥28B): ' + address, true)
         return
       }
       var addrEl = document.getElementById('field-address')
@@ -3131,7 +3133,7 @@
 
     var chainId = chainIdEl ? chainIdEl.value : methodDef.chainId
     var keyPath = keyPathEl ? keyPathEl.value.trim() : ''
-    var address = addressEl ? addressEl.value.trim() : ''
+    var addressRaw = addressEl ? addressEl.value.trim() : ''
     // payload는 opaque sign bytes — 빈 문자열도 유효(SDK signData 핸들러가 empty payload 수용).
     var signPayload = payloadEl ? payloadEl.value.trim() : ''
 
@@ -3140,8 +3142,16 @@
       showFieldError('keyPath', keyPathError)
       return
     }
-    if (!address) {
+    if (!addressRaw) {
       showFieldError('address', 'Address is required (payment / stake / DRep hex)')
+      return
+    }
+    // m09-04-22-fix: signData address는 hex(payment/stake/DRep bytes, ≥28 bytes) 요구.
+    // bech32(addr1…) 입력은 hex로 정규화, hex는 그대로. 유효하지 않으면 client-side 차단
+    // (wm signCardanoData의 hexToBytes+≥28B 계약을 미리 강제 — 디바이스 cryptic 실패 방지).
+    var address = _cardanoBech32ToHex(addressRaw)
+    if (!address || address.length < 56) {
+      showFieldError('address', 'Address must be hex (or bech32 addr1…) of ≥28 bytes — use 📡 getAddress')
       return
     }
 

--- a/playground.js
+++ b/playground.js
@@ -820,6 +820,21 @@
         message: 'Hello Stellar!',
       },
     ],
+    // m09-04-22: signData-family(index-based) preset — 값은 shape 시연용 placeholder.
+    // 실서명 정합(CIP-8 CBOR / Soroban XDR 유효성)은 HW smoke 담당 (verification-exemption).
+    'signData:ada:cip8': [
+      {
+        label: 'Cardano CIP-8 payment (자리표시자 — 디바이스 실계정 self payment 주소로 교체 가능)',
+        address: 'addr1qxy2lpan99fcnhhyj...replace-with-device-payment-address',
+        payload: '48656c6c6f2043617264616e6f', // "Hello Cardano" utf8→hex (CIP-8 opaque sign bytes)
+      },
+    ],
+    'signAuthEntry:xlm:soroban': [
+      {
+        label: 'Stellar Soroban auth entry (자리표시자 — base64 XDR로 교체 가능)',
+        authEntry: 'AAAAAQAAAAA...replace-with-real-soroban-authorization-entry-xdr',
+      },
+    ],
   }
 
   // ── 전역 상태 ──
@@ -1911,6 +1926,14 @@
     sdNote.style.cssText = 'font-size:10px;color:#aaa;margin-bottom:6px;'
     sdNote.textContent = 'Cardano CIP-8/CIP-95 — address must belong to the connected device. Returns { signature, key }.'
     formFields.appendChild(sdNote)
+
+    // preset selector
+    renderPresetSelector(methodDef.id, function (p) {
+      var addrEl = document.getElementById('field-address')
+      if (addrEl && p.address !== undefined) addrEl.value = p.address
+      var plEl = document.getElementById('field-payload')
+      if (plEl && p.payload !== undefined) plEl.value = p.payload
+    })
   }
 
   // ── renderSignAuthEntryForm (m10-01-11) ──
@@ -1942,6 +1965,12 @@
     saNote.style.cssText = 'font-size:10px;color:#aaa;margin-bottom:6px;'
     saNote.textContent = 'Stellar Soroban — authEntry is opaque XDR. Returns { signedAuthEntry, signerAddress }.'
     formFields.appendChild(saNote)
+
+    // preset selector
+    renderPresetSelector(methodDef.id, function (p) {
+      var aeEl = document.getElementById('field-authEntry')
+      if (aeEl && p.authEntry !== undefined) aeEl.value = p.authEntry
+    })
   }
 
   // ── renderSignTxEvmForm ──

--- a/playground.js
+++ b/playground.js
@@ -1799,6 +1799,39 @@
     })
   }
 
+  // ── renderPresetSelector (m09-04-22) ──
+  // signMessage-family(index-based) 폼 3곳(signMessage / signData / signAuthEntry) 공용 preset selector.
+  // PRESETS[presetKey]가 있으면 field-preset select를 렌더하고, change 시 fillFn(presetObj)를 호출한다.
+  // ⚠️ JSON-list 기반 selector(account/bitcoinTx/evm/nonEvm)와는 shape이 달라 공용화 대상 아님 (reuse-shared-utils).
+  function renderPresetSelector (presetKey, fillFn) {
+    var presets = PRESETS[presetKey]
+    if (presets && presets.length > 0) {
+      var presetRow = document.createElement('div')
+      presetRow.className = 'form-row'
+      var presetLabel = document.createElement('label')
+      presetLabel.textContent = 'Preset'
+      var presetSelect = document.createElement('select')
+      presetSelect.id = 'field-preset'
+      var defaultOpt = document.createElement('option')
+      defaultOpt.value = ''
+      defaultOpt.textContent = '-- select preset --'
+      presetSelect.appendChild(defaultOpt)
+      presets.forEach(function (p, i) {
+        var opt = document.createElement('option')
+        opt.value = i
+        opt.textContent = p.label
+        presetSelect.appendChild(opt)
+      })
+      presetSelect.addEventListener('change', function () {
+        var idx = parseInt(presetSelect.value, 10)
+        if (!isNaN(idx) && presets[idx]) fillFn(presets[idx])
+      })
+      presetRow.appendChild(presetLabel)
+      presetRow.appendChild(presetSelect)
+      formFields.appendChild(presetRow)
+    }
+  }
+
   function renderSignMessageForm (methodDef) {
     // chainId — 사용자가 자유 입력 가능 (CAIP-19 pass-through). 같은 family의 chain들을 datalist로 제공.
     var smFamily = (allChainsMap[methodDef.chainId] || {}).family
@@ -1837,36 +1870,10 @@
     }
 
     // preset selector
-    var presets = PRESETS[methodDef.id]
-    if (presets && presets.length > 0) {
-      var presetRow = document.createElement('div')
-      presetRow.className = 'form-row'
-      var presetLabel = document.createElement('label')
-      presetLabel.textContent = 'Preset'
-      var presetSelect = document.createElement('select')
-      presetSelect.id = 'field-preset'
-      var defaultOpt = document.createElement('option')
-      defaultOpt.value = ''
-      defaultOpt.textContent = '-- select preset --'
-      presetSelect.appendChild(defaultOpt)
-      presets.forEach(function (p, i) {
-        var opt = document.createElement('option')
-        opt.value = i
-        opt.textContent = p.label
-        presetSelect.appendChild(opt)
-      })
-      presetSelect.addEventListener('change', function () {
-        var idx = parseInt(presetSelect.value, 10)
-        if (!isNaN(idx) && presets[idx]) {
-          var p = presets[idx]
-          var msgEl = document.getElementById('field-message')
-          if (msgEl && p.message !== undefined) msgEl.value = p.message
-        }
-      })
-      presetRow.appendChild(presetLabel)
-      presetRow.appendChild(presetSelect)
-      formFields.appendChild(presetRow)
-    }
+    renderPresetSelector(methodDef.id, function (p) {
+      var msgEl = document.getElementById('field-message')
+      if (msgEl && p.message !== undefined) msgEl.value = p.message
+    })
   }
 
   // ── renderSignDataForm (m10-01-14) ──

--- a/playground.js
+++ b/playground.js
@@ -1857,7 +1857,8 @@
   // Cardano bech32 주소(addr1.../addr_test1.../stake1.../drep1...)를 raw 바이트 hex로 디코드한다.
   // wm signCardanoData가 address를 hexToBytes로 처리(≥28 bytes 요구)하므로, getAddress의
   // bech32 응답을 hex로 변환해야 signData가 동작한다. 입력이 이미 hex면(0x optional) 정규화만.
-  // BIP-173 bech32 charset. Cardano는 길이 제한 없는 변형이라 checksum 검증 생략(getAddress 신뢰).
+  // BIP-173 bech32 charset. Cardano는 90-char 길이 제한이 없는 변형이지만, checksum(polymod)
+  // 자체는 길이와 무관하게 유효하므로 _bech32VerifyChecksum으로 검증한다(오타/손상 주소 거부).
   // 반환: hex string (실패 시 '').
   var _BECH32_CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l'
   var _BECH32_GEN = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3]

--- a/playground.js
+++ b/playground.js
@@ -1877,7 +1877,8 @@
     setHint('getAddress 요청 중...', false)
     var startMs = Date.now()
     var req = { chainId: chainId, keyPath: keyPath }
-    Promise.resolve(dcent.getAddress(req)).then(_unwrapV1Envelope).then(function (result) {
+    // getAddress의 동기 throw도 .catch로 흡수하도록 .then 안에서 호출 (async-hygiene)
+    Promise.resolve().then(function () { return dcent.getAddress(req) }).then(_unwrapV1Envelope).then(function (result) {
       var address = _summarizeGetAddressResult(result).address
       if (typeof address !== 'string' || !address) {
         setHint('getAddress 응답에서 address 추출 실패', true)

--- a/playground.js
+++ b/playground.js
@@ -604,47 +604,17 @@
           ],
         },
         {
-          kind: 'family',
-          label: 'Tron',
-          items: [
-            {
-              kind: 'method',
-              id: 'signMessage:tron:raw',
-              label: 'signMessage (raw)',
-              chainId: 'tron:0x2b6653dc/slip44:195',
-              metaKind: 'raw',
-            },
-          ],
-        },
-        {
+          // m09-04-22-fix: relay chain(dot:raw, slip44/354)은 wm signMessage가 isParaChain 가드로
+          // throw(internal_process / Tx Sign Fail)하여 제거. Astar 등 paraChain(slip44/810)만 지원.
+          // (Tron/Tezos signMessage는 wm slot이 DC-2296 hotfix로 disabled → family 통째 제거.)
           kind: 'family',
           label: 'Polkadot',
           items: [
             {
               kind: 'method',
-              id: 'signMessage:dot:raw',
-              label: 'signMessage (raw) — Polkadot',
-              chainId: 'polkadot:91b171bb158e2d3848fa23a9f1c25182/slip44:354',
-              metaKind: 'raw',
-            },
-            {
-              kind: 'method',
               id: 'signMessage:dot:raw:astar',
               label: 'signMessage (raw) — Astar',
               chainId: 'polkadot:9eb76c5184c4ab8679d2d5d819fdf90b/slip44:810',
-              metaKind: 'raw',
-            },
-          ],
-        },
-        {
-          kind: 'family',
-          label: 'Tezos',
-          items: [
-            {
-              kind: 'method',
-              id: 'signMessage:xtz:raw',
-              label: 'signMessage (raw)',
-              chainId: 'tezos:NetXdQprcVkpaWU/slip44:1729',
               metaKind: 'raw',
             },
           ],
@@ -796,22 +766,12 @@
         message: 'Hello Solana!',
       },
     ],
-    'signMessage:tron:raw': [
+    // m09-04-22-fix: tron/tezos signMessage preset 제거 (wm slot DC-2296 disabled),
+    // polkadot relay preset 제거 — 지원되는 Astar(paraChain) preset만 유지.
+    'signMessage:dot:raw:astar': [
       {
-        label: 'Tron raw message',
-        message: 'Hello Tron!',
-      },
-    ],
-    'signMessage:dot:raw': [
-      {
-        label: 'Polkadot raw message',
-        message: 'Hello Polkadot!',
-      },
-    ],
-    'signMessage:xtz:raw': [
-      {
-        label: 'Tezos raw message',
-        message: 'Hello Tezos!',
+        label: 'Astar raw message',
+        message: 'Hello Astar!',
       },
     ],
     'signMessage:xlm:raw': [
@@ -1891,6 +1851,48 @@
     })
   }
 
+  // ── _signDataGetAddressClick (m09-04-22-fix) ──
+  // signData 폼의 chainId/keyPath로 dcent.getAddress 호출 → 응답 address(payment)를 field-address에 채운다.
+  // Cardano getAddress 응답은 { address, rewardAddress? } (m09-04-21) — payment 주소(address)를 사용.
+  // signTransaction sender-resolver와 동일 패턴. 기존 헬퍼(_summarizeGetAddressResult/_unwrapV1Envelope/
+  // appendLog/normalizeError/_getDcent) 재사용 (reuse-shared-utils).
+  function _signDataGetAddressClick (chainIdEl, keyPathEl, hintEl) {
+    var chainId = chainIdEl ? chainIdEl.value.trim() : ''
+    var keyPath = keyPathEl ? keyPathEl.value.trim() : ''
+    function setHint (msg, isErr) {
+      if (hintEl) {
+        hintEl.textContent = msg
+        hintEl.style.color = isErr ? '#c00' : '#888'
+      }
+    }
+    if (!chainId || !keyPath) {
+      setHint('chainId / keyPath 필요', true)
+      return
+    }
+    var dcent = _getDcent()
+    if (!dcent || typeof dcent.getAddress !== 'function') {
+      setHint('dcent.getAddress 사용 불가', true)
+      return
+    }
+    setHint('getAddress 요청 중...', false)
+    var startMs = Date.now()
+    var req = { chainId: chainId, keyPath: keyPath }
+    Promise.resolve(dcent.getAddress(req)).then(_unwrapV1Envelope).then(function (result) {
+      var address = _summarizeGetAddressResult(result).address
+      if (typeof address !== 'string' || !address) {
+        setHint('getAddress 응답에서 address 추출 실패', true)
+        return
+      }
+      var addrEl = document.getElementById('field-address')
+      if (addrEl) addrEl.value = address
+      appendLog({ method: 'getAddress', request: req, response: result, latencyMs: Date.now() - startMs })
+      setHint('✅ ' + address, false)
+    }).catch(function (err) {
+      appendLog({ method: 'getAddress', request: req, error: normalizeError(err), latencyMs: Date.now() - startMs })
+      setHint('getAddress 실패 — 결과 로그 확인', true)
+    })
+  }
+
   // ── renderSignDataForm (m10-01-14) ──
   // Cardano CIP-8 / CIP-95 message signing (signData).
   // SDK 핸들러(DcentSdkClient signData ~1087)는 { keyPath, address, payload }를 wm signDataFromWire로
@@ -1915,6 +1917,28 @@
       value: '',
       placeholder: 'addr1... or stake/DRep credential hex',
     })
+
+    // m09-04-22-fix: signData address는 반드시 연결된 디바이스 소유 주소여야 하므로,
+    // static placeholder 대신 getAddress로 실제 payment 주소를 채우는 버튼 제공
+    // (signTransaction sender resolver와 동일 UX).
+    var sdResolveRow = document.createElement('div')
+    sdResolveRow.className = 'form-row'
+    sdResolveRow.style.cssText = 'margin-bottom:8px;padding:6px;background:#f7f7f7;border-radius:4px;'
+    var sdResolveBtn = document.createElement('button')
+    sdResolveBtn.id = 'btn-signdata-getaddress'
+    sdResolveBtn.type = 'button'
+    sdResolveBtn.textContent = '📡 getAddress → fill address'
+    sdResolveBtn.style.cssText = 'font-size:11px;padding:4px 8px;'
+    var sdResolveHint = document.createElement('span')
+    sdResolveHint.id = 'signdata-getaddress-hint'
+    sdResolveHint.style.cssText = 'font-size:10px;color:#888;margin-left:8px;'
+    sdResolveHint.textContent = '연결된 디바이스의 payment 주소로 채움 (address는 디바이스 소유 필수)'
+    sdResolveBtn.addEventListener('click', function () {
+      _signDataGetAddressClick(sdChainIdEl, sdKeyPathEl, sdResolveHint)
+    })
+    sdResolveRow.appendChild(sdResolveBtn)
+    sdResolveRow.appendChild(sdResolveHint)
+    formFields.appendChild(sdResolveRow)
 
     var sdPayloadEl = appendFormRow('payload', 'Payload (hex sign bytes)', 'textarea', {
       value: '',

--- a/playground/presets.evm.json
+++ b/playground/presets.evm.json
@@ -35,7 +35,7 @@
   {
     "id": "evm-erc20-transfer",
     "label": "EVM ERC-20 token transfer (transfer)",
-    "note": "토큰 전송 — ERC-20 transfer(address,uint256). 예시는 Ethereum mainnet USDT(to=0xdAC17...) 기준 — ⚠️ 다른 EVM 체인에서는 to(토큰 컨트랙트 주소)를 해당 체인의 토큰으로 교체할 것. data 두번째 32바이트(recipient)를 본인 주소로 교체하면 self-send(asset-risk 0). 현재 recipient=0x0(placeholder), amount=0x3e8(=1000 base units, USDT 6 decimals=0.001 USDT). value=0x0(토큰 전송은 native value 0). nonce/fee 송금 전 수정. wm는 data를 opaque pass-through(eth-transaction-convert.js), 기기 펌웨어가 ERC-20 transfer 전용 표시 경로 보유.",
+    "note": "토큰 전송 — ERC-20 transfer(address,uint256). 예시는 Ethereum mainnet USDT(to=0xdAC17...) 기준 — ⚠️ 다른 EVM 체인에서는 to(토큰 컨트랙트 주소)를 해당 체인의 토큰으로 교체할 것. data 두번째 32바이트(recipient)를 본인 주소로 교체하면 self-send(asset-risk 0). 현재 recipient=0x0(placeholder), amount=0x3e8(=1000 base units, USDT 6 decimals=0.001 USDT). value=0x0(토큰 전송은 native value 0). nonce/fee 송금 전 수정. [m02-05-51 keystone + DC-3096 link2 이후] wm이 transfer calldata(0xa9059cbb)를 디코드해 등록 토큰(tier-1)이면 TokenAccount를 합성하고 contract={name,address,to,decimals,value,symbol}를 재구성(eth-transaction-convert.js convertTransaction) → 기기가 토큰 심볼/수량/수신자로 표시·서명. (approve/NFT 등 비-transfer selector는 여전히 opaque pass-through — TypeAccount 경로 무회귀.) 미등록 토큰은 evm-erc20-transfer-unregistered 참조.",
     "sourceUrl": "https://eips.ethereum.org/EIPS/eip-20",
     "applicableChainIds": [
       "eip155:1/slip44:60", "eip155:30/slip44:60", "eip155:8217/slip44:60", "eip155:61/slip44:60",
@@ -64,6 +64,26 @@
       "maxPriorityFeePerGas": "0x3b9aca00",
       "nonce": "0x0",
       "data": "0xa9059cbb000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003e8"
+    }
+  },
+  {
+    "id": "evm-erc20-transfer-unregistered",
+    "label": "EVM ERC-20 미등록 토큰 transfer — wc처럼 native 서명",
+    "note": "미등록/커스텀 ERC-20 검증 — wm 레지스트리에 없는 컨트랙트로 transfer(0xa9059cbb) 전송. keystone(m02-05-51)이 토큰을 식별하지만 3-tier 해석(등록/descriptor decimals/RPC 메타)에 실패하면, EVM/KLAYTN 어댑터는 nativeFallbackOnUnresolved=true라 -32602로 막지 않고 wc(wc-eth-api)처럼 native TypeAccount로 원 payload({to:컨트랙트, value:0, data:calldata})를 그대로 서명한다 → 기기 펌웨어가 ERC-20 transfer를 파싱해 표시. 즉 미등록 커스텀 토큰도 fail 없이 서명됨(TokenAccount 미합성이라 wm이 심볼/decimals를 주입하진 않고 펌웨어가 generic하게 표시). value=0이라 native ETH는 안 나가고 calldata 그대로라 wrong-asset 위험 0(= wc 동작). data 두번째 word(recipient)를 본인 주소로 교체하면 self-send. ⚠️ to(0xabab..)는 미등록 예시 placeholder — 실제 미등록 ERC-20로 교체해 테스트. 심볼/decimals까지 풍부하게 표시하려면 form-D(transaction.token={contract,to,amount,decimals,symbol}) 사용(EVM customTokenDeviceStoreId enrichment은 후속). 등록 토큰은 evm-erc20-transfer 참조.",
+    "sourceUrl": "https://eips.ethereum.org/EIPS/eip-20",
+    "applicableChainIds": [
+      "eip155:1/slip44:60", "eip155:56/slip44:60", "eip155:137/slip44:60", "eip155:8453/slip44:60",
+      "eip155:10/slip44:60", "eip155:43114/slip44:60"
+    ],
+    "transaction": {
+      "type": 2,
+      "to": "0xabababababababababababababababababababab",
+      "value": "0x0",
+      "gasLimit": "0x186a0",
+      "maxFeePerGas": "0x77359400",
+      "maxPriorityFeePerGas": "0x3b9aca00",
+      "nonce": "0x0",
+      "data": "0xa9059cbb00000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c800000000000000000000000000000000000000000000000000000000000003e8"
     }
   },
   {

--- a/playground/presets.evm.json
+++ b/playground/presets.evm.json
@@ -153,5 +153,45 @@
       "nonce": "0x0",
       "data": "0x42842e0e000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"
     }
+  },
+  {
+    "id": "kaia-kip7-transfer",
+    "label": "Kaia KIP-7(KCT) token transfer — 실수신자/실수량 서명",
+    "note": "Kaia KIP-7(KCT) 토큰 전송 — KIP-7 = ERC-20 transfer(address,uint256) 동일 selector(0xa9059cbb). Kaia는 wm에서 KLAYTN family(eip155:8217/slip44:60, coinType 60 = m/44'/60')로 해석되어 convertKlaytnTransaction이 처리한다. [m02-05-85 이후] keystone(m02-05-51)이 합성한 TokenAccount + KIP-7 calldata를 convertKlaytnTransaction이 디코드해 recipient/amount를 실수신자/실수량으로 remap하고 transaction.contract={address,to,value,symbol,decimals}를 재구성 → 기기가 KCT 심볼/수량/수신자로 표시·서명(txType=SMART_CONTRACT_EXECUTION 0x30). remap 이전엔 buildTransaction이 transaction.contract undefined로 크래시했고, remap 없으면 transfer(토큰컨트랙트,0) 오생성. ⚠️ to는 예시 KCT(oUSDT-like) placeholder — 실제 등록 KCT 컨트랙트로 교체. data 두번째 32바이트(recipient)를 본인 Kaia 주소로 교체하면 self-send(asset-risk 0). recipient=0x0(placeholder), amount=0x3e8(=1000 base units). value=0x0(토큰 전송은 native value 0). type:2로 보내도 KLAYTN은 legacy gas만 사용 — maxFeePerGas가 gas_price fallback. nonce/fee 송금 전 수정. §9 byte-proof: /verify-wire-sign(KLAYTN/KIP-7)로 transfer(실수신자,실수량)+signer=device 확인(broadcast 미수행). 비-transfer(approve/NFT)는 TypeAccount opaque pass-through 무회귀.",
+    "sourceUrl": "https://docs.kaia.io/build/smart-contracts/kaia-compatible-token/",
+    "applicableChainIds": [
+      "eip155:8217/slip44:60"
+    ],
+    "transaction": {
+      "type": 2,
+      "to": "0xcee8faf64bb97a73bb51e115aa89c17ffa8dd167",
+      "value": "0x0",
+      "gasLimit": "0x186a0",
+      "maxFeePerGas": "0x77359400",
+      "maxPriorityFeePerGas": "0x3b9aca00",
+      "nonce": "0x0",
+      "data": "0xa9059cbb000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003e8"
+    }
+  },
+  {
+    "id": "klaytn-fee-delegation-transfer",
+    "label": "Kaia fee-delegated value transfer — sender 서명(senderTxHashRLP)",
+    "family": "klaytn",
+    "note": "외부 dApp Kaia fee-delegation(FeeDelegatedValueTransfer, 외부 서비스가 fee payer) — 사용자가 sender로 서명. wm m02-05-84: convertKlaytnTransaction이 typeInt(0x09=9)을 kaiaTransaction.txType으로 보존 → signTransaction의 isFeeDelegated(=mode:'sponsor' || ALL_FEE_DELEGATED_TYPES.has(txType))가 true → senderTxHashRLP()(fee payer가 완성할 부분 RLP) 반환. 84 이전엔 mode:'sponsor' 없으면 txHashRLP()(full)로 떨어져 외부 fee payer가 자기 서명을 붙일 수 없었다. **typeInt(정수) 필수** — 9=FeeDelegatedValueTransfer(base). WithRatio(0x0a=10 등)는 feeRatio(1~99) 동반. AccountUpdate(0x21/0x22)/SmartContractDeploy(0x29/0x2a)는 value-transfer shape로 조립 불가라 -32602 fail-closed. from은 생략(디바이스 계정=sender 자동 사용) — 임의 from을 넣으면 sender RLP 불일치. to는 예시 placeholder(0x0)라 본인/실 수신자로 교체, value=송금 wei(현재 0.01 KAIA). Kaia는 legacy gas만 사용 — maxFeePerGas가 gas_price fallback. nonce/fee 송금 전 수정. ★fee payer(외부 서비스)가 senderTxHashRLP에 자기 서명을 append해야 완성 → 이 preset 단독으로는 broadcast 불가(§9 byte-proof: verify-wire-sign(KLAYTN)로 senderTxHashRLP 형식 + signer=device 확인). fee payer 측 서명(kaia_signTransactionAsFeePayer)은 별도 미구현(비스코프). 내부 Gas Pass(mode:'sponsor')는 kaia-kip7-transfer와 별개 경로.",
+    "sourceUrl": "https://docs.kaia.io/references/transaction-types/tx-type-fee-delegated-value-transfer/",
+    "applicableChainIds": [
+      "eip155:8217/slip44:60"
+    ],
+    "transaction": {
+      "typeInt": 9,
+      "to": "0x0000000000000000000000000000000000000000",
+      "value": "0x2386f26fc10000",
+      "gasLimit": "0x186a0",
+      "maxFeePerGas": "0x5d21dba00",
+      "maxPriorityFeePerGas": "0x0",
+      "nonce": "0x0",
+      "chainId": 8217,
+      "data": "0x"
+    }
   }
 ]

--- a/playground/presets.non-evm.json
+++ b/playground/presets.non-evm.json
@@ -455,6 +455,32 @@
     }
   },
   {
+    "id": "vechain-vip180-transfer",
+    "label": "VeChain VIP-180 token transfer (SHA)",
+    "family": "vechain",
+    "applicableChainIds": [
+      "vechain:b1ac3413d346d43539627e6be7ec1b4a/slip44:818"
+    ],
+    "note": "토큰 전송 — VeChain VIP-180(ERC-20 호환) transfer. wm keystone VECHAIN 어댑터(m02-05-75 / DC-3096)가 wire의 clauses[0]={to:토큰 컨트랙트, value:'0x0', data:transfer(address,uint256) calldata}를 extractVechainTokenIdentity(selector 0xa9059cbb)로 식별 → TokenAccount 합성 → convertTransaction이 recipient/amount를 calldata에서 remap → buildClauses가 transfer(recipient,amount) 재인코딩 서명. ★native VET value는 0x0 그대로(native VET 이동 0). 이게 75 이전엔 device가 'native VET / amount 0 / opaque data'로 blind-display 하던 지점 — 자산은 정확히 이동했으나 사용자가 토큰임을 확인 못 함. clauses[0].to=토큰 컨트랙트, calldata=0xa9059cbb + pad32(recipient) + pad32(amount). 현재 SHA(Safe Haven, contract 0x5db3c8a942333f6468176a870db36eef120a34dc, 18 decimals), amount=0xDE0B6B3A7640000(=1e18=1 SHA). VTHO 예시는 to=0x0000000000000000000000000000456E65726779. ⚠️ calldata 안의 recipient(selector 8자 다음 32바이트 중 하위 40 hex)를 본인 디바이스 VeChain 계정(0x…, EVM-style 20B)으로 교체(self-send라 asset risk 0). ⚠️ 반드시 mainnet(slip44:818) — VIP-180 토큰은 vechain-erc20.json registry(parent=VECHAIN)에 등록됐거나 tier-2 RPC(getTokenInfoWithCurrency)로 해석돼야 함, 미해석은 keystone -32602(silent native VET 차단). native VET는 vet-transfer preset 참조. clauses는 단일 transfer만(multi-clause 2개 이상 → extractor undefined → native 경로). gas/gasPriceCoef 제공 시 wm prepare skip(RPC 미호출). blockRef/nonce는 송금 전 갱신. §9 검증: 서명 hex를 verify-wire-sign VECHAIN 디코더로 대조(assetKind=token / recipient / signer=device).",
+    "sourceUrl": "https://docs.vechain.org/introduction-to-vechain/dual-token-economic-model/vethor-vtho",
+    "transaction": {
+      "chainTag": 74,
+      "blockRef": "0x0000000000000000",
+      "expiration": 720,
+      "clauses": [
+        {
+          "to": "0x5db3c8a942333f6468176a870db36eef120a34dc",
+          "value": "0x0",
+          "data": "0xa9059cbb00000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c80000000000000000000000000000000000000000000000000de0b6b3a7640000"
+        }
+      ],
+      "gasPriceCoef": 0,
+      "gas": 80000,
+      "dependsOn": null,
+      "nonce": "0x0"
+    }
+  },
+  {
     "id": "sol-spl-transfer",
     "label": "Solana SPL token transfer (plain JSON, data: 0x hex)",
     "family": "solana",
@@ -959,6 +985,70 @@
       "counter": "1",
       "gasLimit": "10307",
       "storageLimit": "257"
+    }
+  },
+  {
+    "id": "dag-dor-metagraph-transfer",
+    "label": "Constellation DOR metagraph L0 token transfer — form-D descriptor",
+    "family": "constellation",
+    "applicableChainIds": [
+      "constellation:mainnet/slip44:1137"
+    ],
+    "note": "metagraph L0 토큰(DOR) 전송 — form-D descriptor (m02-05-60). ★native DAG 와 wire payload 가 byte-identical(source/destination/amount/fee) 이라 metagraphId 를 transaction.token.contract 로 out-of-band carrier. wm 이 token.contract='DAG0Cyy…'(metagraphId) 를 tier-1 registry(metagraph-token.json, DOR 등록)로 해석 → metagraph TokenAccount 합성 → constellation/transaction.ts:108 metagraph 분기 → getMetagraphApi 가 token.extra.l0Url/l1Url/feesCurrencyId 로 L0/L1 endpoint 서명. native DAG(getDag4Network) 아님. ★추출기·builder·어댑터 불필요(descriptor→resolve→account-driven). ★DOR 는 등록 토큰(tier-1) — 미등록 metagraph 는 endpoint(extra) 부재로 서명 불가(-32602), 등록 토큰만 지원. convertTransaction 은 token 무시하고 top-level source/destination/amount 서명. amount 단위 DATUM(1 DOR=1e8, decimals 8) → 100000000=1 DOR. ⚠️ '🔑 Resolve sender from device' 로 source(+placeholder destination) 를 디바이스 DAG 주소로 치환(self-send). DAG 는 체크섬 검증 있어 zero-placeholder 는 표시 깨짐 — 반드시 resolve-sender 클릭 또는 유효 DAG 입력. ⚠️ SDK wm refresh(m02-05-60 회귀 반영)+connector 재빌드. ⚠️ mainnet. 검증: /verify-wire-sign CONSTELLATION (metagraph token=DOR, native DAG 아님; secp256k1 signer=device).",
+    "sourceUrl": "https://docs.constellationnetwork.io/",
+    "transaction": {
+      "type": "transfer",
+      "source": "DAG0000000000000000000000000000000000000000",
+      "destination": "DAG0000000000000000000000000000000000000001",
+      "amount": "100000000",
+      "fee": "0",
+      "token": {
+        "contract": "DAG0CyySf35ftDQDQBnd1bdQ9aPyUdacMghpnCuM",
+        "decimals": 8,
+        "symbol": "DOR"
+      }
+    }
+  },
+  {
+    "id": "dag-custom-metagraph-transfer",
+    "label": "Constellation metagraph transfer — form-D descriptor (미등록/커스텀 토큰 → -32602)",
+    "family": "constellation",
+    "applicableChainIds": [
+      "constellation:mainnet/slip44:1137"
+    ],
+    "note": "미등록(커스텀) metagraph 토큰 전송 시도 — form-D descriptor (m02-05-60, T-SEC-CONSTELLATION-UNREGISTERED-01). ★★constellation 은 형제(Havah/Hedera/Stellar/Stacks/Tezos)와 달리 미등록 토큰이 tier-3 descriptor 합성으로도 서명 불가 → keystone -32602. 이유: metagraph 서명은 토큰별 D'CENT 게이트웨이 endpoint(extra.l0Url/l1Url/feesCurrencyId)를 요구하는데 이는 wm registry(metagraph-token.json)에만 존재. tier-3 합성은 extra 를 못 채우고 resolveCustomTokenDeviceStoreId 도 deviceStoreId 를 결정 못 함(어댑터 없음 + chainInfo.tokenGroupName 없음) → -32602 로 선차단. ★이 preset 의 기대 결과 = -32602(성공 아님). native DAG 로 silent 오서명되지 않는 것(silent native 0)을 확인하는 negative/가드 검증용 — DOR/PACA 등록 토큰은 dag-dor-metagraph-transfer preset 으로 서명. contract=DAG5UnregisteredMetagraphIdZZZZZZZZZZZZZZ 는 registry 미등록(회귀 테스트 T-SEC-CONSTELLATION-UNREGISTERED-01 과 동일 값, valid DAG 포맷이나 DOR/PACA 아님). decimals 를 빼도(01b) 동일하게 -32602. ⚠️ -32602 는 m02-05-60 픽스 없이도 기존 resolver 로 발생하므로 SDK refresh 전에도 재현됨(성공 경로 DOR 만 60 픽스 필요). ⚠️ mainnet. 서명이 성립 안 하므로 /verify-wire-sign 대상 아님 — 요청 후 에러 코드 -32602 확인이 검증.",
+    "sourceUrl": "https://docs.constellationnetwork.io/",
+    "transaction": {
+      "type": "transfer",
+      "source": "DAG0000000000000000000000000000000000000000",
+      "destination": "DAG0000000000000000000000000000000000000001",
+      "amount": "100000000",
+      "fee": "0",
+      "token": {
+        "contract": "DAG5UnregisteredMetagraphIdZZZZZZZZZZZZZZ",
+        "decimals": 8,
+        "symbol": "UNREG"
+      }
+    }
+  },
+  {
+    "id": "sol-spl-descriptor-transfer",
+    "label": "Solana SPL token transfer — form-D descriptor (미등록/커스텀 토큰)",
+    "family": "solana",
+    "applicableChainIds": [
+      "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1/slip44:501"
+    ],
+    "note": "미등록(커스텀) SPL 토큰 전송 — form-D descriptor. wm m02-05-73(DC-3093) buildSplTransferFromDescriptor 가 transaction.token={contract:mint,to:owner,amount,decimals} 를 Case-4 봉투({type:transfer, sender, recipient, amount}) 로 빌드 → 공유 prepareTransaction(checkAssociation)+buildTransaction(createTransferCheckedInstruction) 이 수신자 ATA 파생 + SPL transferChecked 재구성 → 서명. ★form-E(sol-spl-transfer, opaque instructions)와 달리 spl-token.json/spl-devnet.json registry 등록 불필요 — 미등록 mint 도 토큰으로 식별되어 서명(form-E 는 opaque 라 mint 표시 못 함). ★★SOLANA 는 형제(hedera/stellar/stacks/tezos, offline rebuild)와 달리 prepare 가 devnet RPC 를 호출한다(수신자 ATA isAssociated getAccountInfo + getLatestBlockhash + getFeeForMessage) → contract 는 devnet 실존 SPL mint 여야 RPC 로 해석됨. ★contract 은 실존 미등록 mint 로 미리 채워둠 — Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr(devnet spl-token-faucet USDC-Dev, classic Token program, decimals 6, on-chain 실존 확인). wm spl-devnet.json 등록 4종(USDC 4zMMC9…/WFC 7sSCCR…/WMM 29NECD…/HzwqbKZ…)에 없음 → form-D 미등록 경로 검증용. 다른 미등록 mint 로 바꾸려면 contract+decimals 를 함께 교체(등록 4종 제외). ⚠️ feePayer = 서명 authority(= sender-ATA owner). form-D descriptor 엔 sender 가 없어 wm resolveDescriptorSender 가 transaction.sender??from??feePayer 로 읽는다 → 반드시 본인 디바이스 devnet SOL pubkey 로 교체(부재 시 -32602, 디바이스 불일치 시 addSignature not-required-to-sign). 상단 🔑 Resolve sender from device 버튼이 solana feePayer 를 지원하면 자동 치환, 아니면 수동 교체. ⚠️ token.to = 수신자 owner wallet(NOT ATA — wm 가 ATA 파생). self-send 권장 = 본인 디바이스 devnet SOL 주소(ATA-of-ATA 이중파생 방지). amount = token base units(재스케일 없음, 예 decimals 6 → 1000000=1.0 토큰). decimals 는 교체한 mint 의 실제 decimals(u8, 0-255) — createTransferCheckedInstruction 에 u8 로 인코딩되므로 정확해야 함. ★R4 base58 검증: mint/to/feePayer 가 32바이트 base58 pubkey 가 아니면 builder 가 -32602(downstream new PublicKey generic error 아님). ★R5 decimals 비정수/범위밖(0-255) → -32602. amount NaN/음수/비정수 → -32602. Token-2022: 미등록 Token-2022 mint 은 classic(TOKEN_PROGRAM_ID)으로 빌드돼 온체인 clean-fail(자산 misdirection 0, 본 child 비스코프 — classic SPL 만). ⚠️ SDK wm 을 m02-05-73(DC-3093) 포함본으로 refresh + connector 재빌드 후 실행. ⚠️ Solana Devnet(isTestnet → deviceStoreId SPL-DEVNET). 검증: /verify-wire-sign SOLANA (transferChecked mint=token, native SOL 아님; ed25519 signer=device). ★SPL 서명 바이트에 mint 포함 → byte-proof authoritative(온체인 broadcast 불요).",
+    "sourceUrl": "https://spl.solana.com/token",
+    "transaction": {
+      "token": {
+        "contract": "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr",
+        "to": "11111111111111111111111111111111",
+        "amount": "1000000",
+        "decimals": 6,
+        "symbol": "USDC-Dev"
+      },
+      "feePayer": "11111111111111111111111111111111"
     }
   }
 ]

--- a/playground/presets.non-evm.json
+++ b/playground/presets.non-evm.json
@@ -344,6 +344,102 @@
     }
   },
   {
+    "id": "ada-cbor-signtx-cip95-vote-deleg",
+    "label": "Cardano dApp signTransaction (CIP-95 — 투표권 위임 vote delegation)",
+    "family": "cardano",
+    "applicableChainIds": [
+      "cip34:1-764824073",
+      "cip34:0-2"
+    ],
+    "note": "댑 요청 — CIP-95 거버넌스. api.signTx(CBOR)에 vote_deleg_cert(CSL VoteDelegation kind=15)가 담긴 tx. 사용자의 투표권을 특정 DRep에게 위임한다. wm cardano/witness-analyzer(DC-2965)가 cert를 감지해 stake witness path를 추가 서명(cbor-signer 경로 = connector-wire). 예시 CBOR(wm fixture signTx-vote-deleg)은 placeholder input(aaaa...) + stake credential(2222...) → DRep(3333...). 디바이스는 CBOR body 해시만 서명(UTXO 미검증)하므로 서명 동작 확인용이며 broadcast 불가 — 본인 stake key/실제 UTXO/실제 DRep ID로 교체해야 실제 위임.",
+    "sourceUrl": "https://cips.cardano.org/cips/cip95/",
+    "transaction": {
+      "txCbor": "84a40081825820aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00018182581d61f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f01a000f4240021a00030d40048183098200581c222222222222222222222222222222222222222222222222222222228200581c33333333333333333333333333333333333333333333333333333333a0f5f6"
+    }
+  },
+  {
+    "id": "ada-cbor-signtx-cip95-drep-vote",
+    "label": "Cardano dApp signTransaction (CIP-95 — DRep 투표 voting_procedures)",
+    "family": "cardano",
+    "applicableChainIds": [
+      "cip34:1-764824073",
+      "cip34:0-2"
+    ],
+    "note": "댑 요청 — CIP-95 거버넌스. api.signTx(CBOR)에 voting_procedures(DRep key voter 1 + governance action 1)가 담긴 tx. 등록된 DRep이 거버넌스 안건에 투표한다. wm witness-analyzer(DC-2965)가 voter를 감지해 drep witness path를 추가 서명. 예시 CBOR(wm fixture signTx-vote-drep-simple)은 DRep key voter(3333...) + gov action(bbbb...). ⚠️ 미지원(fail-closed throw): CC Hot/DRep-script/SPO voter, committee cold. placeholder input이라 서명 확인용 — broadcast 불가.",
+    "sourceUrl": "https://cips.cardano.org/cips/cip95/",
+    "transaction": {
+      "txCbor": "84a40081825820aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa00018182581d61f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f01a000f4240021a00030d4013a18202581c33333333333333333333333333333333333333333333333333333333a1825820bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb008201f6a0f5f6"
+    }
+  },
+  {
+    "id": "ada-structured-signtx-ordinary",
+    "label": "Cardano signTransaction (structured — ordinary, 편집 가능)",
+    "family": "cardano",
+    "applicableChainIds": [
+      "cip34:1-764824073",
+      "cip34:0-2"
+    ],
+    "note": "wm m02-05-79 구현됨 — structured cardanoSignTransaction 스타일 params(inputs/outputs/fee/ttl)를 wm가 host-side로 CBOR 조립 후 서명. opaque txCbor(ada-cbor-signtx)과 달리 필드 편집 가능(이 preset의 목적). **최소 입력 스키마**: input은 prev_hash(+txHash alias)와 prev_index(+index alias)만 필수. path/amount는 optional. ① path는 무시됨 — 서명 키는 상단 Key Path 필드(=account.addressPath)로 결정 (D'CENT legacy Cardano = m/44'/1815'/0'/0/0). ② amount는 있으면 밸런스 검증(Σinput==Σoutput+fee)까지 수행, 없으면 스킵(단일 input이면 amount 불필요). 디바이스는 host-built CBOR body 해시만 서명(UTXO 미검증) → placeholder input(aaaa)로 서명 동작 확인 가능하나 broadcast 불가 — 본인 실제 UTXO/주소로 교체해야 실전송. output.address는 유효 bech32(CSL 체크섬 검증) 필수 — 예시는 enterprise mainnet placeholder(payment keyhash f2*28). amount/fee 단위 lovelace.",
+    "transaction": {
+      "signingMode": "ORDINARY_TRANSACTION",
+      "inputs": [
+        {
+          "prev_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "prev_index": 0
+        }
+      ],
+      "outputs": [
+        {
+          "address": "addr1v8e09uhj7te09uhj7te09uhj7te09uhj7te09uhj7te09us0kxhfc",
+          "amount": "2000000"
+        }
+      ],
+      "fee": "170000",
+      "ttl": "100000000",
+      "networkId": 1,
+      "protocolMagic": 764824073
+    }
+  },
+  {
+    "id": "ada-structured-signtx-vote-deleg",
+    "label": "Cardano signTransaction (structured — CIP-95 vote delegation, 편집 가능)",
+    "family": "cardano",
+    "applicableChainIds": [
+      "cip34:1-764824073",
+      "cip34:0-2"
+    ],
+    "note": "wm m02-05-80 구현됨 — structured params(inputs/outputs/fee/ttl + certificates[])를 wm가 host-side로 CBOR 조립 후 서명. opaque txCbor(ada-cbor-signtx-cip95-vote-deleg)의 편집 가능 버전. certificates[]에 VOTE_DELEGATION(stake credential→DRep 위임). **최소 입력 스키마**: input은 prev_hash(+txHash alias)/prev_index(+index alias)만 필수(path/amount optional). cert 필드는 CSL/witness-analyzer 정본 — type=UPPERCASE enum, keyHash=28-byte(56 hex) stake credential, drep={type:'KEY_HASH',keyHash} | {type:'ALWAYS_ABSTAIN'} | {type:'ALWAYS_NO_CONFIDENCE'}. witness path는 wm witness-analyzer(DC-2965/m02-05-36)가 cert를 감지해 stake witness로 자동 판정(cbor-signer 경로). 서명 키는 상단 Key Path(=account.addressPath)로 결정. keyHash/drep.keyHash는 결정적 placeholder(실 owner/key 무관, CBOR body 인코딩용) — 디바이스는 host-built CBOR body 해시만 서명(UTXO 미검증)하므로 서명 확인용, broadcast 불가. 본인 stake key/실 UTXO/실 DRep ID로 교체해야 실 위임. output.address는 유효 bech32(CSL 체크섬 검증) 필수. amount/fee/deposit 단위 lovelace.",
+    "sourceUrl": "https://cips.cardano.org/cips/cip95/",
+    "transaction": {
+      "signingMode": "ORDINARY_TRANSACTION",
+      "inputs": [
+        {
+          "prev_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "prev_index": 0
+        }
+      ],
+      "outputs": [
+        {
+          "address": "addr1qyenxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxv6yg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqjeq96c",
+          "amount": "1000000"
+        }
+      ],
+      "fee": "200000",
+      "ttl": "21084865",
+      "networkId": 1,
+      "certificates": [
+        {
+          "type": "VOTE_DELEGATION",
+          "keyHash": "a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0",
+          "drep": {
+            "type": "KEY_HASH",
+            "keyHash": "c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0"
+          }
+        }
+      ]
+    }
+  },
+  {
     "id": "near-transfer",
     "label": "NEAR Protocol transfer (mainnet)",
     "family": "near",
@@ -548,11 +644,41 @@
     "applicableChainIds": [
       "near:mainnet/slip44:397"
     ],
-    "note": "토큰 전송 — NEAR NEP-141 ft_transfer. near-api-js Transaction shape(signerId/receiverId/actions[]). wm near/wire-convert가 FunctionCall action을 contract_call로 변환(SUPPORTED_ACTION_TYPES). receiverId=토큰 컨트랙트 계정(예: usdt.tether-token.near), args={receiver_id, amount}는 ⚠️JSON 객체(base64 아님, wm가 structuredClone). amount는 토큰 base units(USDT NEAR=6 decimals → 1000000=1 USDT). deposit='1'(yoctoNEAR, NEP-141 보안 요구), gas=30 TGas. ⚠️ signerId는 device 실 on-chain NEAR 계정이어야 서명 유효(access-key를 view_access_key_list RPC로 조회 — near-transfer note 참조). receiver_id/signerId/receiverId 교체 후 송금. blockHash/nonce는 prepareTransaction이 RPC로 덮어씀.",
+    "note": "토큰 전송 — NEAR NEP-141 ft_transfer (★ tier-1 등록 토큰 = USDT). near-api-js Transaction shape(signerId/receiverId/actions[]). wm near/wire-convert가 FunctionCall action을 contract_call로 변환(SUPPORTED_ACTION_TYPES). receiverId=토큰 컨트랙트 계정(usdt.tether-token.near = near-token.json tier-1 등록, RPC 없이 symbol/decimals 해석), args={receiver_id, amount}는 ⚠️JSON 객체(base64 아님, wm가 structuredClone). amount는 토큰 base units(USDT NEAR=6 decimals → 1000000=1 USDT). deposit='1'(yoctoNEAR, NEP-141 보안 요구), gas=30 TGas. ⚠️ signerId는 device 실 on-chain NEAR 계정이어야 서명 유효 → 상단 '🔑 Resolve sender from device' 버튼으로 signerId를 디바이스 NEAR 계정(getAddress)으로 자동 치환(m02-05-70 dispatcher가 near→signerId/sender 지원). ⚠️ 단 그 (implicit) 계정이 on-chain 활성(funded)이어야 view_access_key_list RPC 통과 — 미활성이면 'Invalid public key size (0)'(near-transfer note 참조). receiver_id(수신자)는 self-send 시 동일 signerId로, 아니면 실 수신 계정으로 교체. receiverId(토큰 컨트랙트)는 그대로. blockHash/nonce는 prepareTransaction이 RPC로 덮어씀.\n\n【m02-05-50 (DISPLAY-only fix) §9 device 검수】 서명은 fix 前/後 동일하게 정확(sig_hash byte-identical) — 고치는 것은 device 화면 표시뿐. ▸ fix 前(현재 wm): device Amount 자리에 garbage(펌웨어가 sig_hash를 네이티브 NEAR Transfer로 오파싱, '02' 토큰 옵션 누락). ▸ fix 後: 'USDT 1.0 → receiver.near'처럼 올바른 token symbol/수량/수신자 표시 + optionParam 끝 '02' 포함. 두 상태 모두 서명 자체는 유효(broadcast 시 정상 이동) — 본 게이트는 표시 정확성 + sig 불변 증명용. tier-2(미등록 RPC) 경로는 near-ft-transfer-unregistered preset 참조.",
     "sourceUrl": "https://nomicon.io/Standards/Tokens/FungibleToken/Core",
     "transaction": {
       "signerId": "sender.near",
       "receiverId": "usdt.tether-token.near",
+      "actions": [
+        {
+          "type": "FunctionCall",
+          "params": {
+            "methodName": "ft_transfer",
+            "args": {
+              "receiver_id": "receiver.near",
+              "amount": "1000000"
+            },
+            "gas": "30000000000000",
+            "deposit": "1"
+          }
+        }
+      ],
+      "blockHash": "GJp9NRJGBnXqWJAKFxkzD8p9cJTiSNi1J3UWKVBbcfRw",
+      "nonce": 0
+    }
+  },
+  {
+    "id": "near-ft-transfer-unregistered",
+    "label": "NEAR NEP-141 token transfer (미등록 → RPC fallback)",
+    "family": "near",
+    "applicableChainIds": [
+      "near:mainnet/slip44:397"
+    ],
+    "note": "토큰 전송 — NEAR NEP-141 ft_transfer (★ tier-2 = near-token.json 미등록 토큰). near-ft-transfer(tier-1 USDT)와 동일 shape이나 receiverId=native USDC(17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1 = Circle 네이티브 USDC, 레지스트리 미등록 — 브릿지 USDC.E와 별개). m02-05-50 keystone 3-tier resolver의 tier-2 경로 검증용: tier-1 registry miss → tokenMetadataHook이 ft_metadata RPC로 symbol/decimals 조회(USDC=6 decimals) → TokenAccount 합성. amount=1000000(6 decimals 가정 1 USDC). ⚠️ symbol/decimals는 sign 시점 ft_metadata RPC가 확정하므로 device 표시는 RPC 응답 기준. 【m02-05-50 §9 device】 fix 前=garbage / fix 後='USDC 1.0 → receiver.near'. RPC 실패/timeout·완전 미존재 컨트랙트면 keystone resolver가 -32602 loud fail(silent native 서명 아님 — T-SEC-NEAR-LOUDFAIL-01). loud-fail만 따로 보려면 receiverId를 존재하지 않는 계정(예: nonexistent-token.near)으로 교체. ⚠️ signerId는 상단 '🔑 Resolve sender from device' 버튼으로 디바이스 NEAR 계정 자동 치환(on-chain 활성 계정이어야 view_access_key_list 통과 — near-ft-transfer note 참조). receiver_id는 self-send 시 signerId와 동일하게.",
+    "sourceUrl": "https://nomicon.io/Standards/Tokens/FungibleToken/Metadata",
+    "transaction": {
+      "signerId": "sender.near",
+      "receiverId": "17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1",
       "actions": [
         {
           "type": "FunctionCall",
@@ -596,6 +722,21 @@
       ],
       "memo": "",
       "maxTransactionFee": 100000000
+    }
+  },
+  {
+    "id": "hedera-unsigned-passthrough",
+    "label": "Hedera unsignedTx blind-sign (TokenCreate)",
+    "family": "hedera",
+    "applicableChainIds": [
+      "hedera:mainnet/slip44:3030"
+    ],
+    "note": "★ blind-sign 패스스루 (m02-05-86 / v1 getHederaSignedTransaction parity). 외부에서 이미 빌드·freeze한 Hedera Transaction 직렬화 bytes(unsignedTx, hex)를 operation 무관(TokenCreate/TokenMint/TokenBurn/associate/임의 op)하게 device가 blind-sign. structured 경로(transfer=hbar-transfer, HTS=hedera-hts-transfer, associate=m02-05-83)가 커버 못 하는 전 op를 한 번에 닫음 → 이 preset은 structured가 못 하는 TokenCreate 예시. 【payload key = `unsignedTx`(camelCase, v1 public param과 동일)】 — wm convertTransaction이 obj.unsignedTx 감지 → extra.unsignedTxBytes carry → signTransaction 최상단(전처리 이전) Transaction.fromBytes 복원/검증 → signWith(bodyBytes → device sign) → toBytes() broadcast-ready. `unsigned_tx`(snake_case) alias도 수용. Stellar {xdr} 패스스루(m02-05-18)와 동형. symbol/decimals는 display 힌트(blind-sign은 rich display 제한 — v1 동일). 아래 hex는 treasury=0.0.587690(self 계정) TokenCreate(DPD, 2 decimals, initialSupply 100000), 고정 validStart로 결정적. ⚠️ 실서명 유효하려면 tx의 서명자 계정(treasury/operator)이 디바이스 실 Hedera 계정과 일치해야 함(현재 0.0.587690=self). malformed/비-Transaction bytes → -32602. §9 byte-proof: 반환 signed tx의 bodyBytes = 입력 unsignedTx의 bodyBytes 동일(host tx 무변형, signature만 부착) — broadcast 미수행 시 asset risk 0.",
+    "sourceUrl": "https://docs.hedera.com/hedera/sdks-and-apis/sdks/token-service/define-a-token",
+    "transaction": {
+      "unsignedTx": "0a9d012a9a010a95010a160a080880e2cfaa06100012080800100018aaef23180012060800100018031880bcc1960b2202087832256d30322d30352d383620626c696e642d7369676e20706173737468726f7567682064656d6fea01410a164443454e5420506173737468726f7567682044656d6f1203445044180220a08d062a080800100018aaef236a0808f1b28ed60610007a050880ceda038801001200",
+      "symbol": "HBAR",
+      "decimals": 8
     }
   },
   {
@@ -861,6 +1002,66 @@
     }
   },
   {
+    "id": "stellar-soroban-invoke-hello",
+    "label": "Stellar Soroban invokeHostFunction — hello(symbol)",
+    "family": "stellar",
+    "applicableChainIds": [
+      "stellar:pubnet/slip44:148"
+    ],
+    "note": "Soroban 컨트랙트 호출(invokeHostFunction) — dApp signTransaction wire 경로 plumbing 검증용. wm stellar convertTransaction 이 {type:'invokeHostFunction', contractAddress, functionName, args} 를 extra.stellarOpParams 로 carry → signTransaction 이 getAccountInfo(실제 seq) 후 buildInvokeHostFunctionOperation 로 Soroban op 봉투 빌드 → 서명. ★canonical hello-world 예제(hello(to:symbol)) — args 는 scv_symbol 1개. ⚠️ wire 빌더(buildScValFromSummary)는 현재 scv_symbol/scv_address/scv_bytes 3종만 지원 — i128/u64/vec 등은 'unsupported SCVal type' throw. 실제 토큰 transfer/swap(amount:i128)은 이 경로로 아직 미검증(별도 wm 확장 필요). ★contractAddress 는 결정적 placeholder C-strkey(미배포, = StrKey.encodeContract(0x01×32), CRC16 체크섬 유효). ⚠️ buildInvokeHostFunctionOperation 은 args 처리 전에 Address.fromString(contractAddress) 로 먼저 파싱하므로 반드시 체크섬 유효한 C-strkey(또는 G)여야 한다 — 체크섬 깨진 문자열(길이·prefix 만 맞는 가짜)은 'Unsupported address type' throw(2026-07-07 실측: 이전 CV2X… placeholder 가 이 사유로 실패). Stellar 서명은 로컬 envelope 빌드+해시 서명, on-chain fetch 없음, broadcast 안 함(§9 byte-proof) 이라 미배포 컨트랙트라도 strkey 만 유효하면 서명 검증 가능. 실제 dApp 은 배포된 컨트랙트 C-address 를 넣는다. keyPath 는 chains.json 에서 자동(m/44'/148'/0'). ⚠️ mainnet(slip44:148) 이지만 broadcast 안 하므로 asset risk 0. 검증: /verify-wire-sign STELLAR (invokeHostFunction op, ed25519=device 계정 키).",
+    "sourceUrl": "https://developers.stellar.org/docs/build/smart-contracts/getting-started/hello-world",
+    "transaction": {
+      "type": "invokeHostFunction",
+      "contractAddress": "CAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQC526",
+      "functionName": "hello",
+      "args": [
+        {
+          "type": "scv_symbol",
+          "value": "world"
+        }
+      ],
+      "fee": 100,
+      "sequenceNumber": "0"
+    }
+  },
+  {
+    "id": "stellar-soroban-invoke-set-admin",
+    "label": "Stellar Soroban invokeHostFunction — set_admin(address)",
+    "family": "stellar",
+    "applicableChainIds": [
+      "stellar:pubnet/slip44:148"
+    ],
+    "note": "Soroban 컨트랙트 호출(invokeHostFunction) — scv_address arg 경로 검증용. set_admin(new_admin:address) 은 흔한 admin 패턴 — args 는 scv_address 1개(Address.fromString 은 G-account/C-contract 둘 다 수용). 나머지 동작은 stellar-soroban-invoke-hello 노트와 동일(convertTransaction → stellarOpParams carry → buildInvokeHostFunctionOperation, 로컬 서명, broadcast 없음). ⚠️ wire 빌더는 scv_symbol/scv_address/scv_bytes 3종만 지원. ★args.value 를 본인 디바이스 Stellar 계정(G...) 으로 교체해 self 대상으로 두면 의미 명확. contractAddress placeholder(미배포, = StrKey.encodeContract(0x01×32), CRC16 체크섬 유효) — buildInvokeHostFunctionOperation 이 args 전에 Address.fromString(contractAddress) 로 먼저 파싱하므로 체크섬 유효한 C-strkey 필수(가짜 문자열은 'Unsupported address type' throw). §9 byte-proof 라 서명 검증엔 무방. ⚠️ mainnet(slip44:148), broadcast 안 함. 검증: /verify-wire-sign STELLAR (invokeHostFunction, ed25519=device).",
+    "sourceUrl": "https://developers.stellar.org/docs/build/smart-contracts/example-contracts/deployer",
+    "transaction": {
+      "type": "invokeHostFunction",
+      "contractAddress": "CAAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQCAIBAEAQC526",
+      "functionName": "set_admin",
+      "args": [
+        {
+          "type": "scv_address",
+          "value": "GC6OISCEYJSHTO6QBZYVT52B4ZW63BCVTNCFYLUJQK5FUKLJP6L2XNAJ"
+        }
+      ],
+      "fee": 100,
+      "sequenceNumber": "0"
+    }
+  },
+  {
+    "id": "stellar-xdr-passthrough-blind-sign",
+    "label": "Stellar XDR passthrough — blind-sign 임의 envelope (v1 getStellarSignedTransaction 상위호환)",
+    "family": "stellar",
+    "applicableChainIds": [
+      "stellar:pubnet/slip44:148"
+    ],
+    "note": "★v1 parity 검증용. v1 dcent-web-connector getStellarSignedTransaction 은 host 가 만든 트랜잭션의 signature base 를 디바이스가 블라인드 서명하던 방식(op-type 무관). v2 wire 는 그 상위호환 경로를 갖는다: transaction={xdr:'<base64 envelope>'} → convertTransaction 최상단 분기(transaction.ts:628)가 extra.envelopeXdr 로 carry → signTransaction 이 signStellarEnvelopeXdr(walletconnect blind-sign, sig_hash 32B 만 디바이스 전송)로 서명. ★임의 operation 전부 서명 가능 — 이 샘플은 구조화(structured) 경로가 지원하지 않는 클래식 op 'bumpSequence' envelope 이라, structured 7종(payment/pathPayment×2/manageData/invokeHostFunction/createAccount/changeTrust)을 넘어서는 parity 초과분을 증명한다. accountMerge/manageOffer/setOptions/claimableBalance/i128-args Soroban 등도 동일하게 XDR 로 넣으면 서명됨. wm 은 parseStellarEnvelope 로 구조 검증(최대 ~180KB base64) 후 서명. ⚠️ envelope 내부 source 계정이 placeholder(GDQP2KPQ...)라 서명은 되지만 broadcast 불가 — 실기기 §9 는 byte-proof(디바이스가 이 envelope 해시를 서명하는가)만 확인하면 충분. 실제 broadcast-가능 테스트를 원하면 @stellar/stellar-base TransactionBuilder 로 source=본인 디바이스 Stellar 계정(G...)인 envelope 을 rebuild 해 xdr 만 교체. keyPath 는 chains.json 에서 자동(m/44'/148'/0'). ⚠️ mainnet(slip44:148), broadcast 안 함. 검증: /verify-wire-sign STELLAR (envelope op=bumpSequence, ed25519=device 키).",
+    "sourceUrl": "https://dev-docs.dcentwallet.com/dcent-biometric-wallet-for-pc/dcent-web-connector/stellar",
+    "transaction": {
+      "xdr": "AAAAAgAAAADg/SnwMpB8JNdtEYcw4I0BEQPjTPpXaKVzlY2HVpQObgAAAGQAAAAAAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAACwAAAAA7msoAAAAAAAAAAAA=",
+      "fee": 100
+    }
+  },
+  {
     "id": "stacks-sip010-descriptor-transfer",
     "label": "Stacks SIP-010 transfer — form-D descriptor (미등록/커스텀 토큰)",
     "family": "stacks",
@@ -1049,6 +1250,279 @@
         "symbol": "USDC-Dev"
       },
       "feePayer": "11111111111111111111111111111111"
+    }
+  },
+  {
+    "id": "xrp-accountset",
+    "label": "XRP AccountSet",
+    "family": "xrp",
+    "applicableChainIds": [
+      "xrpl:0/slip44:144"
+    ],
+    "note": "XRP Ledger AccountSet — set account flags/options (e.g. SetFlag asfRequireDest=1). Edit fields before send.",
+    "sourceUrl": "https://xrpl.org/accountset.html",
+    "transaction": {
+      "TransactionType": "AccountSet",
+      "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+      "Fee": "12",
+      "Sequence": 1,
+      "SetFlag": 1,
+      "Flags": 2147483648
+    }
+  },
+  {
+    "id": "xrp-trustset",
+    "label": "XRP TrustSet (trust line)",
+    "family": "xrp",
+    "applicableChainIds": [
+      "xrpl:0/slip44:144"
+    ],
+    "note": "XRP Ledger TrustSet — create/modify a trust line to an issued currency. Edit LimitAmount before send.",
+    "sourceUrl": "https://xrpl.org/trustset.html",
+    "transaction": {
+      "TransactionType": "TrustSet",
+      "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
+      "Fee": "12",
+      "Sequence": 1,
+      "Flags": 2147483648,
+      "LimitAmount": {
+        "currency": "USD",
+        "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+        "value": "1000"
+      }
+    }
+  },
+  {
+    "id": "ada-structured-signtx-stake-registration",
+    "label": "Cardano signTransaction (structured — stake registration + delegation, 편집 가능)",
+    "family": "cardano",
+    "applicableChainIds": [
+      "cip34:1-764824073",
+      "cip34:0-2"
+    ],
+    "note": "wm m02-05-80 구현됨 — structured certificates[]로 stake key 등록(STAKE_REGISTRATION, deposit) + 풀 위임(STAKE_DELEGATION, poolKeyHash)을 한 tx로. wm witness-analyzer가 cert를 감지해 stake witness path 자동 서명. **최소 스키마**: input은 prev_hash/prev_index만 필수. cert 필드(CSL/witness-analyzer 정본): STAKE_REGISTRATION={type,keyHash(28-byte hex),deposit(lovelace)}; STAKE_DELEGATION={type,keyHash,poolKeyHash(28-byte hex 풀 키-해시)}. keyHash/poolKeyHash는 결정적 placeholder(CBOR body 인코딩용) — 디바이스는 host-built CBOR body 해시만 서명, 서명 확인용이며 broadcast 불가(본인 stake key/실 UTXO/실 pool ID로 교체 시 실 등록·위임). deposit은 프로토콜 key deposit(예 2 ADA). amount/fee/deposit 단위 lovelace.",
+    "transaction": {
+      "signingMode": "ORDINARY_TRANSACTION",
+      "inputs": [
+        {
+          "prev_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "prev_index": 0
+        }
+      ],
+      "outputs": [
+        {
+          "address": "addr1qyenxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxv6yg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqjeq96c",
+          "amount": "1000000"
+        }
+      ],
+      "fee": "200000",
+      "ttl": "21084865",
+      "networkId": 1,
+      "certificates": [
+        {
+          "type": "STAKE_REGISTRATION",
+          "keyHash": "a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0",
+          "deposit": "2000000"
+        },
+        {
+          "type": "STAKE_DELEGATION",
+          "keyHash": "a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0",
+          "poolKeyHash": "b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ada-structured-signtx-withdrawal",
+    "label": "Cardano signTransaction (structured — reward withdrawal, 편집 가능)",
+    "family": "cardano",
+    "applicableChainIds": [
+      "cip34:1-764824073",
+      "cip34:0-2"
+    ],
+    "note": "wm m02-05-80 구현됨 — structured withdrawals[]로 스테이킹 보상 인출. wm witness-analyzer가 key-credential reward 주소를 감지해 stake witness path 자동 서명(script-credential reward는 fail-closed). **최소 스키마**: input은 prev_hash/prev_index만 필수. withdrawals=[{rewardAddress, amount}] — rewardAddress는 bech32 reward(stake) 주소(stake1…/stake_test1…, CSL RewardAddress 파싱), amount는 인출 lovelace. rewardAddress는 결정적 placeholder(CBOR body 인코딩용) — 디바이스는 host-built CBOR body 해시만 서명, 서명 확인용이며 broadcast 불가(본인 실 reward 주소/실 UTXO로 교체 시 실 인출). amount/fee 단위 lovelace.",
+    "transaction": {
+      "signingMode": "ORDINARY_TRANSACTION",
+      "inputs": [
+        {
+          "prev_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "prev_index": 0
+        }
+      ],
+      "outputs": [
+        {
+          "address": "addr1qyenxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxv6yg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqjeq96c",
+          "amount": "1000000"
+        }
+      ],
+      "fee": "200000",
+      "ttl": "21084865",
+      "networkId": 1,
+      "withdrawals": [
+        {
+          "rewardAddress": "stake1u8gdp5xs6rgdp5xs6rgdp5xs6rgdp5xs6rgdp5xs6rgdp5qsy63p4",
+          "amount": "1500000"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ada-structured-signtx-drep-vote",
+    "label": "Cardano signTransaction (structured — CIP-95 DRep vote, 편집 가능)",
+    "family": "cardano",
+    "applicableChainIds": [
+      "cip34:1-764824073",
+      "cip34:0-2"
+    ],
+    "note": "wm m02-05-80 구현됨 — structured voting_procedures[]로 등록된 DRep이 거버넌스 안건에 투표. wm witness-analyzer가 DRep key voter를 감지해 drep witness path 자동 서명(CC Hot/DRep-script/SPO voter는 fail-closed). **최소 스키마**: input은 prev_hash/prev_index만 필수. voting_procedures=[{voter:{type:'DREP_KEY',keyHash(28-byte hex)}, govActionId:{txHash(32-byte hex),index}, vote:'YES'|'NO'|'ABSTAIN'}]. keyHash/govActionId.txHash는 결정적 placeholder(CBOR body 인코딩용) — 디바이스는 host-built CBOR body 해시만 서명, 서명 확인용이며 broadcast 불가(본인 DRep key/실 gov action id로 교체 시 실 투표). amount/fee 단위 lovelace.",
+    "sourceUrl": "https://cips.cardano.org/cips/cip95/",
+    "transaction": {
+      "signingMode": "ORDINARY_TRANSACTION",
+      "inputs": [
+        {
+          "prev_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "prev_index": 0
+        }
+      ],
+      "outputs": [
+        {
+          "address": "addr1qyenxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxv6yg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqjeq96c",
+          "amount": "1000000"
+        }
+      ],
+      "fee": "200000",
+      "ttl": "21084865",
+      "networkId": 1,
+      "voting_procedures": [
+        {
+          "voter": {
+            "type": "DREP_KEY",
+            "keyHash": "c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0"
+          },
+          "govActionId": {
+            "txHash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "index": 0
+          },
+          "vote": "YES"
+        }
+      ]
+    }
+  },
+  {
+    "id": "ada-structured-signtx-mint",
+    "label": "Cardano signTransaction (structured — token mint/burn, 편집 가능)",
+    "family": "cardano",
+    "applicableChainIds": [
+      "cip34:1-764824073",
+      "cip34:0-2"
+    ],
+    "note": "wm m02-05-81 구현됨 — structured mint[]로 native 토큰 발행/소각(tx body key 9). **최소 스키마**: input은 prev_hash/prev_index만 필수. mint=[{policyId(28-byte hex), tokens:[{assetNameHex(0..32-byte hex, default asset=''), amount}]}] (tokenAmounts/assetNameBytes alias 수용). amount는 **부호있는** 정수 문자열(양수=발행, 음수=소각, 0 금지). 예시 assetNameHex=744443454e54('tDCENT'). policy witness path 판정은 m02-05-82 담당 — 본 preset은 body key 9 직렬화+서명 확인용, broadcast 불가(본인 정책/실 UTXO로 교체 시 실 발행). policyId/assetNameHex는 결정적 placeholder. amount(mint)는 토큰 base units, fee 단위 lovelace.",
+    "transaction": {
+      "signingMode": "ORDINARY_TRANSACTION",
+      "inputs": [
+        {
+          "prev_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "prev_index": 0
+        }
+      ],
+      "outputs": [
+        {
+          "address": "addr1qyenxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxv6yg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqjeq96c",
+          "amount": "1000000"
+        }
+      ],
+      "fee": "200000",
+      "ttl": "21084865",
+      "networkId": 1,
+      "mint": [
+        {
+          "policyId": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "tokens": [
+            {
+              "assetNameHex": "744443454e54",
+              "amount": "1000000"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "id": "ada-structured-signtx-plutus",
+    "label": "Cardano signTransaction (structured — plutus collateral/refInput/scriptDataHash, 편집 가능)",
+    "family": "cardano",
+    "applicableChainIds": [
+      "cip34:1-764824073",
+      "cip34:0-2"
+    ],
+    "note": "wm m02-05-81 구현됨 — structured plutus 필드로 스크립트 실행 tx 조립(collateral+referenceInputs+scriptDataHash, body keys 11/13/16/17/18). **최소 스키마**: input은 prev_hash/prev_index만 필수. collateralInputs(또는 collateral alias)=[{prev_hash,prev_index}](담보 UTXO), collateralReturn={address,amount}(잔여 담보 반환), totalCollateral(담보 lovelace), referenceInputs=[{prev_hash,prev_index}](reference script/inline datum), scriptDataHash(32-byte hex, redeemer+datum+cost-model 해시). 모든 hash/주소는 결정적 placeholder(CBOR body 인코딩용) — 디바이스는 host-built CBOR body 해시만 서명, 서명 확인용이며 broadcast 불가(본인 실 UTXO/실 scriptDataHash로 교체 필요). amount/fee/collateral 단위 lovelace.",
+    "transaction": {
+      "signingMode": "ORDINARY_TRANSACTION",
+      "inputs": [
+        {
+          "prev_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "prev_index": 0
+        }
+      ],
+      "outputs": [
+        {
+          "address": "addr1qyenxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxv6yg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqjeq96c",
+          "amount": "1000000"
+        }
+      ],
+      "fee": "200000",
+      "ttl": "21084865",
+      "networkId": 1,
+      "collateralInputs": [
+        {
+          "prev_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "prev_index": 1
+        }
+      ],
+      "collateralReturn": {
+        "address": "addr1qyenxvenxvenxvenxvenxvenxvenxvenxvenxvenxvenxv6yg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zqjeq96c",
+        "amount": "4500000"
+      },
+      "totalCollateral": "500000",
+      "referenceInputs": [
+        {
+          "prev_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "prev_index": 2
+        }
+      ],
+      "scriptDataHash": "abababababababababababababababababababababababababababababababab"
+    }
+  },
+  {
+    "id": "hedera-hts-associate",
+    "label": "Hedera HTS token associate (SAUCE)",
+    "family": "hedera",
+    "applicableChainIds": [
+      "hedera:mainnet/slip44:3030"
+    ],
+    "note": "토큰 연결(수신 준비) — Hedera HTS TokenAssociate. wm m02-05-83 wire 배선: extractHederaTokenIdentity가 {type:'associate', tokenId} shape를 인식 → keystone이 등록 HTS TokenAccount 합성 → convertTransaction associate branch(preparedFee=MAX_ASSOCIATE_TOKEN_TINYBAR_FEE 1.5 HBAR) → signTransaction case 'associate'(무수정) TokenAssociateTransaction 서명. HTS 토큰을 받으려면 수신 계정이 먼저 associate 필요. wire payload = {type:'associate', tokenId(0.0.x), sender(0.0.x), memo?, maxTransactionFee?}. ⚠️ 반드시 등록 토큰(SAUCE 0.0.731861) — 미등록 tokenId는 keystone -32602(hedera-hts-transfer와 동일 registry 요건). ⚠️ accountId(0.0.x)는 키에서 파생 불가 → sender를 본인 디바이스 실 Hedera 계정으로 교체해야 서명 유효(현재 0.0.587690은 self 계정). ⚠️ 반드시 mainnet(slip44:3030). 디바이스는 associate tx 해시만 서명 — 서명 확인용, broadcast 미수행(§9 verify-wire-sign HEDERA). dissociate는 hedera-hts-dissociate 참조.",
+    "sourceUrl": "https://docs.hedera.com/hedera/sdks-and-apis/sdks/token-service/associate-tokens-to-an-account",
+    "transaction": {
+      "type": "associate",
+      "tokenId": "0.0.731861",
+      "sender": "0.0.587690",
+      "memo": ""
+    }
+  },
+  {
+    "id": "hedera-hts-dissociate",
+    "label": "Hedera HTS token dissociate (SAUCE)",
+    "family": "hedera",
+    "applicableChainIds": [
+      "hedera:mainnet/slip44:3030"
+    ],
+    "note": "토큰 연결 해제 — Hedera HTS TokenDissociate. wm m02-05-83 wire 배선: extractHederaTokenIdentity가 {type:'disassociate', tokenId} shape를 인식 → keystone HTS TokenAccount 합성 → convertTransaction disassociate branch(preparedFee=MAX_ASSOCIATE_TOKEN_TINYBAR_FEE 1.5 HBAR) → signTransaction case 'disassociate'(무수정) TokenDissociateTransaction 서명. 더 이상 받지 않을 HTS 토큰의 연결을 해제(잔액 0 필요). wire payload = {type:'disassociate', tokenId(0.0.x), sender(0.0.x), memo?, maxTransactionFee?}. ⚠️ 등록 토큰(SAUCE 0.0.731861) — 미등록은 keystone -32602. ⚠️ sender(0.0.x)는 키 파생 불가 → 본인 디바이스 실 Hedera 계정으로 교체(현재 0.0.587690=self). ⚠️ 반드시 mainnet(slip44:3030). 디바이스는 dissociate tx 해시만 서명 — 서명 확인용, broadcast 미수행(§9 verify-wire-sign HEDERA). associate는 hedera-hts-associate 참조.",
+    "sourceUrl": "https://docs.hedera.com/hedera/sdks-and-apis/sdks/token-service/dissociate-tokens-from-an-account",
+    "transaction": {
+      "type": "disassociate",
+      "tokenId": "0.0.731861",
+      "sender": "0.0.587690",
+      "memo": ""
     }
   }
 ]

--- a/playground/presets.rest.json
+++ b/playground/presets.rest.json
@@ -323,7 +323,7 @@
     "applicableChainIds": [
       "vechain:b1ac3413d346d43539627e6be7ec1b4a/slip44:818"
     ],
-    "note": "토큰 전송 — VeChain VIP-180(ERC-20 호환) token transfer. clauses[0].to=토큰 컨트랙트, value=0x0, data=transfer(address,uint256) calldata. 예시: VTHO(VeThor, contract 0x0000...456E65726779). ⚠️ wm vechain은 clauses[0]만 사용(multi-clause 미지원). data recipient(2번째 32바이트, 현재 0 placeholder)를 본인 주소로 교체 시 self-send. amount=0x3e8. ⚠️ wm는 data opaque pass-through — 기기 펌웨어의 VIP-180 표시 동작은 HW smoke 검증 필요. blockRef/nonce는 송금 전 갱신.",
+    "note": "토큰 전송 — VeChain VIP-180(ERC-20 호환) token transfer (VTHO 예시). clauses[0].to=토큰 컨트랙트, value=0x0, data=transfer(address,uint256) calldata. 예시: VTHO(VeThor, contract 0x0000...456E65726779), amount=0x3e8. ⚠️ wm vechain은 clauses[0]만 사용(multi-clause 미지원). data recipient(selector 다음 32바이트 하위 20B, 현재 0 placeholder)를 본인 주소로 교체 시 self-send. ✅ m02-05-75(DC-3096)부터 wm이 VIP-180을 식별→TokenAccount 합성→device에 토큰 symbol/수량/수신자 표시(더 이상 opaque pass-through 아님). 정식 §9 테스트 preset은 non-evm.json의 vechain-vip180-transfer(SHA, self-send-ready) 참조. blockRef/nonce는 송금 전 갱신.",
     "sourceUrl": "https://docs.vechain.org/core-concepts/transactions",
     "transaction": {
       "chainTag": 74,

--- a/src/transport/PopupTransport.ts
+++ b/src/transport/PopupTransport.ts
@@ -34,6 +34,16 @@ export interface PopupTransportOptions {
    * 미수신 시 silent fallback으로 `_handshake`를 즉시 송신 (구 sdk 호환). m07-02 B Gate.
    */
   readyTimeoutMs?: number
+  /**
+   * `_handshake` ack 대기 timeout (ms). 기본 60000 (60s).
+   *
+   * ⚠️ `timeoutMs`(request/response, 180s)와 **분리**한다. handshake ack는
+   * 사람이 개입하지 않는 기계-대-기계 popup-load 확인 신호라, interactive 서명용
+   * 180s backstop을 상속하면 dead/blocked/wrong-URL popup이 최대 190s(readyTimeout
+   * 10s + handshake 180s) 동안 dApp promise를 붙잡는 실패경로 latency 회귀가 생긴다.
+   * handshake는 popup 로드 직후 즉시 응답되므로 60s로 충분하다 (PR #175 이전 동작 유지).
+   */
+  handshakeTimeoutMs?: number
 }
 
 /**
@@ -78,6 +88,7 @@ export class PopupTransport implements MessageTransport {
   private readonly origin: string
   private readonly protocolVersion: string
   private readonly readyTimeoutMs: number
+  private readonly handshakeTimeoutMs: number
   private timeoutMs: number
 
   private popupWindow: Window | null = null
@@ -118,6 +129,19 @@ export class PopupTransport implements MessageTransport {
       )
     } else {
       this.readyTimeoutMs = ready
+    }
+    // boundary-validation: handshakeTimeoutMs도 양의 유한 number만 허용. 미지정 시 default 60s.
+    // timeoutMs(180s)와 분리 — handshake ack는 human-gated 아님 (Claude 크로스 리뷰 WARNING).
+    const hs = options.handshakeTimeoutMs
+    if (hs === undefined) {
+      this.handshakeTimeoutMs = 60000
+    } else if (typeof hs !== 'number' || !Number.isFinite(hs) || hs <= 0) {
+      throw new ProviderError(
+        ErrorCode.INVALID_PARAMS,
+        `handshakeTimeoutMs must be a positive finite number, got ${String(hs)}`,
+      )
+    } else {
+      this.handshakeTimeoutMs = hs
     }
   }
 
@@ -403,7 +427,7 @@ export class PopupTransport implements MessageTransport {
         this.pending.delete(handshakeId)
         const err = new ProviderError(
           ErrorCode.TIMEOUT,
-          `Handshake timed out after ${this.timeoutMs}ms`,
+          `Handshake timed out after ${this.handshakeTimeoutMs}ms`,
         )
         // m07-02: handshake error는 send의 .then(_, errHandler)가 받아 reject되어야 함.
         // close()가 preHandshakeRejecters로 DISCONNECTED를 먼저 던지면 actual error가 가려짐.
@@ -413,7 +437,7 @@ export class PopupTransport implements MessageTransport {
           /* defensive noop */
         })
         reject(err)
-      }, this.timeoutMs)
+      }, this.handshakeTimeoutMs)
 
       this.pending.set(handshakeId, {
         resolve: (response) => {

--- a/src/transport/PopupTransport.ts
+++ b/src/transport/PopupTransport.ts
@@ -15,7 +15,15 @@ import { toWireTransport } from '../sign/_sanitizeTransportOption'
 export interface PopupTransportOptions {
   /** popup으로 열 sdk URL. 기본 'https://bridge.dcentwallet.com/v2' */
   popUpUrl?: string
-  /** 응답 대기 timeout (ms). 기본 60000 (60s, v1 동일) */
+  /**
+   * 응답 대기 timeout (ms). 기본 180000 (180s / 3분).
+   *
+   * 60s(v1 동일)에서 상향: CIP-95(Cardano governance/DRep) 등 디바이스 서명을
+   * 2회 받아야 하는 흐름은 사용자 confirm × 2 + 화면 확인 시간으로 60s를 넘겨
+   * connector layer(TIMEOUT 5006)가 먼저 끊는 사례가 있었다. interactive 서명은
+   * 사람을 기다리므로 넉넉한 backstop이 필요. dApp이 더 짧게/길게 원하면
+   * `setTimeOutMs` / 생성자 `timeoutMs`로 override 가능.
+   */
   timeoutMs?: number
   /** postMessage 보안 origin. 미지정 시 popUpUrl의 URL.origin */
   origin?: string
@@ -96,7 +104,7 @@ export class PopupTransport implements MessageTransport {
 
   constructor (options: PopupTransportOptions = {}) {
     this.popUpUrl = options.popUpUrl ?? 'https://bridge.dcentwallet.com/v2'
-    this.timeoutMs = options.timeoutMs ?? 60000
+    this.timeoutMs = options.timeoutMs ?? 180000
     this.origin = options.origin ?? new URL(this.popUpUrl).origin
     this.protocolVersion = options.protocolVersion ?? '2.0'
     // boundary-validation: readyTimeoutMs는 양의 유한 number만 허용. 미지정 시 default 10s.

--- a/src/transport/PopupTransport.ts
+++ b/src/transport/PopupTransport.ts
@@ -381,7 +381,7 @@ export class PopupTransport implements MessageTransport {
         resolve()
       }
       // Y Timeout fallback — readyTimeoutMs 만료 시 silent resolve. 이후 _handshake 자체가
-      // m02-02의 timeoutMs로 보호되므로 추가 에러 처리 불필요 (error-handling-consistency:
+      // handshakeTimeoutMs로 보호되므로 추가 에러 처리 불필요 (error-handling-consistency:
       // ready signal 자체는 자산과 무관하므로 silent fallback이 정책상 정당).
       this.readyTimer = setTimeout(() => {
         this.readyTimer = null

--- a/tests/unit/2_v2_e2e/05_setTimeoutMs.spec.ts
+++ b/tests/unit/2_v2_e2e/05_setTimeoutMs.spec.ts
@@ -1,9 +1,11 @@
 /**
- * T-E-05 — setTimeoutMs override → TIMEOUT (5006)
+ * T-E-05 — handshakeTimeoutMs가 request setTimeoutMs와 분리됨 (decoupling 계약, PR #175)
  *
- * setTimeoutMs(2000)으로 default 60s를 단축한 뒤
- * popUpUrl을 listener 없는 빈 페이지(harness :9091/empty.html)로 향하게 하여
- * 2s 후 ProviderError(TIMEOUT, 5006)로 reject 검증.
+ * empty.html(listener 없음)은 handshake ack가 오지 않아 handshake 단계에서 실패한다.
+ * request용 setTimeoutMs를 크게(60s) 잡아도, handshake는 전용 handshakeTimeoutMs(2s)로
+ * 제어되므로 ~2s에 5006으로 수렴해야 한다. setTimeoutMs가 handshake까지 지배하던
+ * 구(PR #175 이전) 커플링이면 이 케이스는 60s를 기다려 spec timeout(30s)을 초과한다 →
+ * 회귀 가드. (Codex 크로스 리뷰 R2 finding 반영)
  */
 const { launchBrowser } = require('./launchBrowser')
 
@@ -28,10 +30,15 @@ describe('[v2 e2e] T-E-05 setTimeoutMs → TIMEOUT', () => {
     await page.evaluate(() => (window as any).dcentTest.close())
   })
 
-  it('T-E-05: setTimeoutMs(2000) + empty.html → 5006 TIMEOUT', async () => {
+  it('T-E-05: handshakeTimeoutMs(2000) < 큰 setTimeoutMs(60000) → 2s에 5006 (decoupling)', async () => {
     await page.evaluate((url: string) => {
-      ;(window as any).dcentTest.newTransport({ popUpUrl: url })
-      ;(window as any).dcentTest.setTimeoutMs(2000)
+      ;(window as any).dcentTest.newTransport({
+        popUpUrl: url,
+        handshakeTimeoutMs: 2000,
+        readyTimeoutMs: 500,
+      })
+      // request timeout을 크게 잡아도 handshake 실패경로에는 영향 없어야 함 (decoupling)
+      ;(window as any).dcentTest.setTimeoutMs(60000)
     }, EMPTY_URL)
 
     const start = Date.now()
@@ -42,8 +49,8 @@ describe('[v2 e2e] T-E-05 setTimeoutMs → TIMEOUT', () => {
 
     expect(result.ok).toBe(false)
     expect(result.error.code).toBe(5006)
-    // 2s 이상은 보장(setTimeoutMs 적용 확인). 상한은 default 60s와 분리만 되면 충분
-    // (slowmo/visual mode에서 puppeteer protocol overhead로 elapsed 증가 가능 — 30s까지 허용)
+    // ~2.5s(readyTimeout 0.5 + handshakeTimeout 2)에 수렴. setTimeoutMs(60000)에 커플링되면
+    // 이 상한을 초과 → 회귀. (slowmo/visual overhead 흡수 위해 30s까지 허용)
     expect(elapsed).toBeGreaterThan(1500)
     expect(elapsed).toBeLessThan(30000)
   }, 30000)

--- a/tests/unit/2_v2_e2e/06_origin_validation.spec.ts
+++ b/tests/unit/2_v2_e2e/06_origin_validation.spec.ts
@@ -34,11 +34,15 @@ describe('[v2 e2e] T-E-06 origin mismatch → TIMEOUT', () => {
 
   it('T-E-06: 잘못된 origin → 5006 TIMEOUT', async () => {
     await page.evaluate((url: string) => {
+      // 잘못된 origin → sdk의 _ready/handshake ack가 connector origin 검증에서 drop됨
+      // → handshake 미완료 → 5006. decoupling(PR #175) 후 handshake는 handshakeTimeoutMs로
+      // 제어되므로 짧게 주어 빠르게 수렴 (구: setTimeoutMs(2000)는 request 경로만 조정).
       ;(window as any).dcentTest.newTransport({
         popUpUrl: url,
         origin: 'https://evil.example.com',
+        handshakeTimeoutMs: 2000,
+        readyTimeoutMs: 500,
       })
-      ;(window as any).dcentTest.setTimeoutMs(2000)
     }, SDK_URL)
 
     const result = await page.evaluate(() => {

--- a/tests/unit/2_v2_e2e/08_handshake_timeout.spec.ts
+++ b/tests/unit/2_v2_e2e/08_handshake_timeout.spec.ts
@@ -2,9 +2,13 @@
  * T-E-08 — handshake timeout (listener 부재)
  *
  * popUpUrl을 listener 없는 빈 페이지(harness :9091/empty.html)로 향하게 하면
- * 연결된 popup에서 `_handshake` ack가 오지 않음. setTimeoutMs(3000) 후 ProviderError(TIMEOUT, 5006).
+ * 연결된 popup에서 `_handshake` ack가 오지 않음 → handshakeTimeoutMs 만료 후
+ * ProviderError(TIMEOUT, 5006).
  *
- * (T-E-05와 차이: T-E-05는 send timeout 일반, T-E-08은 specifically handshake가 ack 받지 못한 경우)
+ * PR #175 decoupling: handshake ack 대기는 request timeoutMs(180s)가 아닌 전용
+ * handshakeTimeoutMs로 제어된다. 따라서 이 실패경로는 newTransport에 짧은
+ * handshakeTimeoutMs(+readyTimeoutMs)를 주어 빠르게 5006으로 수렴시킨다
+ * (구: setTimeoutMs(3000) — decoupling 이후 setTimeoutMs는 request 경로만 조정).
  */
 const { launchBrowser } = require('./launchBrowser')
 
@@ -29,10 +33,13 @@ describe('[v2 e2e] T-E-08 handshake timeout', () => {
     await page.evaluate(() => (window as any).dcentTest.close())
   })
 
-  it('T-E-08: empty.html (listener 없음) + setTimeoutMs(3000) → 5006', async () => {
+  it('T-E-08: empty.html (listener 없음) + handshakeTimeoutMs(3000) → 5006', async () => {
     await page.evaluate((url: string) => {
-      ;(window as any).dcentTest.newTransport({ popUpUrl: url })
-      ;(window as any).dcentTest.setTimeoutMs(3000)
+      ;(window as any).dcentTest.newTransport({
+        popUpUrl: url,
+        handshakeTimeoutMs: 3000,
+        readyTimeoutMs: 500,
+      })
     }, EMPTY_URL)
 
     const start = Date.now()

--- a/tests/unit/v2/playground.signdata-authentry.test.ts
+++ b/tests/unit/v2/playground.signdata-authentry.test.ts
@@ -348,3 +348,85 @@ it('T-U-PRESET-RG-01: signMessage 폼 preset selector 회귀 0 — 공유 헬퍼
   const msgEl = document.getElementById('field-message') as HTMLTextAreaElement
   expect(msgEl.value).toBe(p.message)
 })
+
+// ─────────────────────────────────────────────────────────
+// m09-04-22-fix: signData getAddress-채움 버튼 (실제 디바이스 payment 주소)
+// ─────────────────────────────────────────────────────────
+it('T-U-SIGNDATA-GA-01: signData getAddress 버튼이 디바이스 payment 주소로 field-address를 채운다', async () => {
+  const api = (window as any)._playgroundTestAPI
+  const mockGetAddress = jest
+    .fn()
+    .mockResolvedValue({ address: 'addr1qDEVICE_PAYMENT', rewardAddress: 'stake1DEVICE' })
+  const dcent = makeMockDcent()
+  ;(dcent as any).getAddress = mockGetAddress
+
+  selectNode('signData:ada:cip8')
+  api.simulateConnect(dcent, null, { model: 'Bio', firmware: '3.0' })
+
+  const btn = document.getElementById('btn-signdata-getaddress') as HTMLButtonElement
+  expect(btn).toBeTruthy()
+  btn.click()
+  // getAddress Promise 체인(microtask) flush
+  await new Promise((r) => setTimeout(r, 0))
+
+  // 폼 기본값(chainId=cip34, keyPath=default)으로 getAddress가 1회 호출되고
+  expect(mockGetAddress).toHaveBeenCalledTimes(1)
+  const gaArg = mockGetAddress.mock.calls[0][0]
+  expect(gaArg.chainId).toBe('cip34:1-764824073')
+  expect(typeof gaArg.keyPath).toBe('string')
+  expect(gaArg.keyPath.length).toBeGreaterThan(0)
+
+  // 응답의 payment 주소(address)가 field-address에 주입됨 (rewardAddress 아님)
+  const addrEl = document.getElementById('field-address') as HTMLInputElement
+  expect(addrEl.value).toBe('addr1qDEVICE_PAYMENT')
+})
+
+it('T-U-SIGNDATA-GA-02: getAddress 응답에 address 없으면 field-address 미변경 (boundary-validation)', async () => {
+  const api = (window as any)._playgroundTestAPI
+  const mockGetAddress = jest.fn().mockResolvedValue({ rewardAddress: 'stake1ONLY' }) // address 부재
+  const dcent = makeMockDcent()
+  ;(dcent as any).getAddress = mockGetAddress
+
+  selectNode('signData:ada:cip8')
+  api.simulateConnect(dcent, null, { model: 'Bio', firmware: '3.0' })
+
+  const addrEl = document.getElementById('field-address') as HTMLInputElement
+  addrEl.value = 'PRESERVED'
+  ;(document.getElementById('btn-signdata-getaddress') as HTMLButtonElement).click()
+  await new Promise((r) => setTimeout(r, 0))
+
+  expect(mockGetAddress).toHaveBeenCalledTimes(1)
+  expect(addrEl.value).toBe('PRESERVED') // 추출 실패 시 기존 값 보존
+})
+
+// ─────────────────────────────────────────────────────────
+// m09-04-22-fix: 미지원 signMessage 노드 제거 lock
+//   tron/tezos = wm slot DC-2296 disabled, polkadot relay(dot:raw) = isParaChain 가드 throw.
+//   지원되는 Astar(paraChain) / stellar / solana signMessage는 유지.
+// ─────────────────────────────────────────────────────────
+it('T-U-SIGNMSG-REMOVED-01: 미지원 signMessage 노드(tron/tezos/polkadot relay)가 트리·PRESETS에서 제거됨', () => {
+  const api = (window as any)._playgroundTestAPI
+
+  // 제거된 노드 — DOM 부재
+  expect(document.querySelector('[data-method-id="signMessage:tron:raw"]')).toBeNull()
+  expect(document.querySelector('[data-method-id="signMessage:xtz:raw"]')).toBeNull()
+  expect(document.querySelector('[data-method-id="signMessage:dot:raw"]')).toBeNull()
+
+  // 제거된 노드 — PRESETS map 부재
+  expect(api.PRESETS['signMessage:tron:raw']).toBeUndefined()
+  expect(api.PRESETS['signMessage:xtz:raw']).toBeUndefined()
+  expect(api.PRESETS['signMessage:dot:raw']).toBeUndefined()
+})
+
+it('T-U-SIGNMSG-REMOVED-02: 지원되는 signMessage 노드(Astar/stellar/solana)는 유지됨', () => {
+  const api = (window as any)._playgroundTestAPI
+
+  expect(document.querySelector('[data-method-id="signMessage:dot:raw:astar"]')).toBeTruthy()
+  expect(document.querySelector('[data-method-id="signMessage:xlm:raw"]')).toBeTruthy()
+  expect(document.querySelector('[data-method-id="signMessage:sol:raw"]')).toBeTruthy()
+
+  // Astar preset(paraChain 지원 경로)은 유지
+  const astarPresets = api.PRESETS['signMessage:dot:raw:astar']
+  expect(Array.isArray(astarPresets)).toBe(true)
+  expect(astarPresets.length).toBeGreaterThan(0)
+})

--- a/tests/unit/v2/playground.signdata-authentry.test.ts
+++ b/tests/unit/v2/playground.signdata-authentry.test.ts
@@ -267,3 +267,84 @@ it('T-U-SIGNMSG-XLM-01: stellar signMessage 노드가 기존 signMessage wire로
   expect(xlmPresets.length).toBeGreaterThan(0)
   expect(xlmPresets[0].message).toBe('Hello Stellar!')
 })
+
+// ─────────────────────────────────────────────────────────
+// m09-04-22: preset selector (공유 헬퍼 renderPresetSelector)
+// ─────────────────────────────────────────────────────────
+
+// 트리 노드 선택 → 폼 렌더 (connect 불필요; 폼은 click 시 렌더)
+function selectNode(methodId: string): void {
+  const item = document.querySelector('[data-method-id="' + methodId + '"]') as HTMLElement
+  item.click()
+}
+
+// #field-preset의 option[value=idx]를 change 디스패치
+function pickPreset(idx: number): void {
+  const sel = document.getElementById('field-preset') as HTMLSelectElement
+  sel.value = String(idx)
+  sel.dispatchEvent(new Event('change'))
+}
+
+it('T-U-PRESET-SD-01: PRESETS[signData:ada:cip8] 존재 + 각 엔트리 {label,address,payload} shape', () => {
+  const api = (window as any)._playgroundTestAPI
+  const presets = api.PRESETS['signData:ada:cip8']
+  expect(Array.isArray(presets)).toBe(true)
+  expect(presets.length).toBeGreaterThan(0)
+  presets.forEach((p: any) => {
+    expect(typeof p.label).toBe('string')
+    expect(typeof p.address).toBe('string')
+    expect(typeof p.payload).toBe('string')
+  })
+})
+
+it('T-U-PRESET-SD-02: signData 폼 preset selector → field-address/field-payload 채움', () => {
+  const api = (window as any)._playgroundTestAPI
+  const p = api.PRESETS['signData:ada:cip8'][0]
+  selectNode('signData:ada:cip8')
+
+  const sel = document.getElementById('field-preset') as HTMLSelectElement
+  expect(sel).toBeTruthy()
+  pickPreset(0)
+
+  const addrEl = document.getElementById('field-address') as HTMLInputElement
+  const plEl = document.getElementById('field-payload') as HTMLTextAreaElement
+  expect(addrEl.value).toBe(p.address)
+  expect(plEl.value).toBe(p.payload)
+})
+
+it('T-U-PRESET-AE-01: PRESETS[signAuthEntry:xlm:soroban] 존재 + 각 엔트리 {label,authEntry} shape', () => {
+  const api = (window as any)._playgroundTestAPI
+  const presets = api.PRESETS['signAuthEntry:xlm:soroban']
+  expect(Array.isArray(presets)).toBe(true)
+  expect(presets.length).toBeGreaterThan(0)
+  presets.forEach((p: any) => {
+    expect(typeof p.label).toBe('string')
+    expect(typeof p.authEntry).toBe('string')
+  })
+})
+
+it('T-U-PRESET-AE-02: signAuthEntry 폼 preset selector → field-authEntry 채움', () => {
+  const api = (window as any)._playgroundTestAPI
+  const p = api.PRESETS['signAuthEntry:xlm:soroban'][0]
+  selectNode('signAuthEntry:xlm:soroban')
+
+  const sel = document.getElementById('field-preset') as HTMLSelectElement
+  expect(sel).toBeTruthy()
+  pickPreset(0)
+
+  const aeEl = document.getElementById('field-authEntry') as HTMLTextAreaElement
+  expect(aeEl.value).toBe(p.authEntry)
+})
+
+it('T-U-PRESET-RG-01: signMessage 폼 preset selector 회귀 0 — 공유 헬퍼 경유 후에도 field-message 채움', () => {
+  const api = (window as any)._playgroundTestAPI
+  const p = api.PRESETS['signMessage:xlm:raw'][0]
+  selectNode('signMessage:xlm:raw')
+
+  const sel = document.getElementById('field-preset') as HTMLSelectElement
+  expect(sel).toBeTruthy()
+  pickPreset(0)
+
+  const msgEl = document.getElementById('field-message') as HTMLTextAreaElement
+  expect(msgEl.value).toBe(p.message)
+})

--- a/tests/unit/v2/playground.signdata-authentry.test.ts
+++ b/tests/unit/v2/playground.signdata-authentry.test.ts
@@ -285,19 +285,20 @@ function pickPreset(idx: number): void {
   sel.dispatchEvent(new Event('change'))
 }
 
-it('T-U-PRESET-SD-01: PRESETS[signData:ada:cip8] 존재 + 각 엔트리 {label,address,payload} shape', () => {
+it('T-U-PRESET-SD-01: PRESETS[signData:ada:cip8] 존재 + {label,payload} shape (address는 getAddress로)', () => {
   const api = (window as any)._playgroundTestAPI
   const presets = api.PRESETS['signData:ada:cip8']
   expect(Array.isArray(presets)).toBe(true)
   expect(presets.length).toBeGreaterThan(0)
   presets.forEach((p: any) => {
     expect(typeof p.label).toBe('string')
-    expect(typeof p.address).toBe('string')
     expect(typeof p.payload).toBe('string')
+    // m09-04-22-fix: address는 hex+디바이스 소유 필수라 preset에 없음 (📡 getAddress로 채움)
+    expect(p.address).toBeUndefined()
   })
 })
 
-it('T-U-PRESET-SD-02: signData 폼 preset selector → field-address/field-payload 채움', () => {
+it('T-U-PRESET-SD-02: signData 폼 preset selector → field-payload 채움 (address 미변경)', () => {
   const api = (window as any)._playgroundTestAPI
   const p = api.PRESETS['signData:ada:cip8'][0]
   selectNode('signData:ada:cip8')
@@ -306,13 +307,14 @@ it('T-U-PRESET-SD-02: signData 폼 preset selector → field-address/field-paylo
   expect(sel).toBeTruthy()
   pickPreset(0)
 
-  const addrEl = document.getElementById('field-address') as HTMLInputElement
   const plEl = document.getElementById('field-payload') as HTMLTextAreaElement
-  expect(addrEl.value).toBe(p.address)
   expect(plEl.value).toBe(p.payload)
+  // preset은 address를 채우지 않는다 (getAddress 담당)
+  const addrEl = document.getElementById('field-address') as HTMLInputElement
+  expect(addrEl.value).toBe('')
 })
 
-it('T-U-PRESET-AE-01: PRESETS[signAuthEntry:xlm:soroban] 존재 + 각 엔트리 {label,authEntry} shape', () => {
+it('T-U-PRESET-AE-01: PRESETS[signAuthEntry:xlm:soroban] 존재 + 유효 XDR (placeholder 아님)', () => {
   const api = (window as any)._playgroundTestAPI
   const presets = api.PRESETS['signAuthEntry:xlm:soroban']
   expect(Array.isArray(presets)).toBe(true)
@@ -320,6 +322,11 @@ it('T-U-PRESET-AE-01: PRESETS[signAuthEntry:xlm:soroban] 존재 + 각 엔트리 
   presets.forEach((p: any) => {
     expect(typeof p.label).toBe('string')
     expect(typeof p.authEntry).toBe('string')
+    // m09-04-22-fix: 실제 생성한 유효 SorobanAuthorizationEntry XDR — placeholder 금지
+    expect(p.authEntry).not.toContain('replace')
+    expect(p.authEntry.length).toBeGreaterThan(100)
+    // base64 형식 (device가 파싱할 수 있는 문자셋)
+    expect(/^[A-Za-z0-9+/=]+$/.test(p.authEntry)).toBe(true)
   })
 })
 
@@ -352,11 +359,17 @@ it('T-U-PRESET-RG-01: signMessage 폼 preset selector 회귀 0 — 공유 헬퍼
 // ─────────────────────────────────────────────────────────
 // m09-04-22-fix: signData getAddress-채움 버튼 (실제 디바이스 payment 주소)
 // ─────────────────────────────────────────────────────────
-it('T-U-SIGNDATA-GA-01: signData getAddress 버튼이 디바이스 payment 주소로 field-address를 채운다', async () => {
+// 알려진 mainnet base address ↔ raw bytes hex (bech32 npm 라이브러리로 디코드한 reference 벡터)
+const REF_ADDR_BECH32 =
+  'addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x'
+const REF_ADDR_HEX =
+  '019493315cd92eb5d8c4304e67b7e16ae36d61d34502694657811a2c8e337b62cfff6403a06a3acbc34f8c46003c69fe79a3628cefa9c47251'
+
+it('T-U-SIGNDATA-GA-01: signData getAddress 버튼이 디바이스 payment 주소를 hex로 변환해 field-address를 채운다', async () => {
   const api = (window as any)._playgroundTestAPI
   const mockGetAddress = jest
     .fn()
-    .mockResolvedValue({ address: 'addr1qDEVICE_PAYMENT', rewardAddress: 'stake1DEVICE' })
+    .mockResolvedValue({ address: REF_ADDR_BECH32, rewardAddress: 'stake1DEVICE' })
   const dcent = makeMockDcent()
   ;(dcent as any).getAddress = mockGetAddress
 
@@ -376,9 +389,19 @@ it('T-U-SIGNDATA-GA-01: signData getAddress 버튼이 디바이스 payment 주�
   expect(typeof gaArg.keyPath).toBe('string')
   expect(gaArg.keyPath.length).toBeGreaterThan(0)
 
-  // 응답의 payment 주소(address)가 field-address에 주입됨 (rewardAddress 아님)
+  // bech32 payment 주소가 raw hex로 변환되어 주입됨 (signData는 hex address 요구)
   const addrEl = document.getElementById('field-address') as HTMLInputElement
-  expect(addrEl.value).toBe('addr1qDEVICE_PAYMENT')
+  expect(addrEl.value).toBe(REF_ADDR_HEX)
+})
+
+it('T-U-SIGNDATA-GA-03: 미연결 상태에서는 getAddress 버튼이 facade를 호출하지 않는다 (Connect 게이트)', () => {
+  // simulateConnect 하지 않음 → state.connected = false
+  const mockGetAddress = jest.fn()
+  selectNode('signData:ada:cip8')
+  ;(window as any).dcent = { getAddress: mockGetAddress }
+  ;(document.getElementById('btn-signdata-getaddress') as HTMLButtonElement).click()
+  expect(mockGetAddress).not.toHaveBeenCalled()
+  delete (window as any).dcent
 })
 
 it('T-U-SIGNDATA-GA-02: getAddress 응답에 address 없으면 field-address 미변경 (boundary-validation)', async () => {
@@ -429,4 +452,56 @@ it('T-U-SIGNMSG-REMOVED-02: 지원되는 signMessage 노드(Astar/stellar/solana
   const astarPresets = api.PRESETS['signMessage:dot:raw:astar']
   expect(Array.isArray(astarPresets)).toBe(true)
   expect(astarPresets.length).toBeGreaterThan(0)
+})
+
+// ─────────────────────────────────────────────────────────
+// m09-04-22-fix: Cardano bech32 → hex 변환 (signData address)
+// ─────────────────────────────────────────────────────────
+it('T-U-BECH32-01: _cardanoBech32ToHex — reference 벡터 + hex passthrough + edge', () => {
+  const api = (window as any)._playgroundTestAPI
+  const f = api._cardanoBech32ToHex
+
+  // 알려진 mainnet base address → raw bytes hex (external 라이브러리 bech32와 bytewise 동등)
+  expect(f(REF_ADDR_BECH32)).toBe(REF_ADDR_HEX)
+
+  // 이미 hex면 정규화만 (0x 제거, 소문자)
+  expect(f('0x019493')).toBe('019493')
+  expect(f('AABBCC')).toBe('aabbcc')
+
+  // 형식 불량 / 빈 입력 → ''
+  expect(f('')).toBe('')
+  expect(f('not-an-address')).toBe('')
+  expect(f('odd-len-hex-abc')).toBe('')
+})
+
+// ─────────────────────────────────────────────────────────
+// m09-04-22-fix: signMessage datalist에서 미지원 polkadot relay 제외
+// ─────────────────────────────────────────────────────────
+it('T-U-SIGNMSG-DATALIST-01: Astar signMessage 폼 datalist가 polkadot relay(slip44:354)를 제외한다', () => {
+  const api = (window as any)._playgroundTestAPI
+  const chains = [
+    {
+      chainId: 'polkadot:91b171bb158e2d3848fa23a9f1c25182/slip44:354',
+      family: 'polkadot',
+      displayName: 'Polkadot',
+      defaultKeyPath: "m/44'/354'/0'/0/0",
+    },
+    {
+      chainId: 'polkadot:9eb76c5184c4ab8679d2d5d819fdf90b/slip44:810',
+      family: 'polkadot',
+      displayName: 'Astar',
+      defaultKeyPath: "m/44'/810'/0'/0/0",
+    },
+  ]
+  api.simulateNonEvmLoad(chains, [])
+  selectNode('signMessage:dot:raw:astar')
+
+  const datalist = document.getElementById('datalist-chainId') as HTMLDataListElement
+  expect(datalist).toBeTruthy()
+  const values = Array.from(datalist.querySelectorAll('option')).map(
+    (o) => (o as HTMLOptionElement).value
+  )
+  // relay(slip44:354)는 자동완성에서 제외, Astar(slip44:810)는 포함
+  expect(values.some((v) => v.indexOf('slip44:354') !== -1)).toBe(false)
+  expect(values.some((v) => v.indexOf('slip44:810') !== -1)).toBe(true)
 })

--- a/tests/unit/v2/playground.signdata-authentry.test.ts
+++ b/tests/unit/v2/playground.signdata-authentry.test.ts
@@ -507,6 +507,14 @@ it('T-U-BECH32-01: _cardanoBech32ToHex — reference 벡터 + hex passthrough + 
   expect(f('')).toBe('')
   expect(f('not-an-address')).toBe('')
   expect(f('odd-len-hex-abc')).toBe('')
+
+  // BIP-173 checksum 검증: 첫 data char(q→p) 변조 → '' (typo/corruption 거부)
+  const corrupted = REF_ADDR_BECH32.slice(0, 5) + 'p' + REF_ADDR_BECH32.slice(6)
+  expect(corrupted).not.toBe(REF_ADDR_BECH32)
+  expect(f(corrupted)).toBe('')
+
+  // mixed-case → '' (BIP-173 전부 소문자/대문자만 허용)
+  expect(f('A' + REF_ADDR_BECH32.slice(1))).toBe('')
 })
 
 // ─────────────────────────────────────────────────────────

--- a/tests/unit/v2/playground.signdata-authentry.test.ts
+++ b/tests/unit/v2/playground.signdata-authentry.test.ts
@@ -109,12 +109,14 @@ it('T-U-SIGNDATA-01: signData:ada:cip8 노드가 cardano chainId로 트리에 �
   expect(dom).toBeTruthy()
 })
 
-it('T-U-SIGNDATA-02: signData dispatcher가 { method, chainId, payload:{ keyPath, address, payload } } wire를 전송한다', () => {
+it('T-U-SIGNDATA-02: signData dispatcher가 { method, chainId, payload:{ keyPath, address(hex), payload } } wire를 전송한다', () => {
   const mockSign = jest.fn().mockResolvedValue({ header: { status: 'success' }, body: { parameter: { signature: 'sig', key: 'k' } } })
+  // 유효 hex address (57 bytes)
+  const HEX57 = '0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738'
   selectAndSend('signData:ada:cip8', {
     chainId: 'cip34:1-764824073',
     keyPath: "m/44'/1815'/0'/0/0",
-    address: 'addr1qxy...',
+    address: HEX57,
     payload: 'deadbeef',
   }, mockSign)
 
@@ -122,8 +124,41 @@ it('T-U-SIGNDATA-02: signData dispatcher가 { method, chainId, payload:{ keyPath
   expect(mockSign).toHaveBeenCalledWith({
     method: 'signData',
     chainId: 'cip34:1-764824073',
-    payload: { keyPath: "m/44'/1815'/0'/0/0", address: 'addr1qxy...', payload: 'deadbeef' },
+    payload: { keyPath: "m/44'/1815'/0'/0/0", address: HEX57, payload: 'deadbeef' },
   })
+})
+
+it('T-U-SIGNDATA-02b: bech32 addr1 입력은 hex로 정규화되어 wire에 실린다', () => {
+  const mockSign = jest.fn().mockResolvedValue({ header: { status: 'success' }, body: { parameter: {} } })
+  selectAndSend('signData:ada:cip8', {
+    chainId: 'cip34:1-764824073',
+    keyPath: "m/44'/1815'/0'/0/0",
+    address: REF_ADDR_BECH32,
+    payload: 'deadbeef',
+  }, mockSign)
+
+  expect(mockSign).toHaveBeenCalledTimes(1)
+  expect(mockSign.mock.calls[0][0].payload.address).toBe(REF_ADDR_HEX)
+})
+
+it('T-U-SIGNDATA-02c: hex도 bech32도 아닌/짧은 address는 dispatcher 호출 0건 (hex ≥28B 강제)', () => {
+  const mockShort = jest.fn()
+  selectAndSend('signData:ada:cip8', {
+    chainId: 'cip34:1-764824073',
+    keyPath: "m/44'/1815'/0'/0/0",
+    address: 'deadbeef', // 4 bytes < 28
+    payload: 'deadbeef',
+  }, mockShort)
+  expect(mockShort).not.toHaveBeenCalled()
+
+  const mockGarbage = jest.fn()
+  selectAndSend('signData:ada:cip8', {
+    chainId: 'cip34:1-764824073',
+    keyPath: "m/44'/1815'/0'/0/0",
+    address: 'not-a-valid-address',
+    payload: 'deadbeef',
+  }, mockGarbage)
+  expect(mockGarbage).not.toHaveBeenCalled()
 })
 
 it('T-U-SIGNDATA-03: address 누락 시 dispatcher 호출 0건 (boundary-validation)', () => {
@@ -143,7 +178,7 @@ it('T-U-SIGNDATA-04: 빈 payload는 유효 — CIP-8 opaque empty payload 수용
   selectAndSend('signData:ada:cip8', {
     chainId: 'cip34:1-764824073',
     keyPath: "m/44'/1815'/0'/0/0",
-    address: 'addr1qxy...',
+    address: REF_ADDR_HEX, // 유효 hex address (57 bytes)
     payload: '',
   }, mockSign)
 

--- a/tests/unit/v2/playground.signtx-evm.test.ts
+++ b/tests/unit/v2/playground.signtx-evm.test.ts
@@ -129,8 +129,9 @@ it('T-U-EVM-01: simulateEvmLoad 후 EVM 체인 노드가 TREE에 추가된다', 
   // DC-2309 (b11-01): sign message 비-EVM family 3종(sol/tron/dot) + Astar 추가 → 4→8 → 20
   // m10-01-11/12/14: signMessage Stellar(1) + signData Cardano(1) + signAuthEntry Stellar(1) → 23
   // m09-04-21: Account API에 getPublicKey(1) 추가 → 24
+  // m09-04-22-fix: 미지원 signMessage 3종 제거(tron/tezos slot disabled + polkadot relay throw) → 21
   const beforeCount = api.countMethodNodes()
-  expect(beforeCount).toBe(24)
+  expect(beforeCount).toBe(21)
 
   // EVM 체인 로드 시뮬레이션
   api.simulateEvmLoad(SAMPLE_CHAINS, SAMPLE_PRESETS)

--- a/tests/unit/v2/playground.signtx-non-evm.test.ts
+++ b/tests/unit/v2/playground.signtx-non-evm.test.ts
@@ -337,7 +337,7 @@ it('T-U-NEVM-04: presets.non-evm.json — wm 등록 family preset 모두 valid J
   // 누락보강(P1)으로 NON_EVM_FAMILIES에 추가된 xahau/cardano/near/constellation preset이
   // orphan에서 활성화됨 + havah preset 신규 추가 → expectedFamilies에 포함.
   // 토큰 transfer preset(m02-05-55~68) 추가로 stacks(SIP-010)/tezos(FA1.2·FA2) family 신규 등록.
-  const expectedFamilies = ['bitcoin', 'solana', 'xrp', 'hedera', 'stellar', 'xahau', 'cardano', 'near', 'constellation', 'havah', 'stacks', 'tezos']
+  const expectedFamilies = ['bitcoin', 'solana', 'xrp', 'hedera', 'stellar', 'xahau', 'cardano', 'near', 'constellation', 'havah', 'stacks', 'tezos', 'vechain']
 
   // CAIP-19 정규식: namespace:reference/slip44:N
   // CAIP-2 namespace는 spec상 3-8 chars 권장이나 wm registry는 더 긴 namespace 사용

--- a/tests/unit/v2/playground.smoke.test.ts
+++ b/tests/unit/v2/playground.smoke.test.ts
@@ -71,7 +71,7 @@ afterEach(() => {
 // T-U-01: 트리 DOM 빌더 — TREE 선언적 객체에서 expected node 개수
 // m11-01-01: Account/Device 그룹 8 method + signMessage 4 method = 12 (기존 5에서 변경)
 // ─────────────────────────────────────────────────────────
-it('T-U-01: 트리 DOM에 24개 non-placeholder method node가 렌더링된다', () => {
+it('T-U-01: 트리 DOM에 21개 non-placeholder method node가 렌더링된다', () => {
   const api = (window as any)._playgroundTestAPI
   expect(api).toBeDefined()
 
@@ -81,12 +81,14 @@ it('T-U-01: 트리 DOM에 24개 non-placeholder method node가 렌더링된다',
   // DC-2309 (b11-01): signMessage 비-EVM family 3종(sol/tron/dot) + Astar → 4→8 → 20
   // m10-01-11/12/14: signMessage Stellar(1) + signData Cardano(1) + signAuthEntry Stellar(1) → 23
   // m09-04-21: Account API에 getPublicKey(1) 추가 → 24
+  // m09-04-22-fix: 미지원 signMessage 3종 제거 — tron/tezos(wm slot DC-2296 disabled) +
+  //   polkadot relay(dot:raw, isParaChain 가드 throw). Astar(paraChain)만 유지 → 24-3 = 21
   const count = api.countMethodNodes()
-  expect(count).toBe(24)
+  expect(count).toBe(21)
 
-  // DOM에는 placeholder 포함 25개 .tree-item (EVM 체인 로드 전 placeholder 1개 추가)
+  // DOM에는 placeholder 포함 22개 .tree-item (EVM 체인 로드 전 placeholder 1개 추가)
   const domItems = document.querySelectorAll('.tree-item')
-  expect(domItems.length).toBe(25) // 24 non-placeholder + 1 EVM loading placeholder
+  expect(domItems.length).toBe(22) // 21 non-placeholder + 1 EVM loading placeholder
 })
 
 // ─────────────────────────────────────────────────────────

--- a/tests/unit/v2/transport/PopupTransport.test.ts
+++ b/tests/unit/v2/transport/PopupTransport.test.ts
@@ -272,7 +272,8 @@ describe('PopupTransport', () => {
   // ===== T-U-07: origin mismatch =====
   describe('T-U-07: origin mismatch silent drop', () => {
     it('다른 origin의 메시지는 무시 — pending 영향 0', async () => {
-      transport = new PopupTransport()
+      // timeout을 assertion 수단으로만 사용 — default(180s)와 분리해 60000으로 고정
+      transport = new PopupTransport({ timeoutMs: 60000 })
       const promise = transport.send(makeEnvelope('req-1'))
       await flushHandshake()
 
@@ -294,7 +295,8 @@ describe('PopupTransport', () => {
       ['T-U-08c (id 누락)', { result: 'no-id' }],
       ['T-U-08d (id non-string)', { id: 123, result: 'x' }],
     ])('%s → silent drop, pending unchanged', async (_label, badData) => {
-      transport = new PopupTransport()
+      // timeout을 assertion 수단으로만 사용 — default(180s)와 분리해 60000으로 고정
+      transport = new PopupTransport({ timeoutMs: 60000 })
       const promise = transport.send(makeEnvelope('req-1'))
       await flushHandshake()
 
@@ -310,7 +312,8 @@ describe('PopupTransport', () => {
   // ===== T-U-09: unknown id silent drop =====
   describe('T-U-09: unknown id silent drop', () => {
     it('모르는 id의 응답은 무시 (이미 timeout 처리된 후 도착할 수 있음)', async () => {
-      transport = new PopupTransport()
+      // timeout을 assertion 수단으로만 사용 — default(180s)와 분리해 60000으로 고정
+      transport = new PopupTransport({ timeoutMs: 60000 })
       const promise = transport.send(makeEnvelope('req-1'))
       await flushHandshake()
 
@@ -439,7 +442,16 @@ describe('PopupTransport', () => {
       expect(openSpy).toHaveBeenCalledWith(DEFAULT_URL, '_blank')
       expect(mockPopup.postMessage).toHaveBeenCalledWith(expect.any(Object), DEFAULT_ORIGIN)
 
+      // default timeout = 180000 (60s에서 상향, CIP-95 2회 서명 대응).
+      // 60000으로의 회귀를 잡기 위해: 60s 시점엔 아직 pending, 180s에 TIMEOUT.
+      let settled = false
+      promise.then(() => { settled = true }, () => { settled = true })
+
       jest.advanceTimersByTime(60000)
+      await Promise.resolve()
+      expect(settled).toBe(false) // 60s에 안 끊김 → default > 60s 증명
+
+      jest.advanceTimersByTime(120000) // 총 180s
       await expect(promise).rejects.toMatchObject({ code: ErrorCode.TIMEOUT })
 
       await transport.close()
@@ -575,8 +587,9 @@ describe('PopupTransport', () => {
 
   // ===== T-U-HS-05: handshake timeout =====
   describe('T-U-HS-05: handshake timeout', () => {
-    it('default 60s 안에 ack 안 옴 → TIMEOUT reject + close()', async () => {
-      transport = new PopupTransport()
+    it('timeoutMs 안에 ack 안 옴 → TIMEOUT reject + close()', async () => {
+      // handshake timeout도 this.timeoutMs를 공유 — assertion 수단으로 60000 고정
+      transport = new PopupTransport({ timeoutMs: 60000 })
       // handshake auto-respond 비활성화 (응답 안 옴)
       mockPopup.postMessage.mockImplementation(() => { /* swallow */ })
 

--- a/tests/unit/v2/transport/PopupTransport.test.ts
+++ b/tests/unit/v2/transport/PopupTransport.test.ts
@@ -587,9 +587,9 @@ describe('PopupTransport', () => {
 
   // ===== T-U-HS-05: handshake timeout =====
   describe('T-U-HS-05: handshake timeout', () => {
-    it('timeoutMs 안에 ack 안 옴 → TIMEOUT reject + close()', async () => {
-      // handshake timeout도 this.timeoutMs를 공유 — assertion 수단으로 60000 고정
-      transport = new PopupTransport({ timeoutMs: 60000 })
+    it('handshakeTimeoutMs 안에 ack 안 옴 → TIMEOUT reject + close()', async () => {
+      // handshake는 전용 handshakeTimeoutMs 사용 — assertion 수단으로 60000 고정
+      transport = new PopupTransport({ handshakeTimeoutMs: 60000 })
       // handshake auto-respond 비활성화 (응답 안 옴)
       mockPopup.postMessage.mockImplementation(() => { /* swallow */ })
 
@@ -600,6 +600,46 @@ describe('PopupTransport', () => {
 
       await expect(promise).rejects.toMatchObject({ code: ErrorCode.TIMEOUT })
       expect(mockPopup.close).toHaveBeenCalled()
+    })
+  })
+
+  // ===== T-U-HS-07: handshake timeout이 request timeoutMs(180s)에 커플링되지 않음 =====
+  // Claude 크로스 리뷰 WARNING 회귀 가드 (PR #175): timeoutMs 180s 상향이
+  // handshake ack까지 상속하면 dead popup이 190s 붙잡는 latency 회귀. handshake는
+  // 전용 default 60s를 유지해야 한다.
+  describe('T-U-HS-07: handshake timeout decoupled from request timeoutMs', () => {
+    it('timeoutMs=180000(default)여도 handshake는 60s에 TIMEOUT (180s 미상속)', async () => {
+      // request timeout만 180s, handshakeTimeoutMs는 미지정 → default 60s
+      transport = new PopupTransport({ timeoutMs: 180000 })
+      mockPopup.postMessage.mockImplementation(() => { /* ack 안 옴 */ })
+
+      const promise = transport.send(makeEnvelope('req-1'))
+      let settled = false
+      promise.then(() => { settled = true }, () => { settled = true })
+      await flushHandshake()
+
+      // 59s 시점: 아직 pending (60s 미도달)
+      jest.advanceTimersByTime(59000)
+      await Promise.resolve()
+      expect(settled).toBe(false)
+
+      // 60s 시점: handshake TIMEOUT (180s를 기다리지 않음)
+      jest.advanceTimersByTime(1000)
+      await expect(promise).rejects.toMatchObject({ code: ErrorCode.TIMEOUT })
+      expect(mockPopup.close).toHaveBeenCalled()
+    })
+  })
+
+  // ===== T-U-HS-08: handshakeTimeoutMs boundary-validation =====
+  describe('T-U-HS-08: handshakeTimeoutMs 검증', () => {
+    it.each([
+      ['0', 0],
+      ['음수', -1],
+      ['NaN', NaN],
+      ['Infinity', Number.POSITIVE_INFINITY],
+    ])('%s → INVALID_PARAMS throw', (_label, bad) => {
+      expect(() => new PopupTransport({ handshakeTimeoutMs: bad as number }))
+        .toThrow(ProviderError)
     })
   })
 


### PR DESCRIPTION
## Summary

playground-v2에서 Cardano **signData** / Stellar **signAuthEntry**를 원클릭 샘플로 테스트할 수 있도록 PRESETS 엔트리 + 폼 preset selector를 추가하고, 배포 전 playground 전수 검증에서 함께 발견된 3개 영역을 편입했다:

- **(원 스코프)** signData/signAuthEntry preset selector — 공유 헬퍼 `renderPresetSelector(presetKey, fillFn)`로 3곳(signMessage 포함) 헬퍼화
- **(확장 A)** signData 폼 robustness — address hex 변환/유효성 + bech32 BIP-173 checksum + Connect 게이트 (Codex 로컬 크로스 리뷰 반영)
- **(확장 B)** 다체인 token·signTx JSON preset 대량 추가 (`presets.{evm,non-evm,rest}.json`)
- **(확장 C)** `PopupTransport` default timeout **60s → 180s** — CIP-95 2회 서명 대응 (backward-compatible)

> 스코프 확장 근거는 objective §11 RE-AUDIT-LOG 참조. 모두 동일 playground 검증 세션 파생 + hardware-independent 경계 + cross-repo 영향 0.

## Objective

- **ID**: `m09-04-22-playground-signdata-authentry-presets`
- **Jira**: [DC-3043](https://iotrust.atlassian.net/browse/DC-3043) (Sub-task, parent epic DC-2223)
- **Epic**: m09-04 (connector v2 cleanup) — base=`epic/DC-2223_m09-04-connector-v2-cleanup`
- **Type**: chore (hardware-independent — jest 단위 검증) · `pr-size-exception: generated-code`(static preset JSON)

## Scope

### 원 스코프 — signData/signAuthEntry preset selector
- `PRESETS` 맵에 `'signData:ada:cip8'`({label,address,payload}) + `'signAuthEntry:xlm:soroban'`({label,authEntry}) 추가
- 폼 빌더 2곳에 preset selector 이식 — 공유 헬퍼 `renderPresetSelector` 추출 (signMessage 포함 3곳, 회귀 0)
- JSON-list 기반 4개 selector(account/bitcoinTx/evm/nonEvm)는 shape 달라 **병합 금지**

### 확장 A — signData 폼 입력 robustness (Codex 리뷰)
- signData address hex 변환/유효성 강제 + bech32 BIP-173 checksum + mixed-case 검증
- Connect 게이트 + datalist 필터 + getAddress-채움 버튼 (동기 throw도 `.catch` 흡수 — async-hygiene)

### 확장 B — 다체인 token·signTx JSON preset
- **EVM**: `evm-erc20-transfer-unregistered`(nativeFallback wc-style) + erc20-transfer note
- **VeChain**: `vechain-vip180-transfer`(SHA, self-send-ready)
- **Constellation**: `dag-dor-metagraph-transfer` / `dag-custom-metagraph-transfer`(form-D, 등록/미등록 -32602 가드)
- **Solana**: `sol-spl-descriptor-transfer`(form-D descriptor)
- **Kaia**: `kaia-kip7-transfer`, `klaytn-fee-delegation-transfer`(senderTxHashRLP)
- **Cardano**: CIP-95 vote-deleg/drep-vote + structured signTx 다수(ordinary/vote-deleg/stake-registration/withdrawal/drep-vote/mint/plutus)
- **NEAR/Hedera/Stellar/XRP**: near-ft-unregistered, hedera unsigned-passthrough·hts-associate/dissociate, stellar soroban invoke·xdr-passthrough, xrp accountset·trustset

### 확장 C — PopupTransport interactive 서명 timeout
- default `timeoutMs` 60s → 180s. dApp은 `setTimeOutMs`/생성자 `timeoutMs`로 override 가능.
- **handshake ack 대기는 전용 `handshakeTimeoutMs`(default 60s)로 분리** — request용 180s backstop이 기계-대-기계 handshake까지 상속해 dead popup을 190s 붙잡는 실패경로 회귀를 방지 (로컬 크로스 리뷰 반영).
- **메시지 shape/method/params 불변 → backward-compatible, sdk 동시 변경 불필요** (`cross-repo-interface-edit` 판정).

## Non-scope

- method wiring / 라우팅 / capability 변경 — 전 계층 존재 확인 완료. 변경 없음.
- 메시지 프로토콜 shape 변경 — 확장 C는 default 값 상향뿐.
- 실서명 payload 정합(CIP-8 CBOR / Soroban XDR / form-D 디바이스 표시) — 실서명 round-trip은 HW smoke.

## Automated Verification

- `npm run unit-v2` → **696/696 pass** (36 suites; transport decoupling 회귀 5종 포함)
- `npx tsc --noEmit` / `npm run lint` / `npm run build` → exit 0 (lint 0 errors/19 style warnings, webpack 0 errors/3 size warnings)
- e2e `05/06/08`(decoupling 관련) → 3/3 PASS (실기 puppeteer + sdk :5174). round-trip specs 01~04/07/09은 sdk dist drift로 pre-existing 실패(본 PR 무관, 기록 코멘트 참조).

## T-XX Coverage

- T-U-PRESET-SD-01/SD-02, T-U-PRESET-AE-01/AE-02: signData/signAuthEntry preset + selector 채움
- T-U-PRESET-RG-01: 기존 signMessage selector 회귀 0 (공유 헬퍼 추출 가드)
- T-U-SD-HEX-01: signData address hex/bech32 검증
- T-U-TIMEOUT-01: PopupTransport default > 60s 증명 (60s pending, 180s TIMEOUT)
- T-U-TIMEOUT-HS-01: handshake timeout `this.timeoutMs` 공유 회귀
- T-U-NEVM-04(T-DATA-01): non-evm preset CAIP-19 + family whitelist (vechain 추가)

## Commits

- `086c08d` refactor(playground): renderPresetSelector 공유 헬퍼 추출 + signMessage 폼 경유
- `8368f9f` feat(playground): signData/signAuthEntry preset selector 추가
- `21ad2d8` test(playground): signData/signAuthEntry preset selector 회귀 케이스 5종
- `5a1640a` fix(playground): signData getAddress-채움 버튼 + 미지원 signMessage 노드 제거
- `a18ac50` fix(playground): signData getAddress 동기 throw도 .catch 흡수
- `fa37d8d` fix(playground): signData address hex 변환 + Connect 게이트 + datalist 필터 + 유효 XDR preset
- `21d8a82` fix(playground): signData address hex 유효성 강제 (Codex 리뷰)
- `8ed37eb` fix(playground): bech32 BIP-173 checksum + mixed-case 검증 (Codex 리뷰)
- `01fbac2` chore(playground): 미등록 토큰 + metagraph + SPL descriptor preset 추가
- `11fcbb3` fix(transport): PopupTransport default timeout 60s → 180s
- `c45318e` chore(playground): Kaia/Cardano/NEAR/Hedera/Stellar/XRP token·signTx preset 추가
- `d21cbe8` test(playground): vechain을 non-evm preset family whitelist에 추가
- `b37cd52` fix(transport): handshake ack timeout을 request 180s와 분리 (크로스 리뷰 R1)
- `56ab878` fix(e2e): handshake-failure specs를 handshakeTimeoutMs로 전환 (크로스 리뷰 R2)

## Checklist

- [x] Automated verification (`npm run unit-v2` **696/696**, tsc/lint/build 0 error)
- [x] 로컬 크로스 리뷰 (Codex ↔ Claude 3R 수렴, 둘 다 PASS — 기록 코멘트 참조)
- [ ] 사람 코드 리뷰
- [ ] 머지 (base=epic/DC-2223)

---

🤖 Objective 전문은 워크스페이스 리포 `objectives/m09-04-22-playground-signdata-authentry-presets.md` (§11 RE-AUDIT-LOG에 스코프 확장 이력) 참조.
