### PR TITLE
[DC-3043] m09-04-22: playground signData/authEntry + Coston 제거 (post-#175 → epic)

### DIFF
--- a/playground/chains.json
+++ b/playground/chains.json
@@ -6,13 +6,6 @@
     "defaultKeyPath": "m/44'/60'/0'/0/0"
   },
   {
-    "chainId": "eip155:16/slip44:60",
-    "family": "ethereum",
-    "displayName": "Flare Network Coston",
-    "defaultKeyPath": "m/44'/60'/0'/0/0",
-    "isTestnet": true
-  },
-  {
     "chainId": "eip155:30/slip44:60",
     "family": "ethereum",
     "displayName": "RSK Smart Bitcoin",

--- a/scripts/extract-chains.js
+++ b/scripts/extract-chains.js
@@ -384,20 +384,36 @@ function main () {
     process.exit(1)
   }
 
+  // playground 지원 목록에서 명시적으로 제외할 chainId (denylist).
+  // 이 목록은 **playground 테스트 표면 전용**이며 runtime connector API(src/)에는 영향 없음 —
+  // connector-chain-addition-isolation 룰의 대상(chain enum/정적 라우팅 매핑)이 아니라
+  // 생성기 후처리 필터다. 제외 사유를 각 항목에 명시한다.
+  const EXCLUDED_CHAIN_IDS = new Set([
+    // Flare Network Coston (eip155:16) — device coin_list의 EVM 멀티체인 capability('CHAN')로
+    // 커버되지 않는 전용 deviceStoreId(FLR-COSTON)라 서명 시 5005(device_fw_incompatible) 발생.
+    // wm testnetFor 미연결(등록 갭). playground에서 테스트 불가하므로 지원 목록에서 제외.
+    'eip155:16/slip44:60',
+  ])
+  const publishedChains = allChains.filter(function (c) { return !EXCLUDED_CHAIN_IDS.has(c.chainId) })
+  const excludedCount = allChains.length - publishedChains.length
+
   // 출력 디렉터리 생성
   const outDir = path.dirname(OUTPUT_PATH)
   if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true })
 
-  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(allChains, null, 2) + '\n')
+  fs.writeFileSync(OUTPUT_PATH, JSON.stringify(publishedChains, null, 2) + '\n')
 
   // family별 통계 출력
   const stats = {}
-  const testnetCount = allChains.filter(function (c) { return c.isTestnet }).length
-  for (const c of allChains) {
+  const testnetCount = publishedChains.filter(function (c) { return c.isTestnet }).length
+  for (const c of publishedChains) {
     stats[c.family] = (stats[c.family] || 0) + 1
   }
-  console.log('extract-chains: wrote ' + allChains.length + ' chains to ' + OUTPUT_PATH)
-  console.log('  mainnet: ' + (allChains.length - testnetCount) + ', testnet: ' + testnetCount)
+  if (excludedCount > 0) {
+    console.log('extract-chains: excluded ' + excludedCount + ' chain(s) via denylist')
+  }
+  console.log('extract-chains: wrote ' + publishedChains.length + ' chains to ' + OUTPUT_PATH)
+  console.log('  mainnet: ' + (publishedChains.length - testnetCount) + ', testnet: ' + testnetCount)
   for (const [fam, count] of Object.entries(stats)) {
     console.log('  ' + fam + ': ' + count)
   }


### PR DESCRIPTION
## 개요

epic child **DC-3043 (m09-04-22)** 브랜치의 **post-#175 추가 작업**을 epic 브랜치 `epic/DC-2223_m09-04-connector-v2-cleanup`에 머지하기 위한 **draft** child PR입니다.

- child PR #175(이미 MERGED) 이후 DC-3043에 쌓인 **14 커밋**을 담습니다.
- base = epic 브랜치 (child → epic). epic → mainline(master)은 별도 최종 PR.
- **머지 금지 (사람이 리뷰/머지)** — `objective-no-auto-merge`. epic child라 reviewer 미지정.

## ⛔ 게이트 (Blockers — mainline/publish 전 반드시 해결)

- [ ] **bridge popup URL 원복** — `src/singleton.ts`의 `popUpUrl: 'http://localhost:5173' // for local development` (playground 로컬 테스트용 override). **web-sdk(bridge) v2 배포 완료 후** 프로덕션 URL(`https://bridge.dcentwallet.com/v2` — `PopupTransport` 기본값)로 원복해야 함. 이대로 publish되면 배포된 connector가 사용자 브라우저에서 localhost를 열게 됨. (`cross-repo-interface-edit` 짝 영역 — connector ↔ bridge)
  - 순서: **web-sdk(bridge) 배포 완료 → connector URL 원복 → connector publish** (`no-version-bump`의 배포 순서).

## 포함 커밋 (14)

**이번 세션 추가:**
- `chore(playground): Flare Coston(eip155:16) 지원 목록에서 제거` — device CHAN 멀티체인 미커버(FLR-COSTON deviceStoreId)로 서명 시 5005. `extract-chains.js` denylist + `chains.json` 엔트리 제거 (playground 테스트 표면 전용, runtime API 무관).

**기존 DC-3043 후속(크로스 리뷰 반영 등):**
- handshake ack timeout을 request 180s와 분리 + e2e specs 전환 (크로스 리뷰 R2)
- PopupTransport default timeout 60s → 180s
- Kaia/Cardano/NEAR/Hedera/Stellar/XRP token·signTx preset + vechain whitelist
- 미등록 토큰/metagraph/SPL descriptor preset
- signData/signAuthEntry preset selector + 회귀 케이스 5종 + renderPresetSelector 공유 헬퍼
- bech32 BIP-173 checksum / signData address hex 검증 (Codex 리뷰 반영)

## 검증 상태

- epic 브랜치는 CI/리뷰봇 미트리거 → ready 전환 전 **로컬 Codex↔Claude 크로스 리뷰 루프** 필요 (`local-cross-review-loop`). 현재 **draft** 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
