### PR TITLE
[DC-3228] feat(playground): no-network preset 완성 필드 + 값 형식 (m09-04-24)

### DIFF
--- a/playground/presets.non-evm.json
+++ b/playground/presets.non-evm.json
@@ -231,8 +231,9 @@
       "Destination": "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
       "Amount": "1000000",
       "Fee": "12",
-      "Sequence": 1,
-      "Flags": 2147483648
+      "Sequence": 42,
+      "Flags": 2147483648,
+      "LastLedgerSequence": 85000000
     }
   },
   {
@@ -251,8 +252,9 @@
       "Destination": "rPT1Sjq2YGrBMTttX4GZHjKu9dyfzbpAYe",
       "Amount": "1000000",
       "Fee": "12",
-      "Sequence": 1,
-      "Flags": 2147483648
+      "Sequence": 42,
+      "Flags": 2147483648,
+      "LastLedgerSequence": 85000000
     }
   },
   {
@@ -459,7 +461,8 @@
       "recipient": "receiver.near",
       "amount": "1000000000000000000000000",
       "blockHash": "GJp9NRJGBnXqWJAKFxkzD8p9cJTiSNi1J3UWKVBbcfRw",
-      "publicKey": "ed25519:11111111111111111111111111111111"
+      "publicKey": "ed25519:BtCjvJYNeN8RoVze7WTsgxN64g3ckSUAwQWNJjdzthwV",
+      "nonce": 112247371000042
     }
   },
   {
@@ -482,7 +485,8 @@
       "recipient": "receiver.testnet",
       "amount": "1000000000000000000000000",
       "blockHash": "GJp9NRJGBnXqWJAKFxkzD8p9cJTiSNi1J3UWKVBbcfRw",
-      "publicKey": "ed25519:11111111111111111111111111111111"
+      "publicKey": "ed25519:BtCjvJYNeN8RoVze7WTsgxN64g3ckSUAwQWNJjdzthwV",
+      "nonce": 112247371000042
     }
   },
   {
@@ -500,7 +504,11 @@
       "source": "DAG0000000000000000000000000000000000000000",
       "destination": "DAG0000000000000000000000000000000000000001",
       "amount": "100000000",
-      "fee": "0"
+      "fee": "0",
+      "lastRef": {
+        "ordinal": 1024,
+        "hash": "58ba6390b751a9e04edea64ada97024798e91519983a94f5992d6a3fd72953b1"
+      }
     }
   },
   {
@@ -520,7 +528,8 @@
       "stepLimit": "0x186a0",
       "nid": "0x100",
       "nonce": "0x1",
-      "version": "0x3"
+      "version": "0x3",
+      "stepPrice": "0x2e90edd000"
     }
   },
   {
@@ -547,7 +556,8 @@
           "_to": "hx99bc2f9ee6aea6f9ed252e3dc48f6a7fdc9e916c",
           "_value": "0xDE0B6B3A7640001"
         }
-      }
+      },
+      "stepPrice": "0x2e90edd000"
     }
   },
   {
@@ -561,7 +571,7 @@
     "sourceUrl": "https://docs.vechain.org/introduction-to-vechain/dual-token-economic-model/vethor-vtho",
     "transaction": {
       "chainTag": 74,
-      "blockRef": "0x0000000000000000",
+      "blockRef": "0x00b3c1e4a5f6d7e8",
       "expiration": 720,
       "clauses": [
         {
@@ -633,8 +643,9 @@
         "value": "10"
       },
       "Fee": "12",
-      "Sequence": 1,
-      "Flags": 2147483648
+      "Sequence": 42,
+      "Flags": 2147483648,
+      "LastLedgerSequence": 85000000
     }
   },
   {
@@ -664,7 +675,8 @@
         }
       ],
       "blockHash": "GJp9NRJGBnXqWJAKFxkzD8p9cJTiSNi1J3UWKVBbcfRw",
-      "nonce": 0
+      "nonce": 112247371000042,
+      "publicKey": "ed25519:BtCjvJYNeN8RoVze7WTsgxN64g3ckSUAwQWNJjdzthwV"
     }
   },
   {
@@ -694,7 +706,8 @@
         }
       ],
       "blockHash": "GJp9NRJGBnXqWJAKFxkzD8p9cJTiSNi1J3UWKVBbcfRw",
-      "nonce": 0
+      "nonce": 112247371000042,
+      "publicKey": "ed25519:BtCjvJYNeN8RoVze7WTsgxN64g3ckSUAwQWNJjdzthwV"
     }
   },
   {
@@ -758,7 +771,9 @@
         "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE",
         "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE",
         ""
-      ]
+      ],
+      "nonce": "0",
+      "fee": "180"
     }
   },
   {
@@ -954,7 +969,8 @@
       "stepLimit": "0x186a0",
       "nid": "0x100",
       "nonce": "0x1",
-      "version": "0x3"
+      "version": "0x3",
+      "stepPrice": "0x2e90edd000"
     }
   },
   {
@@ -1207,6 +1223,10 @@
         "contract": "DAG0CyySf35ftDQDQBnd1bdQ9aPyUdacMghpnCuM",
         "decimals": 8,
         "symbol": "DOR"
+      },
+      "lastRef": {
+        "ordinal": 1024,
+        "hash": "58ba6390b751a9e04edea64ada97024798e91519983a94f5992d6a3fd72953b1"
       }
     }
   },
@@ -1229,6 +1249,10 @@
         "contract": "DAG5UnregisteredMetagraphIdZZZZZZZZZZZZZZ",
         "decimals": 8,
         "symbol": "UNREG"
+      },
+      "lastRef": {
+        "ordinal": 1024,
+        "hash": "58ba6390b751a9e04edea64ada97024798e91519983a94f5992d6a3fd72953b1"
       }
     }
   },
@@ -1265,9 +1289,10 @@
       "TransactionType": "AccountSet",
       "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
       "Fee": "12",
-      "Sequence": 1,
+      "Sequence": 42,
       "SetFlag": 1,
-      "Flags": 2147483648
+      "Flags": 2147483648,
+      "LastLedgerSequence": 85000000
     }
   },
   {
@@ -1283,13 +1308,14 @@
       "TransactionType": "TrustSet",
       "Account": "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh",
       "Fee": "12",
-      "Sequence": 1,
+      "Sequence": 42,
       "Flags": 2147483648,
       "LimitAmount": {
         "currency": "USD",
         "issuer": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
         "value": "1000"
-      }
+      },
+      "LastLedgerSequence": 85000000
     }
   },
   {

--- a/playground/presets.rest.json
+++ b/playground/presets.rest.json
@@ -14,8 +14,8 @@
       "to": "737777777777777777777777777777777777777777777777777UFEJ2CI",
       "amount": 1000000,
       "fee": 1000,
-      "firstRound": 1,
-      "lastRound": 1000,
+      "firstRound": 34000000,
+      "lastRound": 34001000,
       "genesisID": "mainnet-v1.0",
       "genesisHash": "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiHc0CYz/uo="
     }
@@ -36,8 +36,8 @@
       "to": "Y76M3MSY6DKBRHBL7C3NNDXGS5IIMQVQVUAB6MP4XEMMGVF2QWNPL226CA",
       "amount": 1000,
       "fee": 1000,
-      "firstRound": 1,
-      "lastRound": 1000,
+      "firstRound": 34000000,
+      "lastRound": 34001000,
       "genesisID": "mainnet-v1.0",
       "genesisHash": "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiHc0CYz/uo="
     }
@@ -59,7 +59,7 @@
       "gasPrice": "0x3b9aca00",
       "nonce": "0x0",
       "chainId": "0x405",
-      "epochHeight": "0x0",
+      "epochHeight": "0x6a1b2c",
       "storageLimit": "0x0",
       "data": "0x"
     }
@@ -75,8 +75,8 @@
     "sourceUrl": "https://github.com/cosmos/cosmjs",
     "transaction": {
       "chain_id": "cosmoshub-4",
-      "account_number": "0",
-      "sequence": "0",
+      "account_number": "12345",
+      "sequence": "3",
       "fee": {
         "amount": [
           {
@@ -241,13 +241,13 @@
             }
           }
         ],
-        "ref_block_bytes": "0000",
-        "ref_block_hash": "0000000000000000",
+        "ref_block_bytes": "b801",
+        "ref_block_hash": "e4a5f6d7c8b9a0e1",
         "expiration": 0,
         "timestamp": 0
       },
       "raw_data_hex": "",
-      "fee_limit": 0
+      "fee_limit": 1000000
     }
   },
   {
@@ -274,8 +274,8 @@
             }
           }
         ],
-        "ref_block_bytes": "0000",
-        "ref_block_hash": "0000000000000000",
+        "ref_block_bytes": "b801",
+        "ref_block_hash": "e4a5f6d7c8b9a0e1",
         "expiration": 0,
         "timestamp": 0
       },
@@ -307,8 +307,8 @@
             }
           }
         ],
-        "ref_block_bytes": "0000",
-        "ref_block_hash": "0000000000000000",
+        "ref_block_bytes": "b801",
+        "ref_block_hash": "e4a5f6d7c8b9a0e1",
         "expiration": 0,
         "timestamp": 0
       },
@@ -353,8 +353,8 @@
     "sourceUrl": "https://github.com/cosmos/cosmjs",
     "transaction": {
       "chain_id": "coreum-mainnet-1",
-      "account_number": "0",
-      "sequence": "0",
+      "account_number": "12345",
+      "sequence": "3",
       "fee": {
         "amount": [
           {
@@ -393,8 +393,8 @@
     "sourceUrl": "https://docs.coreum.dev/docs/modules/assetft",
     "transaction": {
       "chain_id": "coreum-mainnet-1",
-      "account_number": "0",
-      "sequence": "0",
+      "account_number": "12345",
+      "sequence": "3",
       "fee": {
         "amount": [
           {
@@ -433,8 +433,8 @@
     "sourceUrl": "https://github.com/cosmos/cosmjs",
     "transaction": {
       "chain_id": "coreum-testnet-1",
-      "account_number": "0",
-      "sequence": "0",
+      "account_number": "12345",
+      "sequence": "3",
       "fee": {
         "amount": [
           {
@@ -473,8 +473,8 @@
     "sourceUrl": "https://github.com/cosmos/cosmjs",
     "transaction": {
       "chain_id": "hippo-protocol-1",
-      "account_number": "0",
-      "sequence": "0",
+      "account_number": "12345",
+      "sequence": "3",
       "fee": {
         "amount": [
           {
@@ -513,8 +513,8 @@
     "sourceUrl": "https://github.com/cosmos/cosmjs",
     "transaction": {
       "chain_id": "hippo-protocol-testnet-1",
-      "account_number": "0",
-      "sequence": "0",
+      "account_number": "12345",
+      "sequence": "3",
       "fee": {
         "amount": [
           {
@@ -661,8 +661,8 @@
       },
       "from": "core1qjhxdnswckx9l2yn2p8yyq2sphcjnlu9qg68ll",
       "chain_id": "coreum-mainnet-1",
-      "account_number": "0",
-      "sequence": "0",
+      "account_number": "12345",
+      "sequence": "3",
       "fee": {
         "amount": [
           {
@@ -694,8 +694,8 @@
       },
       "from": "Y76M3MSY6DKBRHBL7C3NNDXGS5IIMQVQVUAB6MP4XEMMGVF2QWNPL226CA",
       "fee": 1000,
-      "firstRound": 1,
-      "lastRound": 1000,
+      "firstRound": 34000000,
+      "lastRound": 34001000,
       "genesisID": "mainnet-v1.0",
       "genesisHash": "wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiHc0CYz/uo="
     }

--- a/playground/presets.rest.json
+++ b/playground/presets.rest.json
@@ -71,7 +71,7 @@
     "applicableChainIds": [
       "cosmos:cosmoshub-4/slip44:118"
     ],
-    "note": "Cosmos Hub MsgSend — wm 기대 형식 Amino SignDoc (msgs[].type + from_address/to_address/chain_id snake_case). amount 단위 uatom (1 ATOM = 1e6). ⚠️ from_address는 디바이스 실 cosmoshub 계정이어야 서명 성공(self-send 시 to_address 동일). account_number/sequence/pub_key는 sign 시 wm가 live REST로 덮어쓰므로 preset의 '0'은 placeholder — sender가 on-chain 미존재면 404. 현재 from/to=cosmos1n9a7x46880h6qrtjmvwxrlgt0yprj702kcv0hr (디바이스 self-send). 실서명 검증은 짝 m09-04-13(swproxy e2e).",
+    "note": "Cosmos Hub MsgSend — wm 기대 형식 Amino SignDoc (msgs[].type + from_address/to_address/chain_id snake_case). amount 단위 uatom (1 ATOM = 1e6). ⚠️ from_address는 디바이스 실 cosmoshub 계정이어야 서명 성공(self-send 시 to_address 동일). account_number/sequence/pub_key는 대표값(유효 형식) — network 모드에선 wm가 sign 시 live REST로 덮어쓰고, no-network 모드에선 preset 값 그대로 사용 — sender가 on-chain 미존재면 404. 현재 from/to=cosmos1n9a7x46880h6qrtjmvwxrlgt0yprj702kcv0hr (디바이스 self-send). 실서명 검증은 짝 m09-04-13(swproxy e2e).",
     "sourceUrl": "https://github.com/cosmos/cosmjs",
     "transaction": {
       "chain_id": "cosmoshub-4",
@@ -202,7 +202,7 @@
     "sourceUrl": "https://github.com/vechain/thor-devkit.js",
     "transaction": {
       "chainTag": 74,
-      "blockRef": "0x0000000000000000",
+      "blockRef": "0x00b3c1e4a5f6d7e8",
       "expiration": 720,
       "clauses": [
         {
@@ -327,7 +327,7 @@
     "sourceUrl": "https://docs.vechain.org/core-concepts/transactions",
     "transaction": {
       "chainTag": 74,
-      "blockRef": "0x0000000000000000",
+      "blockRef": "0x00b3c1e4a5f6d7e8",
       "expiration": 720,
       "clauses": [
         {
@@ -349,7 +349,7 @@
     "applicableChainIds": [
       "cosmos:coreum-mainnet-1/slip44:990"
     ],
-    "note": "Coreum CORE transfer — wm Amino SignDoc(MsgSend). denom ucore.  from/to=core1n9a7x46880h6qrtjmvwxrlgt0yprj7029k55sc(디바이스 self-send, atom 키 재인코딩). account_number/sequence는 sign 시 wm가 live REST로 덮어씀(placeholder '0'). applicableChainIds 단일-체인(1d4201c 가드). 실서명 검증은 짝 m09-04-13.",
+    "note": "Coreum CORE transfer — wm Amino SignDoc(MsgSend). denom ucore.  from/to=core1n9a7x46880h6qrtjmvwxrlgt0yprj7029k55sc(디바이스 self-send, atom 키 재인코딩). account_number/sequence는 대표값 — network 모드=wm live REST 덮어쓰기, no-network 모드=preset 값 그대로 사용. applicableChainIds 단일-체인(1d4201c 가드). 실서명 검증은 짝 m09-04-13.",
     "sourceUrl": "https://github.com/cosmos/cosmjs",
     "transaction": {
       "chain_id": "coreum-mainnet-1",
@@ -389,7 +389,7 @@
     "applicableChainIds": [
       "cosmos:coreum-mainnet-1/slip44:990"
     ],
-    "note": "m02-05-54 검증용. wm Amino SignDoc(bank MsgSend)인데 amount[0].denom = assetft 토큰 denom. 기대: extractCosmosTokenIdentity가 denom을 토큰으로 식별 → tier-1 registry hit(smart-token.json 'test', parent CZONE:core, decimals 6) → TokenAccount 합성 → MsgSend가 token denom으로 서명(native ucore 아님). 54 전이면 native ucore로 silent 오서명(버그). amount '1000000' = 1 token(6dec). fee는 항상 native ucore. from/to=디바이스 coreum self-send. account_number/sequence는 sign 시 wm live REST가 덮어씀. /verify-wire-sign COSMOS로 byte 검증: MsgSend denom=token + secp recover=device 계정.",
+    "note": "m02-05-54 검증용. wm Amino SignDoc(bank MsgSend)인데 amount[0].denom = assetft 토큰 denom. 기대: extractCosmosTokenIdentity가 denom을 토큰으로 식별 → tier-1 registry hit(smart-token.json 'test', parent CZONE:core, decimals 6) → TokenAccount 합성 → MsgSend가 token denom으로 서명(native ucore 아님). 54 전이면 native ucore로 silent 오서명(버그). amount '1000000' = 1 token(6dec). fee는 항상 native ucore. from/to=디바이스 coreum self-send. account_number/sequence는 대표값 — network 모드=wm live REST 덮어쓰기, no-network 모드=그대로 사용. /verify-wire-sign COSMOS로 byte 검증: MsgSend denom=token + secp recover=device 계정.",
     "sourceUrl": "https://docs.coreum.dev/docs/modules/assetft",
     "transaction": {
       "chain_id": "coreum-mainnet-1",
@@ -429,7 +429,7 @@
     "applicableChainIds": [
       "cosmos:coreum-testnet-1/slip44:990"
     ],
-    "note": "Coreum Testnet CORE transfer — wm Amino SignDoc(MsgSend). denom utestcore.  from/to=testcore1n9a7x46880h6qrtjmvwxrlgt0yprj702nz0flw(디바이스 self-send, atom 키 재인코딩). account_number/sequence는 sign 시 wm가 live REST로 덮어씀(placeholder '0'). applicableChainIds 단일-체인(1d4201c 가드). 실서명 검증은 짝 m09-04-13.",
+    "note": "Coreum Testnet CORE transfer — wm Amino SignDoc(MsgSend). denom utestcore.  from/to=testcore1n9a7x46880h6qrtjmvwxrlgt0yprj702nz0flw(디바이스 self-send, atom 키 재인코딩). account_number/sequence는 대표값 — network 모드=wm live REST 덮어쓰기, no-network 모드=preset 값 그대로 사용. applicableChainIds 단일-체인(1d4201c 가드). 실서명 검증은 짝 m09-04-13.",
     "sourceUrl": "https://github.com/cosmos/cosmjs",
     "transaction": {
       "chain_id": "coreum-testnet-1",
@@ -469,7 +469,7 @@
     "applicableChainIds": [
       "cosmos:hippo-protocol-1/slip44:118"
     ],
-    "note": "Hippo Protocol HP transfer — wm Amino SignDoc(MsgSend). denom ahp.  from/to=hippo1n9a7x46880h6qrtjmvwxrlgt0yprj7028s65fc(디바이스 self-send, atom 키 재인코딩). account_number/sequence는 sign 시 wm가 live REST로 덮어씀(placeholder '0'). applicableChainIds 단일-체인(1d4201c 가드). 실서명 검증은 짝 m09-04-13.",
+    "note": "Hippo Protocol HP transfer — wm Amino SignDoc(MsgSend). denom ahp.  from/to=hippo1n9a7x46880h6qrtjmvwxrlgt0yprj7028s65fc(디바이스 self-send, atom 키 재인코딩). account_number/sequence는 대표값 — network 모드=wm live REST 덮어쓰기, no-network 모드=preset 값 그대로 사용. applicableChainIds 단일-체인(1d4201c 가드). 실서명 검증은 짝 m09-04-13.",
     "sourceUrl": "https://github.com/cosmos/cosmjs",
     "transaction": {
       "chain_id": "hippo-protocol-1",
@@ -509,7 +509,7 @@
     "applicableChainIds": [
       "cosmos:hippo-protocol-testnet-1/slip44:118"
     ],
-    "note": "Hippo Protocol Testnet HP transfer — wm Amino SignDoc(MsgSend). denom ahp.  from/to=hippo1n9a7x46880h6qrtjmvwxrlgt0yprj7028s65fc(디바이스 self-send, atom 키 재인코딩). account_number/sequence는 sign 시 wm가 live REST로 덮어씀(placeholder '0'). applicableChainIds 단일-체인(1d4201c 가드). 실서명 검증은 짝 m09-04-13.",
+    "note": "Hippo Protocol Testnet HP transfer — wm Amino SignDoc(MsgSend). denom ahp.  from/to=hippo1n9a7x46880h6qrtjmvwxrlgt0yprj7028s65fc(디바이스 self-send, atom 키 재인코딩). account_number/sequence는 대표값 — network 모드=wm live REST 덮어쓰기, no-network 모드=preset 값 그대로 사용. applicableChainIds 단일-체인(1d4201c 가드). 실서명 검증은 짝 m09-04-13.",
     "sourceUrl": "https://github.com/cosmos/cosmjs",
     "transaction": {
       "chain_id": "hippo-protocol-testnet-1",
@@ -649,7 +649,7 @@
     "applicableChainIds": [
       "cosmos:coreum-mainnet-1/slip44:990"
     ],
-    "note": "미등록(커스텀) 토큰 전송 — form-D descriptor. wm m02-05-69 buildCosmosTokenTransferFromDescriptor 가 transaction.token={contract,to,amount} 를 amino MsgSend 봉투(msgs:[{type:'cosmos-sdk/MsgSend', value:{from_address,to_address,amount:[{denom:contract,amount}]}}]) 로 빌드 → 서명. ★form-E(coreum-assetft-transfer)와 달리 smart-token.json registry 등록 불필요 — 미등록 denom 도 서명 가능. contract=utkn-core1n9a7x46880h6qrtjmvwxrlgt0yprj7029k55sc 는 registry 에 없는 valid-format assetft denom(subunit-issuer). descriptor 에 decimals 가 있으면 wm 3-tier resolver 가 tier-3(descriptor)로 합성 → on-chain RPC 없이 해석되므로 denom 실재 불필요(§9 byte-proof 는 broadcast 안 함). denom 은 chain-prefix 검증 없이 verbatim 사용(54 parity). amount=base units(decimals 6 → 1000000=1토큰, 재스케일 없음). sender 는 transaction.from 에서 read-only — convertTransaction 이 denom drop 후 buildTransaction 이 합성 TokenAccount.contractAddress(=denom)로 재주입. account_number/sequence/fee 는 sign 시 wm live REST 가 덮어씀. ⚠️ token.to/from 을 본인 디바이스 Coreum 계정(core1...)으로 확인/교체(self-send 권장, asset risk 0). ⚠️ 반드시 Coreum mainnet(slip44:990). 검증: /verify-wire-sign COSMOS (MsgSend denom=token, native ucore 아님; secp recover=device 계정).",
+    "note": "미등록(커스텀) 토큰 전송 — form-D descriptor. wm m02-05-69 buildCosmosTokenTransferFromDescriptor 가 transaction.token={contract,to,amount} 를 amino MsgSend 봉투(msgs:[{type:'cosmos-sdk/MsgSend', value:{from_address,to_address,amount:[{denom:contract,amount}]}}]) 로 빌드 → 서명. ★form-E(coreum-assetft-transfer)와 달리 smart-token.json registry 등록 불필요 — 미등록 denom 도 서명 가능. contract=utkn-core1n9a7x46880h6qrtjmvwxrlgt0yprj7029k55sc 는 registry 에 없는 valid-format assetft denom(subunit-issuer). descriptor 에 decimals 가 있으면 wm 3-tier resolver 가 tier-3(descriptor)로 합성 → on-chain RPC 없이 해석되므로 denom 실재 불필요(§9 byte-proof 는 broadcast 안 함). denom 은 chain-prefix 검증 없이 verbatim 사용(54 parity). amount=base units(decimals 6 → 1000000=1토큰, 재스케일 없음). sender 는 transaction.from 에서 read-only — convertTransaction 이 denom drop 후 buildTransaction 이 합성 TokenAccount.contractAddress(=denom)로 재주입. account_number/sequence/fee 는 대표값 — network 모드=wm live REST 덮어쓰기, no-network 모드=그대로 사용. ⚠️ token.to/from 을 본인 디바이스 Coreum 계정(core1...)으로 확인/교체(self-send 권장, asset risk 0). ⚠️ 반드시 Coreum mainnet(slip44:990). 검증: /verify-wire-sign COSMOS (MsgSend denom=token, native ucore 아님; secp recover=device 계정).",
     "sourceUrl": "https://docs.coreum.dev/docs/modules/assetft",
     "transaction": {
       "token": {

--- a/tests/unit/v2/playground.signtx-non-evm.test.ts
+++ b/tests/unit/v2/playground.signtx-non-evm.test.ts
@@ -1293,3 +1293,92 @@ it('T-U-CARDANO-01: ada-transfer preset 제거됨 + ada-cbor-signtx(CBOR) 유지
   expect(adaCbor.family).toBe('cardano')
   expect(adaCbor.transaction).toHaveProperty('txCbor')
 })
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T-PRESET-COMPLETE-01 / T-PRESET-FIELDSHAPE-01 (m09-04-24)
+// wm no-network(pure-signer) 계약: ①prepare-skip / ③marker-consume / ②boundary family
+// preset이 완성 consensus 필드를 담아야 wm이 -32602 없이 서명한다. connector preset은
+// 만료성 live 값이 아닌 "대표값(유효 형식)"만 책임 — 서명 시점 실값 주입은 bridge/wm 담당.
+// 여기서는 non-evm.json의 NEAR/Havah/Vechain/Constellation/Stacks/Ripple/Xahau family의
+// field presence + 값 형식만 단언. (Cosmos/Tron/Algorand/Conflux는 signtx-rest 테스트 담당.)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('T-PRESET no-network 완성 필드 (non-evm)', () => {
+  const presetsPath = path.resolve(__dirname, '../../../playground/presets.non-evm.json')
+  const PRESETS: any[] = JSON.parse(fs.readFileSync(presetsPath, 'utf8'))
+  const byId = (id: string) => PRESETS.find((p) => p.id === id)
+
+  it('T-PRESET-COMPLETE-01(non-evm): NEAR/Havah/Vechain/Constellation/Stacks/XRP 완성 필드 포함', () => {
+    // NEAR ① — nonce + blockHash + publicKey (native+ft 모두)
+    ;['near-transfer', 'near-transfer-testnet', 'near-ft-transfer', 'near-ft-transfer-unregistered'].forEach((id) => {
+      const tx = byId(id)!.transaction
+      expect(tx).toHaveProperty('nonce')
+      expect(tx).toHaveProperty('blockHash')
+      expect(tx).toHaveProperty('publicKey')
+    })
+
+    // Havah ① — stepPrice + stepLimit (fee=0 placeholder 대체)
+    ;['havah-transfer', 'havah-hsp20-transfer', 'havah-hsp20-descriptor-transfer'].forEach((id) => {
+      const tx = byId(id)!.transaction
+      expect(tx).toHaveProperty('stepPrice')
+      expect(tx).toHaveProperty('stepLimit')
+    })
+
+    // Vechain ③ — blockRef (0x0000… placeholder 금지)
+    const vet = byId('vechain-vip180-transfer')!.transaction
+    expect(vet.blockRef).toBeTruthy()
+    expect(vet.blockRef).not.toBe('0x0000000000000000')
+
+    // Constellation ③ — lastRef{ordinal,hash}
+    ;['dag-transfer', 'dag-dor-metagraph-transfer', 'dag-custom-metagraph-transfer'].forEach((id) => {
+      const tx = byId(id)!.transaction
+      expect(tx).toHaveProperty('lastRef')
+      expect(tx.lastRef).toHaveProperty('ordinal')
+      expect(tx.lastRef).toHaveProperty('hash')
+    })
+
+    // Stacks ① — top-level nonce + fee (form-E preset에 추가)
+    const stx = byId('stacks-sip010-transfer')!.transaction
+    expect(stx).toHaveProperty('nonce')
+    expect(stx).toHaveProperty('fee')
+
+    // Ripple/Xahau ② — LastLedgerSequence + Sequence
+    ;['xrp-payment', 'xrp-iou-payment', 'xrp-accountset', 'xrp-trustset', 'xahau-payment'].forEach((id) => {
+      const tx = byId(id)!.transaction
+      expect(tx).toHaveProperty('LastLedgerSequence')
+      expect(tx).toHaveProperty('Sequence')
+    })
+  })
+
+  it('T-PRESET-FIELDSHAPE-01(non-evm): 신규/변경 필드 값 형식 정합', () => {
+    const ED25519_B58_RE = /^ed25519:[1-9A-HJ-NP-Za-km-z]{43,44}$/ // base58, 32-byte access-key
+    const HEX_RE = /^0x[0-9a-fA-F]+$/
+    const HEX64_RE = /^[0-9a-fA-F]{64}$/
+
+    // NEAR publicKey = ed25519 base58 (all-1 placeholder 32-char은 이 regex 불통과)
+    ;['near-transfer', 'near-ft-transfer'].forEach((id) => {
+      expect(byId(id)!.transaction.publicKey).toMatch(ED25519_B58_RE)
+    })
+
+    // Havah stepPrice = 0x-hex > 0
+    const hv = byId('havah-transfer')!.transaction
+    expect(hv.stepPrice).toMatch(HEX_RE)
+    expect(parseInt(hv.stepPrice, 16)).toBeGreaterThan(0)
+
+    // Constellation lastRef.ordinal = number, hash = 64-hex
+    const dag = byId('dag-transfer')!.transaction.lastRef
+    expect(typeof dag.ordinal).toBe('number')
+    expect(dag.hash).toMatch(HEX64_RE)
+
+    // Ripple/Xahau LastLedgerSequence = 양의 정수, Sequence = 양의 정수
+    ;['xrp-payment', 'xahau-payment'].forEach((id) => {
+      const tx = byId(id)!.transaction
+      expect(Number.isInteger(tx.LastLedgerSequence)).toBe(true)
+      expect(tx.LastLedgerSequence).toBeGreaterThan(0)
+      expect(Number.isInteger(tx.Sequence)).toBe(true)
+      expect(tx.Sequence).toBeGreaterThan(0)
+    })
+
+    // Vechain blockRef = 0x + 16 hex (8 bytes)
+    expect(byId('vechain-vip180-transfer')!.transaction.blockRef).toMatch(/^0x[0-9a-fA-F]{16}$/)
+  })
+})

--- a/tests/unit/v2/playground.signtx-non-evm.test.ts
+++ b/tests/unit/v2/playground.signtx-non-evm.test.ts
@@ -12,6 +12,7 @@
  */
 import * as fs from 'fs'
 import * as path from 'path'
+import { base58 } from '@scure/base'
 
 // ── Playground 로드 helper ──────────────────────────────────────────────────
 function loadPlayground(): void {
@@ -1353,24 +1354,31 @@ describe('T-PRESET no-network 완성 필드 (non-evm)', () => {
     const ED25519_B58_RE = /^ed25519:[1-9A-HJ-NP-Za-km-z]{43,44}$/ // base58, 32-byte access-key
     const HEX_RE = /^0x[0-9a-fA-F]+$/
     const HEX64_RE = /^[0-9a-fA-F]{64}$/
+    const BLOCKREF_RE = /^0x[0-9a-fA-F]{16}$/
 
-    // NEAR publicKey = ed25519 base58 (all-1 placeholder 32-char은 이 regex 불통과)
-    ;['near-transfer', 'near-ft-transfer'].forEach((id) => {
-      expect(byId(id)!.transaction.publicKey).toMatch(ED25519_B58_RE)
+    // NEAR publicKey = ed25519: + base58(32 bytes). 전 preset 검증 + base58 decode로 정확히 32바이트.
+    ;['near-transfer', 'near-transfer-testnet', 'near-ft-transfer', 'near-ft-transfer-unregistered'].forEach((id) => {
+      const pk: string = byId(id)!.transaction.publicKey
+      expect(pk).toMatch(ED25519_B58_RE)
+      expect(base58.decode(pk.slice('ed25519:'.length)).length).toBe(32)
     })
 
-    // Havah stepPrice = 0x-hex > 0
-    const hv = byId('havah-transfer')!.transaction
-    expect(hv.stepPrice).toMatch(HEX_RE)
-    expect(parseInt(hv.stepPrice, 16)).toBeGreaterThan(0)
+    // Havah stepPrice = 0x-hex > 0 (전 preset)
+    ;['havah-transfer', 'havah-hsp20-transfer', 'havah-hsp20-descriptor-transfer'].forEach((id) => {
+      const sp: string = byId(id)!.transaction.stepPrice
+      expect(sp).toMatch(HEX_RE)
+      expect(parseInt(sp, 16)).toBeGreaterThan(0)
+    })
 
-    // Constellation lastRef.ordinal = number, hash = 64-hex
-    const dag = byId('dag-transfer')!.transaction.lastRef
-    expect(typeof dag.ordinal).toBe('number')
-    expect(dag.hash).toMatch(HEX64_RE)
+    // Constellation lastRef.ordinal = number, hash = 64-hex (전 preset)
+    ;['dag-transfer', 'dag-dor-metagraph-transfer', 'dag-custom-metagraph-transfer'].forEach((id) => {
+      const ref = byId(id)!.transaction.lastRef
+      expect(typeof ref.ordinal).toBe('number')
+      expect(ref.hash).toMatch(HEX64_RE)
+    })
 
-    // Ripple/Xahau LastLedgerSequence = 양의 정수, Sequence = 양의 정수
-    ;['xrp-payment', 'xahau-payment'].forEach((id) => {
+    // Ripple/Xahau LastLedgerSequence + Sequence = 양의 정수 (전 preset)
+    ;['xrp-payment', 'xrp-iou-payment', 'xrp-accountset', 'xrp-trustset', 'xahau-payment'].forEach((id) => {
       const tx = byId(id)!.transaction
       expect(Number.isInteger(tx.LastLedgerSequence)).toBe(true)
       expect(tx.LastLedgerSequence).toBeGreaterThan(0)
@@ -1379,6 +1387,11 @@ describe('T-PRESET no-network 완성 필드 (non-evm)', () => {
     })
 
     // Vechain blockRef = 0x + 16 hex (8 bytes)
-    expect(byId('vechain-vip180-transfer')!.transaction.blockRef).toMatch(/^0x[0-9a-fA-F]{16}$/)
+    expect(byId('vechain-vip180-transfer')!.transaction.blockRef).toMatch(BLOCKREF_RE)
+
+    // Stacks top-level nonce/fee = decimal string
+    const stx = byId('stacks-sip010-transfer')!.transaction
+    expect(String(stx.nonce)).toMatch(/^\d+$/)
+    expect(String(stx.fee)).toMatch(/^\d+$/)
   })
 })

--- a/tests/unit/v2/playground.signtx-non-evm.test.ts
+++ b/tests/unit/v2/playground.signtx-non-evm.test.ts
@@ -1307,6 +1307,8 @@ describe('T-PRESET no-network 완성 필드 (non-evm)', () => {
   const presetsPath = path.resolve(__dirname, '../../../playground/presets.non-evm.json')
   const PRESETS: any[] = JSON.parse(fs.readFileSync(presetsPath, 'utf8'))
   const byId = (id: string) => PRESETS.find((p) => p.id === id)
+  // top-level nonce+fee 보유 Stacks preset(전 preset) — sip010-transfer는 신규 추가, descriptor는 기존 보유.
+  const STACKS_IDS = ['stacks-sip010-transfer', 'stacks-sip010-descriptor-transfer']
 
   it('T-PRESET-COMPLETE-01(non-evm): NEAR/Havah/Vechain/Constellation/Stacks/XRP 완성 필드 포함', () => {
     // NEAR ① — nonce + blockHash + publicKey (native+ft 모두)
@@ -1337,10 +1339,12 @@ describe('T-PRESET no-network 완성 필드 (non-evm)', () => {
       expect(tx.lastRef).toHaveProperty('hash')
     })
 
-    // Stacks ① — top-level nonce + fee (form-E preset에 추가)
-    const stx = byId('stacks-sip010-transfer')!.transaction
-    expect(stx).toHaveProperty('nonce')
-    expect(stx).toHaveProperty('fee')
+    // Stacks ① — top-level nonce + fee (sip010-transfer에 신규 추가; descriptor는 기존 보유 — 회귀 가드)
+    STACKS_IDS.forEach((id) => {
+      const stx = byId(id)!.transaction
+      expect(stx).toHaveProperty('nonce')
+      expect(stx).toHaveProperty('fee')
+    })
 
     // Ripple/Xahau ② — LastLedgerSequence + Sequence
     ;['xrp-payment', 'xrp-iou-payment', 'xrp-accountset', 'xrp-trustset', 'xahau-payment'].forEach((id) => {
@@ -1389,9 +1393,11 @@ describe('T-PRESET no-network 완성 필드 (non-evm)', () => {
     // Vechain blockRef = 0x + 16 hex (8 bytes)
     expect(byId('vechain-vip180-transfer')!.transaction.blockRef).toMatch(BLOCKREF_RE)
 
-    // Stacks top-level nonce/fee = decimal string
-    const stx = byId('stacks-sip010-transfer')!.transaction
-    expect(String(stx.nonce)).toMatch(/^\d+$/)
-    expect(String(stx.fee)).toMatch(/^\d+$/)
+    // Stacks top-level nonce/fee = decimal string (전 preset)
+    STACKS_IDS.forEach((id) => {
+      const stx = byId(id)!.transaction
+      expect(String(stx.nonce)).toMatch(/^\d+$/)
+      expect(String(stx.fee)).toMatch(/^\d+$/)
+    })
   })
 })

--- a/tests/unit/v2/playground.signtx-rest.test.ts
+++ b/tests/unit/v2/playground.signtx-rest.test.ts
@@ -361,3 +361,86 @@ it('T-U-REST-SCOPE-01: 신규 cosmos/polkadot preset payload 식별자 ↔ appli
     }
   })
 })
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T-PRESET-COMPLETE-01 / T-PRESET-FIELDSHAPE-01 (m09-04-24)
+// wm no-network(pure-signer) 계약: ①prepare-skip / ③marker-consume family preset이
+// 완성 consensus 필드를 담아야 wm이 -32602 없이 서명한다. connector preset은 만료성
+// live 값이 아닌 "대표값(유효 형식)"만 책임 — 서명 시점 실값 주입은 bridge/wm 담당.
+// 여기서는 rest.json의 cosmos/tron/algorand/conflux family field presence + 값 형식만 단언.
+// ─────────────────────────────────────────────────────────────────────────────
+const restById = (id: string) => SAMPLE_REST_PRESETS.find((x: any) => x.id === id)
+
+it('T-PRESET-COMPLETE-01(rest): cosmos/tron/algorand/conflux preset이 no-network 완성 필드를 포함', () => {
+  // Cosmos ① — account_number/sequence + 완성 fee(gas+amount). placeholder("0") 금지.
+  const cosmosIds = [
+    'atom-transfer', 'coreum-transfer', 'coreum-assetft-transfer', 'coreum-testnet-transfer',
+    'hippo-transfer', 'hippo-testnet-transfer', 'cosmos-assetft-descriptor-transfer',
+  ]
+  cosmosIds.forEach((id) => {
+    const tx = restById(id)!.transaction
+    expect(tx).toHaveProperty('account_number')
+    expect(tx).toHaveProperty('sequence')
+    expect(tx.account_number).not.toBe('0') // 0 = module-account placeholder
+    expect(tx.fee).toBeTruthy()
+    expect(tx.fee.gas).toBeTruthy()
+    expect(Array.isArray(tx.fee.amount)).toBe(true)
+    expect(tx.fee.amount.length).toBeGreaterThan(0)
+  })
+
+  // Tron ③ — raw_data ref_block_bytes/ref_block_hash (placeholder 0000/0000… 금지)
+  const tronRawIds = ['trx-transfer', 'trx-trc20-transfer', 'trx-trc20-approve']
+  tronRawIds.forEach((id) => {
+    const rd = restById(id)!.transaction.raw_data
+    expect(rd.ref_block_bytes).toBeTruthy()
+    expect(rd.ref_block_bytes).not.toBe('0000')
+    expect(rd.ref_block_hash).not.toBe('0000000000000000')
+    expect(rd.ref_block_hash.length).toBe(16) // 8 bytes hex
+  })
+  expect(restById('trx-transfer')!.transaction.fee_limit).toBeGreaterThan(0)
+
+  // Algorand ③ — firstRound/lastRound (placeholder 1/1000 금지) + genesis 필드
+  const algoIds = ['algo-payment', 'algo-asa-transfer', 'algo-asa-descriptor-transfer']
+  algoIds.forEach((id) => {
+    const tx = restById(id)!.transaction
+    expect(tx.firstRound).toBeGreaterThan(1)
+    expect(tx.lastRound).toBeGreaterThan(tx.firstRound)
+    expect(tx.genesisHash).toBeTruthy()
+    expect(tx.genesisID).toBeTruthy()
+  })
+
+  // Conflux ① — epochHeight (placeholder 0x0 금지) + gas/gasPrice/storageLimit/nonce
+  const cfx = restById('cfx-transfer')!.transaction
+  expect(cfx.epochHeight).toBeTruthy()
+  expect(cfx.epochHeight).not.toBe('0x0')
+  ;['gas', 'gasPrice', 'storageLimit', 'nonce'].forEach((f) => expect(cfx).toHaveProperty(f))
+})
+
+it('T-PRESET-FIELDSHAPE-01(rest): cosmos/tron/algorand/conflux 값 형식 정합', () => {
+  const HEX_RE = /^0x[0-9a-fA-F]+$/
+  const DEC_STR_RE = /^\d+$/
+
+  // Cosmos: account_number/sequence = decimal string
+  restById('atom-transfer')!.transaction // ensure fixture present
+  ;['atom-transfer', 'coreum-transfer', 'hippo-transfer'].forEach((id) => {
+    const tx = restById(id)!.transaction
+    expect(typeof tx.account_number).toBe('string')
+    expect(tx.account_number).toMatch(DEC_STR_RE)
+    expect(typeof tx.sequence).toBe('string')
+    expect(tx.sequence).toMatch(DEC_STR_RE)
+  })
+
+  // Tron: ref_block_bytes/ref_block_hash = lowercase hex (no 0x prefix)
+  const rd = restById('trx-transfer')!.transaction.raw_data
+  expect(rd.ref_block_bytes).toMatch(/^[0-9a-f]+$/)
+  expect(rd.ref_block_hash).toMatch(/^[0-9a-f]{16}$/)
+
+  // Algorand: firstRound/lastRound = positive integers
+  const algo = restById('algo-payment')!.transaction
+  expect(Number.isInteger(algo.firstRound)).toBe(true)
+  expect(Number.isInteger(algo.lastRound)).toBe(true)
+  expect(algo.firstRound).toBeGreaterThan(0)
+
+  // Conflux: epochHeight = 0x-hex
+  expect(restById('cfx-transfer')!.transaction.epochHeight).toMatch(HEX_RE)
+})

--- a/tests/unit/v2/playground.signtx-rest.test.ts
+++ b/tests/unit/v2/playground.signtx-rest.test.ts
@@ -367,17 +367,23 @@ it('T-U-REST-SCOPE-01: 신규 cosmos/polkadot preset payload 식별자 ↔ appli
 // wm no-network(pure-signer) 계약: ①prepare-skip / ③marker-consume family preset이
 // 완성 consensus 필드를 담아야 wm이 -32602 없이 서명한다. connector preset은 만료성
 // live 값이 아닌 "대표값(유효 형식)"만 책임 — 서명 시점 실값 주입은 bridge/wm 담당.
-// 여기서는 rest.json의 cosmos/tron/algorand/conflux family field presence + 값 형식만 단언.
+// 여기서는 rest.json의 cosmos/tron/algorand/conflux/vechain family field presence + 값 형식만 단언.
+// (COMPLETE와 FIELDSHAPE가 같은 ID 배열을 공유 — subset sampling으로 미검증 preset이 회귀하는 구멍 방지.)
+// trx-trc20-descriptor-transfer(form-D descriptor)는 raw_data가 없어 ref_block 필드가 없다 —
+// wm이 descriptor→raw_data를 구성하므로 여기서 완성 대상이 아님(Solana form-D 제외와 동형). 의도적 제외.
 // ─────────────────────────────────────────────────────────────────────────────
 const restById = (id: string) => SAMPLE_REST_PRESETS.find((x: any) => x.id === id)
+const COSMOS_IDS = [
+  'atom-transfer', 'coreum-transfer', 'coreum-assetft-transfer', 'coreum-testnet-transfer',
+  'hippo-transfer', 'hippo-testnet-transfer', 'cosmos-assetft-descriptor-transfer',
+]
+const TRON_RAW_IDS = ['trx-transfer', 'trx-trc20-transfer', 'trx-trc20-approve'] // descriptor 제외(raw_data 없음)
+const ALGO_IDS = ['algo-payment', 'algo-asa-transfer', 'algo-asa-descriptor-transfer']
+const VET_IDS = ['vet-transfer', 'vet-vip180-transfer']
 
-it('T-PRESET-COMPLETE-01(rest): cosmos/tron/algorand/conflux preset이 no-network 완성 필드를 포함', () => {
+it('T-PRESET-COMPLETE-01(rest): cosmos/tron/algorand/conflux/vechain preset이 no-network 완성 필드를 포함', () => {
   // Cosmos ① — account_number/sequence + 완성 fee(gas+amount). placeholder("0") 금지.
-  const cosmosIds = [
-    'atom-transfer', 'coreum-transfer', 'coreum-assetft-transfer', 'coreum-testnet-transfer',
-    'hippo-transfer', 'hippo-testnet-transfer', 'cosmos-assetft-descriptor-transfer',
-  ]
-  cosmosIds.forEach((id) => {
+  COSMOS_IDS.forEach((id) => {
     const tx = restById(id)!.transaction
     expect(tx).toHaveProperty('account_number')
     expect(tx).toHaveProperty('sequence')
@@ -389,8 +395,7 @@ it('T-PRESET-COMPLETE-01(rest): cosmos/tron/algorand/conflux preset이 no-networ
   })
 
   // Tron ③ — raw_data ref_block_bytes/ref_block_hash (placeholder 0000/0000… 금지)
-  const tronRawIds = ['trx-transfer', 'trx-trc20-transfer', 'trx-trc20-approve']
-  tronRawIds.forEach((id) => {
+  TRON_RAW_IDS.forEach((id) => {
     const rd = restById(id)!.transaction.raw_data
     expect(rd.ref_block_bytes).toBeTruthy()
     expect(rd.ref_block_bytes).not.toBe('0000')
@@ -400,8 +405,7 @@ it('T-PRESET-COMPLETE-01(rest): cosmos/tron/algorand/conflux preset이 no-networ
   expect(restById('trx-transfer')!.transaction.fee_limit).toBeGreaterThan(0)
 
   // Algorand ③ — firstRound/lastRound (placeholder 1/1000 금지) + genesis 필드
-  const algoIds = ['algo-payment', 'algo-asa-transfer', 'algo-asa-descriptor-transfer']
-  algoIds.forEach((id) => {
+  ALGO_IDS.forEach((id) => {
     const tx = restById(id)!.transaction
     expect(tx.firstRound).toBeGreaterThan(1)
     expect(tx.lastRound).toBeGreaterThan(tx.firstRound)
@@ -414,15 +418,23 @@ it('T-PRESET-COMPLETE-01(rest): cosmos/tron/algorand/conflux preset이 no-networ
   expect(cfx.epochHeight).toBeTruthy()
   expect(cfx.epochHeight).not.toBe('0x0')
   ;['gas', 'gasPrice', 'storageLimit', 'nonce'].forEach((f) => expect(cfx).toHaveProperty(f))
+
+  // Vechain ③ — blockRef (placeholder 0x0000… 금지). rest.json에 vet-transfer/vet-vip180-transfer 존재.
+  VET_IDS.forEach((id) => {
+    const tx = restById(id)!.transaction
+    expect(tx.blockRef).toBeTruthy()
+    expect(tx.blockRef).not.toBe('0x0000000000000000')
+    expect(tx.blockRef).toMatch(/^0x[0-9a-fA-F]{16}$/)
+  })
 })
 
-it('T-PRESET-FIELDSHAPE-01(rest): cosmos/tron/algorand/conflux 값 형식 정합', () => {
+it('T-PRESET-FIELDSHAPE-01(rest): cosmos/tron/algorand/conflux/vechain 값 형식 정합 (전 preset)', () => {
   const HEX_RE = /^0x[0-9a-fA-F]+$/
   const DEC_STR_RE = /^\d+$/
+  const BLOCKREF_RE = /^0x[0-9a-fA-F]{16}$/
 
-  // Cosmos: account_number/sequence = decimal string
-  restById('atom-transfer')!.transaction // ensure fixture present
-  ;['atom-transfer', 'coreum-transfer', 'hippo-transfer'].forEach((id) => {
+  // Cosmos: account_number/sequence = decimal string (전 preset)
+  COSMOS_IDS.forEach((id) => {
     const tx = restById(id)!.transaction
     expect(typeof tx.account_number).toBe('string')
     expect(tx.account_number).toMatch(DEC_STR_RE)
@@ -430,17 +442,27 @@ it('T-PRESET-FIELDSHAPE-01(rest): cosmos/tron/algorand/conflux 값 형식 정합
     expect(tx.sequence).toMatch(DEC_STR_RE)
   })
 
-  // Tron: ref_block_bytes/ref_block_hash = lowercase hex (no 0x prefix)
-  const rd = restById('trx-transfer')!.transaction.raw_data
-  expect(rd.ref_block_bytes).toMatch(/^[0-9a-f]+$/)
-  expect(rd.ref_block_hash).toMatch(/^[0-9a-f]{16}$/)
+  // Tron: ref_block_bytes/ref_block_hash = lowercase hex (no 0x prefix) — 전 raw_data preset
+  TRON_RAW_IDS.forEach((id) => {
+    const rd = restById(id)!.transaction.raw_data
+    expect(rd.ref_block_bytes).toMatch(/^[0-9a-f]+$/)
+    expect(rd.ref_block_hash).toMatch(/^[0-9a-f]{16}$/)
+  })
 
-  // Algorand: firstRound/lastRound = positive integers
-  const algo = restById('algo-payment')!.transaction
-  expect(Number.isInteger(algo.firstRound)).toBe(true)
-  expect(Number.isInteger(algo.lastRound)).toBe(true)
-  expect(algo.firstRound).toBeGreaterThan(0)
+  // Algorand: firstRound/lastRound = positive integers, firstRound<lastRound (전 preset)
+  ALGO_IDS.forEach((id) => {
+    const algo = restById(id)!.transaction
+    expect(Number.isInteger(algo.firstRound)).toBe(true)
+    expect(Number.isInteger(algo.lastRound)).toBe(true)
+    expect(algo.firstRound).toBeGreaterThan(0)
+    expect(algo.lastRound).toBeGreaterThan(algo.firstRound)
+  })
 
   // Conflux: epochHeight = 0x-hex
   expect(restById('cfx-transfer')!.transaction.epochHeight).toMatch(HEX_RE)
+
+  // Vechain: blockRef = 0x + 16 hex (전 preset)
+  VET_IDS.forEach((id) => {
+    expect(restById(id)!.transaction.blockRef).toMatch(BLOCKREF_RE)
+  })
 })


### PR DESCRIPTION
## Objective
`m09-04-24-preset-nonetwork-fields` (epic child of **m09-04**, Jira **DC-3228**, parent Epic DC-2223)

wm no-network(pure-signer) 계약(epic m02-08)에 맞춰 connector playground preset의 ①prepare-skip / ③marker-consume / ②boundary family를 **placeholder → 대표값(유효 형식) + 신규 필드**로 완성한다. bridge가 `noNetwork:true`를 세팅(sdk sibling `m09-05-11`)한 뒤 이 preset들이 불완전하면 wm이 `-32602`하므로 field presence + 값 형식이 필수.

### 값 조달 원칙 (사용자 결정 2026-07-14)
connector preset은 **대표값(유효 형식)만** 보유한다. 만료성 live consensus 값(blockhash/account#/seq/LastLedgerSequence/NEAR nonce·blockHash 등)은 **서명 검증 시점에 wm이 조회/주입**한다(`m09-05-09` prepare-injection 선례). 즉 이 PR은 **field presence + 값 형식**만 책임지고 만료성 live 값을 baked-in 하지 않는다.

## 변경 (per-family, `WIRE-NONETWORK-SDK-CHANGES` §2)
**① prepare-skip**
- **NEAR**: 실 `nonce` + `publicKey`(access-key ed25519 base58) — native/ft 전부 (ft preset에 `publicKey` 신규 추가; native의 all-1 placeholder pubkey 교체)
- **Havah**: 신규 `stepPrice` (fee=0 placeholder 대체) — 3 preset
- **Cosmos**: `account_number`/`sequence` non-zero (module-account placeholder "0" 제거) — 7 preset
- **Conflux**: `epochHeight` non-zero
- **Stacks**: `stacks-sip010-transfer` top-level `nonce`+`fee` 신규

**③ marker-consume**
- **Tron**: raw_data `ref_block_bytes`/`ref_block_hash` non-zero + native `fee_limit`
- **Vechain**: `blockRef` non-zero
- **Algorand**: `firstRound`/`lastRound` non-zero (genesisHash/genesisID 기존 유지)
- **Constellation**: 신규 `lastRef{ordinal,hash}`

**② boundary**
- **Ripple/Xahau**: 신규 `LastLedgerSequence` + 실 `Sequence`

## 격리
- **`playground/presets.{non-evm,rest}.json` 만 수정** — `src/sign/`에 chain enum/switch 추가 **0** (`connector-chain-addition-isolation`)
- `package.json` version 미변경 (`no-version-bump`)
- Cosmos/Conflux/Tron/Algorand는 `presets.rest.json`에 존재 → 스코프 family가 해당 파일에 있어 함께 갱신 (objective 산출물 라인의 `{evm,non-evm}` 표기는 primary 파일 명시일 뿐, 스코프 family 기준으로 완성)

## 검증
| 명령 | 결과 |
|---|---|
| `yarn unit-v2 playground.signtx-non-evm` | ✅ PASS (36 suites / 700 tests) |
| `yarn unit-v2 playground.signtx-rest` | ✅ PASS |
| `yarn lint` | ✅ PASS (0 errors, 19 pre-existing warnings) |
| `yarn build` | ✅ PASS |
| `yarn unit-mock` | ✅ PASS (11 suites / 69 tests) |
| `check:payload-contract` / `check:payload-shape` | ✅ PASS |

**신규 회귀 테스트**: `T-PRESET-COMPLETE-01` + `T-PRESET-FIELDSHAPE-01` (signtx-non-evm: NEAR/Havah/Vechain/Constellation/Stacks/Ripple/Xahau; signtx-rest: Cosmos/Tron/Algorand/Conflux).

### Conditional SKIP (설계상)
`T-PRESET-NONETWORK-SIGN-01` / `T-PRESET-INCOMPLETE-32602-01` (bridge swproxy 하네스 서명 라운드트립)은 sdk sibling **m09-05-11 미머지 + sister wm m02-08 미sync**로 실행 전제 미충족 → **SKIP(FAIL 아님)**. 해당 sibling 머지 후 bridge conformance 하네스에서 검증.

## 스코프 외 (후속)
- ② blob 이전(Solana form-E/Stellar xdr/Tezos·Hedera unsignedTx/Polkadot scaleHex) — m09-04-25
- docs — m09-04-26

🤖 Generated with [Claude Code](https://claude.com/claude-code)
