### PR TITLE
[DC-3889] m09-04-28: DCENT X 모델 축 — DeviceInfoPayload.deviceModel + 문서 펌웨어 표 2모델 분리

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -659,58 +659,72 @@ function navLink(c){
 /* ---- per-network minimum firmware requirements ----
    Source: github.com/DcentWallet/info firmwareVersion.md (version a coin/method was introduced).
    WC-based methods (signData/signAuthEntry/getPublicKey + Cardano/Stellar signMessage) = 2.35.0 ("general message signing").
-   Rendered as a per-page Requirements table by injectFwReq(); Support Matrix "Min FW" column uses MATRIX row .fw. */
+   Rendered as a per-page Requirements table by injectFwReq(); Support Matrix "Min FW" columns use MATRIX row .fw.
+
+   Value shape: {bio, x} — both keys are REQUIRED.
+     bio = D'CENT Biometric Wallet (firmware 1.x~2.x line)   x = DCENT X (firmware 1.x line)
+
+   NOTE(decision-anchor: dcentx-fw-table-two-columns): 두 모델의 버전 라인(X 1.x vs Biometric 2.x)은
+   같은 수직선에서 비교할 수 없다. 단일 컬럼으로 합치면 X 사용자에게 "내 펌웨어 1.0.0 < 2.35.0 →
+   미지원"으로 읽혀, 실제로는 지원되는 기능을 안 쓰게 만든다. bio/x 두 키는 항상 함께 유지하고
+   단일 값으로 되돌리지 말 것 — `yarn check:index-fw-models`(scripts/check-index-html-fw-models.mjs)가
+   전 항목을 강제한다 (2026-08-07 사용자 결정, m09-04-28). */
 window.FWREQ = {
- "chain-ethereum":[["getAddress","1.0.0"],["signTransaction","1.0.0"],["signMessage","1.3.0"],["signTypedData","2.11.1"]],
- "chain-kaia":[["getAddress","1.5.1"],["signTransaction","1.5.1"],["signMessage","1.5.1"],["signTypedData","2.11.1"]],
- "chain-bitcoin":[["getAddress","1.0.0"],["signTransaction","1.0.0"]],
- "chain-bitcoincash":[["getAddress","1.5.1"],["signTransaction","1.5.1"]],
- "chain-litecoin":[["getAddress","1.5.1"],["signTransaction","1.5.1"]],
- "chain-dogecoin":[["getAddress","2.3.0"],["signTransaction","2.3.0"]],
- "chain-dash":[["getAddress","1.5.1"],["signTransaction","1.5.1"]],
- "chain-conflux":[["getAddress","2.18.3"],["signTransaction","2.18.3"]],
- "chain-solana":[["getAddress","2.16.5"],["signTransaction","2.16.5"],["signMessage","2.31.0"]],
- "chain-cardano":[["getAddress","2.7.0"],["signTransaction","2.7.0",{en:"plain transfer<br>CIP-30 / CIP-95 governance requests (DRep, voting, certificates) require <code>2.35.0</code>",ko:"일반 전송 기준<br>CIP-30 / CIP-95 거버넌스 요청(DRep·투표·인증서)은 <code>2.35.0</code> 필요"}],["signData","2.35.0"],["getPublicKey","2.35.0"]],
- "chain-cosmos":[["getAddress","2.21.0"],["signTransaction","2.21.0"]],
- "chain-xrp":[["getAddress","2.4.0"],["signTransaction","2.4.0",{en:"plain transfer<br>dApp (WalletConnect) requests require <code>2.35.0</code>",ko:"일반 전송 기준<br>댑(WalletConnect) 요청은 <code>2.35.0</code> 필요"}]],
- "chain-xahau":[["getAddress","2.32.0"],["signTransaction","2.32.0"]],
- "chain-tron":[["getAddress","2.3.0"],["signTransaction","2.3.0"]],
- "chain-stellar":[["getAddress","2.20.0"],["signTransaction","2.20.0",{en:"plain transfer<br>dApp (WalletConnect / Soroban) requests require <code>2.35.0</code>",ko:"일반 전송 기준<br>댑(WalletConnect / Soroban) 요청은 <code>2.35.0</code> 필요"}],["signMessage","2.35.0"],["signAuthEntry","2.35.0"]],
- "chain-polkadot":[["getAddress","2.19.1"],["signTransaction","2.19.1"],["signMessage","2.30.2"]],
- "chain-near":[["getAddress","2.24.0"],["signTransaction","2.24.0"]],
- "chain-hedera":[["getAddress","2.19.3"],["signTransaction","2.19.3"]],
- "chain-vechain":[["getAddress","2.23.4"],["signTransaction","2.23.4"]],
- "chain-filecoin":[["getAddress","2.33.0"],["signTransaction","2.33.0"]],
- "chain-tezos":[["getAddress","2.24.1"],["signTransaction","2.24.1"]],
- "chain-stacks":[["getAddress","2.14.1"],["signTransaction","2.14.1"]],
- "chain-algorand":[["getAddress","2.29.0"],["signTransaction","2.29.0"]],
- "chain-constellation":[["getAddress","2.34.0"],["signTransaction","2.34.0"]],
- "chain-havah":[["getAddress","2.26.0"],["signTransaction","2.26.0"]]
+ "chain-ethereum":[["getAddress",{bio:"1.0.0",x:"1.0.0"}],["signTransaction",{bio:"1.0.0",x:"1.0.0"}],["signMessage",{bio:"1.3.0",x:"1.0.0"}],["signTypedData",{bio:"2.11.1",x:"1.0.0"}]],
+ "chain-kaia":[["getAddress",{bio:"1.5.1",x:"1.0.0"}],["signTransaction",{bio:"1.5.1",x:"1.0.0"}],["signMessage",{bio:"1.5.1",x:"1.0.0"}],["signTypedData",{bio:"2.11.1",x:"1.0.0"}]],
+ "chain-bitcoin":[["getAddress",{bio:"1.0.0",x:"1.0.0"}],["signTransaction",{bio:"1.0.0",x:"1.0.0"}]],
+ "chain-bitcoincash":[["getAddress",{bio:"1.5.1",x:"1.0.0"}],["signTransaction",{bio:"1.5.1",x:"1.0.0"}]],
+ "chain-litecoin":[["getAddress",{bio:"1.5.1",x:"1.0.0"}],["signTransaction",{bio:"1.5.1",x:"1.0.0"}]],
+ "chain-dogecoin":[["getAddress",{bio:"2.3.0",x:"1.0.0"}],["signTransaction",{bio:"2.3.0",x:"1.0.0"}]],
+ "chain-dash":[["getAddress",{bio:"1.5.1",x:"1.0.0"}],["signTransaction",{bio:"1.5.1",x:"1.0.0"}]],
+ "chain-conflux":[["getAddress",{bio:"2.18.3",x:"1.0.0"}],["signTransaction",{bio:"2.18.3",x:"1.0.0"}]],
+ "chain-solana":[["getAddress",{bio:"2.16.5",x:"1.0.0"}],["signTransaction",{bio:"2.16.5",x:"1.0.0"}],["signMessage",{bio:"2.31.0",x:"1.0.0"}]],
+ "chain-cardano":[["getAddress",{bio:"2.7.0",x:"1.0.0"}],["signTransaction",{bio:"2.7.0",x:"1.0.0"},{en:"plain transfer<br>CIP-30 / CIP-95 governance requests (DRep, voting, certificates) require <code>2.35.0</code>",ko:"일반 전송 기준<br>CIP-30 / CIP-95 거버넌스 요청(DRep·투표·인증서)은 <code>2.35.0</code> 필요"}],["signData",{bio:"2.35.0",x:"1.0.0"}],["getPublicKey",{bio:"2.35.0",x:"1.0.0"}]],
+ "chain-cosmos":[["getAddress",{bio:"2.21.0",x:"1.0.0"}],["signTransaction",{bio:"2.21.0",x:"1.0.0"}]],
+ "chain-xrp":[["getAddress",{bio:"2.4.0",x:"1.0.0"}],["signTransaction",{bio:"2.4.0",x:"1.0.0"},{en:"plain transfer<br>dApp (WalletConnect) requests require <code>2.35.0</code>",ko:"일반 전송 기준<br>댑(WalletConnect) 요청은 <code>2.35.0</code> 필요"}]],
+ "chain-xahau":[["getAddress",{bio:"2.32.0",x:"1.0.0"}],["signTransaction",{bio:"2.32.0",x:"1.0.0"}]],
+ "chain-tron":[["getAddress",{bio:"2.3.0",x:"1.0.0"}],["signTransaction",{bio:"2.3.0",x:"1.0.0"}]],
+ "chain-stellar":[["getAddress",{bio:"2.20.0",x:"1.0.0"}],["signTransaction",{bio:"2.20.0",x:"1.0.0"},{en:"plain transfer<br>dApp (WalletConnect / Soroban) requests require <code>2.35.0</code>",ko:"일반 전송 기준<br>댑(WalletConnect / Soroban) 요청은 <code>2.35.0</code> 필요"}],["signMessage",{bio:"2.35.0",x:"1.0.0"}],["signAuthEntry",{bio:"2.35.0",x:"1.0.0"}]],
+ "chain-polkadot":[["getAddress",{bio:"2.19.1",x:"1.0.0"}],["signTransaction",{bio:"2.19.1",x:"1.0.0"}],["signMessage",{bio:"2.30.2",x:"1.0.0"}]],
+ "chain-near":[["getAddress",{bio:"2.24.0",x:"1.0.0"}],["signTransaction",{bio:"2.24.0",x:"1.0.0"}]],
+ "chain-hedera":[["getAddress",{bio:"2.19.3",x:"1.0.0"}],["signTransaction",{bio:"2.19.3",x:"1.0.0"}]],
+ "chain-vechain":[["getAddress",{bio:"2.23.4",x:"1.0.0"}],["signTransaction",{bio:"2.23.4",x:"1.0.0"}]],
+ "chain-filecoin":[["getAddress",{bio:"2.33.0",x:"1.0.0"}],["signTransaction",{bio:"2.33.0",x:"1.0.0"}]],
+ "chain-tezos":[["getAddress",{bio:"2.24.1",x:"1.0.0"}],["signTransaction",{bio:"2.24.1",x:"1.0.0"}]],
+ "chain-stacks":[["getAddress",{bio:"2.14.1",x:"1.0.0"}],["signTransaction",{bio:"2.14.1",x:"1.0.0"}]],
+ "chain-algorand":[["getAddress",{bio:"2.29.0",x:"1.0.0"}],["signTransaction",{bio:"2.29.0",x:"1.0.0"}]],
+ "chain-constellation":[["getAddress",{bio:"2.34.0",x:"1.0.0"}],["signTransaction",{bio:"2.34.0",x:"1.0.0"}]],
+ "chain-havah":[["getAddress",{bio:"2.26.0",x:"1.0.0"}],["signTransaction",{bio:"2.26.0",x:"1.0.0"}]]
 };
 window.FWNOTE = {
- "chain-ethereum":{en:"Values are for Ethereum mainnet. Some EVM chains need newer firmware — 64-bit chainIds require <code>2.19.7</code>, and several chains were added later (e.g. BSC <code>2.6.1</code>, Polygon <code>2.8.0</code>).",ko:"Ethereum 메인넷 기준입니다. 일부 EVM 체인은 더 최신 펌웨어가 필요합니다 — 64-bit chainId는 <code>2.19.7</code>, 일부 체인은 이후 추가되었습니다(예: BSC <code>2.6.1</code>, Polygon <code>2.8.0</code>)."},
- "chain-bitcoin":{en:"SegWit (bech32) addresses require firmware <code>1.7.0</code> or higher.",ko:"SegWit(bech32) 주소는 펌웨어 <code>1.7.0</code> 이상이 필요합니다."},
- "chain-solana":{en:"SPL token support was added in firmware <code>2.17.1</code>.",ko:"SPL 토큰 지원은 펌웨어 <code>2.17.1</code>에서 추가되었습니다."},
- "chain-cosmos":{en:"COREUM smart-token support was added in firmware <code>2.28.1</code>.",ko:"COREUM 스마트 토큰 지원은 펌웨어 <code>2.28.1</code>에서 추가되었습니다."},
- "chain-near":{en:"NEAR token (not native NEAR) requires firmware <code>2.27.1</code> or higher.",ko:"NEAR 토큰(네이티브 NEAR 제외)은 펌웨어 <code>2.27.1</code> 이상이 필요합니다."},
- "chain-polkadot":{en:"Astar and other Substrate parachains are a separate device family (Parachain), added in firmware <code>2.30.0</code> — distinct from Polkadot (DOT).",ko:"Astar 등 기타 Substrate 파라체인은 별도의 기기 계열(Parachain)로 펌웨어 <code>2.30.0</code>에서 추가되었습니다 — Polkadot(DOT)과 구분됩니다."},
- "chain-xrp":{en:"The dApp (WalletConnect) <code>signTransaction</code> path requires firmware <code>2.35.0+</code> and is supported — arbitrary XRPL transaction types (AccountSet, OfferCreate, EscrowCreate, TrustSet, …) sign through the same wire path.",ko:"dApp(WalletConnect) <code>signTransaction</code> 경로는 펌웨어 <code>2.35.0+</code>가 필요하며 지원됩니다 — 다양한 XRPL 트랜잭션 타입(AccountSet, OfferCreate, EscrowCreate, TrustSet 등)이 동일 wire 경로로 서명됩니다."},
- "chain-stellar":{en:"The dApp (WalletConnect / Soroban) <code>signTransaction</code> path requires firmware <code>2.35.0+</code> and is supported — see the <code>stellar-soroban-invoke-*</code> and <code>stellar-xdr-passthrough-blind-sign</code> playground presets.",ko:"dApp(WalletConnect / Soroban) <code>signTransaction</code> 경로는 펌웨어 <code>2.35.0+</code>가 필요하며 지원됩니다 — playground의 <code>stellar-soroban-invoke-*</code>, <code>stellar-xdr-passthrough-blind-sign</code> preset 참고."}
+ "chain-ethereum":{en:"Firmware versions below are for the <strong>D'CENT Biometric Wallet</strong> line — <strong>DCENT X</strong> supports them from <code>1.0.0</code>. Values are for Ethereum mainnet. Some EVM chains need newer firmware — 64-bit chainIds require <code>2.19.7</code>, and several chains were added later (e.g. BSC <code>2.6.1</code>, Polygon <code>2.8.0</code>).",ko:"아래 펌웨어 버전은 <strong>D'CENT Biometric Wallet</strong> 기준입니다 — <strong>DCENT X</strong>는 <code>1.0.0</code>부터 지원합니다. Ethereum 메인넷 기준입니다. 일부 EVM 체인은 더 최신 펌웨어가 필요합니다 — 64-bit chainId는 <code>2.19.7</code>, 일부 체인은 이후 추가되었습니다(예: BSC <code>2.6.1</code>, Polygon <code>2.8.0</code>)."},
+ "chain-bitcoin":{en:"Firmware versions below are for the <strong>D'CENT Biometric Wallet</strong> line — <strong>DCENT X</strong> supports them from <code>1.0.0</code>. SegWit (bech32) addresses require firmware <code>1.7.0</code> or higher.",ko:"아래 펌웨어 버전은 <strong>D'CENT Biometric Wallet</strong> 기준입니다 — <strong>DCENT X</strong>는 <code>1.0.0</code>부터 지원합니다. SegWit(bech32) 주소는 펌웨어 <code>1.7.0</code> 이상이 필요합니다."},
+ "chain-solana":{en:"Firmware versions below are for the <strong>D'CENT Biometric Wallet</strong> line — <strong>DCENT X</strong> supports them from <code>1.0.0</code>. SPL token support was added in firmware <code>2.17.1</code>.",ko:"아래 펌웨어 버전은 <strong>D'CENT Biometric Wallet</strong> 기준입니다 — <strong>DCENT X</strong>는 <code>1.0.0</code>부터 지원합니다. SPL 토큰 지원은 펌웨어 <code>2.17.1</code>에서 추가되었습니다."},
+ "chain-cosmos":{en:"Firmware versions below are for the <strong>D'CENT Biometric Wallet</strong> line — <strong>DCENT X</strong> supports them from <code>1.0.0</code>. COREUM smart-token support was added in firmware <code>2.28.1</code>.",ko:"아래 펌웨어 버전은 <strong>D'CENT Biometric Wallet</strong> 기준입니다 — <strong>DCENT X</strong>는 <code>1.0.0</code>부터 지원합니다. COREUM 스마트 토큰 지원은 펌웨어 <code>2.28.1</code>에서 추가되었습니다."},
+ "chain-near":{en:"Firmware versions below are for the <strong>D'CENT Biometric Wallet</strong> line — <strong>DCENT X</strong> supports them from <code>1.0.0</code>. NEAR token (not native NEAR) requires firmware <code>2.27.1</code> or higher.",ko:"아래 펌웨어 버전은 <strong>D'CENT Biometric Wallet</strong> 기준입니다 — <strong>DCENT X</strong>는 <code>1.0.0</code>부터 지원합니다. NEAR 토큰(네이티브 NEAR 제외)은 펌웨어 <code>2.27.1</code> 이상이 필요합니다."},
+ "chain-polkadot":{en:"Firmware versions below are for the <strong>D'CENT Biometric Wallet</strong> line — <strong>DCENT X</strong> supports them from <code>1.0.0</code>. Astar and other Substrate parachains are a separate device family (Parachain), added in firmware <code>2.30.0</code> — distinct from Polkadot (DOT).",ko:"아래 펌웨어 버전은 <strong>D'CENT Biometric Wallet</strong> 기준입니다 — <strong>DCENT X</strong>는 <code>1.0.0</code>부터 지원합니다. Astar 등 기타 Substrate 파라체인은 별도의 기기 계열(Parachain)로 펌웨어 <code>2.30.0</code>에서 추가되었습니다 — Polkadot(DOT)과 구분됩니다."},
+ "chain-xrp":{en:"Firmware versions below are for the <strong>D'CENT Biometric Wallet</strong> line — <strong>DCENT X</strong> supports them from <code>1.0.0</code>. The dApp (WalletConnect) <code>signTransaction</code> path requires firmware <code>2.35.0+</code> and is supported — arbitrary XRPL transaction types (AccountSet, OfferCreate, EscrowCreate, TrustSet, …) sign through the same wire path.",ko:"아래 펌웨어 버전은 <strong>D'CENT Biometric Wallet</strong> 기준입니다 — <strong>DCENT X</strong>는 <code>1.0.0</code>부터 지원합니다. dApp(WalletConnect) <code>signTransaction</code> 경로는 펌웨어 <code>2.35.0+</code>가 필요하며 지원됩니다 — 다양한 XRPL 트랜잭션 타입(AccountSet, OfferCreate, EscrowCreate, TrustSet 등)이 동일 wire 경로로 서명됩니다."},
+ "chain-stellar":{en:"Firmware versions below are for the <strong>D'CENT Biometric Wallet</strong> line — <strong>DCENT X</strong> supports them from <code>1.0.0</code>. The dApp (WalletConnect / Soroban) <code>signTransaction</code> path requires firmware <code>2.35.0+</code> and is supported — see the <code>stellar-soroban-invoke-*</code> and <code>stellar-xdr-passthrough-blind-sign</code> playground presets.",ko:"아래 펌웨어 버전은 <strong>D'CENT Biometric Wallet</strong> 기준입니다 — <strong>DCENT X</strong>는 <code>1.0.0</code>부터 지원합니다. dApp(WalletConnect / Soroban) <code>signTransaction</code> 경로는 펌웨어 <code>2.35.0+</code>가 필요하며 지원됩니다 — playground의 <code>stellar-soroban-invoke-*</code>, <code>stellar-xdr-passthrough-blind-sign</code> preset 참고."}
 };
 function injectFwReq(root,id,ko){
   const rows=window.FWREQ&&window.FWREQ[id]; if(!rows) return;
   const chips=root.querySelector('.method-chips'); if(!chips) return;
   const title=ko?'요구사항':'Requirements';
+  // 모델별 2컬럼 — 두 버전 라인은 비교 대상이 아니라 별개 축이다 (dcentx-fw-table-two-columns 참조)
   const lead=ko
-    ?'메서드별 최소 <strong>D\'CENT Biometric Wallet</strong> 펌웨어 버전입니다. 미달 시 펌웨어 업데이트 에러(<code>5005</code>)를 반환하고 브리지가 업데이트를 안내합니다.'
-    :'Minimum <strong>D\'CENT Biometric Wallet</strong> firmware for each method. Below this the request returns the firmware-update error (<code>5005</code>) and the bridge prompts to update.';
-  const mh=ko?'메서드':'Method', vh=ko?'최소 펌웨어':'Min firmware';
+    ?'메서드별 최소 펌웨어 버전입니다. 모델마다 버전 라인이 달라 <strong>D\'CENT Biometric Wallet</strong>과 <strong>DCENT X</strong>를 각각 표기합니다(서로 비교하는 값이 아닙니다). 미달 시 펌웨어 업데이트 에러(<code>5005</code>)를 반환하고 브리지가 업데이트를 안내합니다.'
+    :'Minimum firmware for each method. The two models are on different version lines, so <strong>D\'CENT Biometric Wallet</strong> and <strong>DCENT X</strong> are listed separately (the numbers are not comparable across models). Below this the request returns the firmware-update error (<code>5005</code>) and the bridge prompts to update.';
+  const mh=ko?'메서드':'Method', bh='D\'CENT Biometric Wallet', xh='DCENT X';
   const tr=rows.map(r=>{
     const q=r[2]?` <span class="muted">— ${ko?(r[2].ko||r[2].en):r[2].en}</span>`:'';
-    return `<tr><td><code>${r[0]}</code></td><td><code>${r[1]}</code> ${ko?'이상':'or higher'}${q}</td></tr>`;
+    // 값은 {bio,x} 객체가 계약이다. 옛 단일 문자열이 남아 있어도 페이지가 깨지지 않게 접어준다
+    // (계약 강제는 렌더가 아니라 check:index-fw-models 가 한다).
+    const v=(r[1]&&typeof r[1]==='object')?r[1]:{bio:r[1],x:'—'};
+    const cell=s=>s?`<code>${s}</code> ${ko?'이상':'or higher'}`:'—';
+    return `<tr><td><code>${r[0]}</code></td><td>${cell(v.bio)}${q}</td><td>${cell(v.x)}</td></tr>`;
   }).join('');
   const nt=(window.FWNOTE&&window.FWNOTE[id])?`<div class="note info"><span class="ni">i</span><div>${ko?window.FWNOTE[id].ko:window.FWNOTE[id].en}</div></div>`:'';
-  const html=`<h2>${title}</h2><p>${lead}</p><div style="overflow-x:auto"><table class="params"><thead><tr><th>${mh}</th><th>${vh}</th></tr></thead><tbody>${tr}</tbody></table></div>${nt}`;
+  const html=`<h2>${title}</h2><p>${lead}</p><div style="overflow-x:auto"><table class="params"><thead><tr><th>${mh}</th><th>${bh}</th><th>${xh}</th></tr></thead><tbody>${tr}</tbody></table></div>${nt}`;
   chips.insertAdjacentHTML('afterend',html);
 }
 /* ---- router ---- */
@@ -950,10 +964,10 @@ search:'overview browser-native architecture call flow chainId keyPath V1Respons
 
 <h2>Requirements</h2>
 <div class="reqs">
-  <div class="rq"><div class="k"><span class="ico"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="2" width="12" height="20" rx="2.5"/><path d="M9.5 6h5"/><circle cx="12" cy="17" r="1.6"/></svg></span>Device</div><div class="v">A <strong>D'CENT Biometric Wallet</strong>. Get one at the <a href="https://store-kr.dcentwallet.com/pages/dcent-biometric-crypto-wallet" target="_blank" rel="noopener">D'CENT store</a>.</div></div>
+  <div class="rq"><div class="k"><span class="ico"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="2" width="12" height="20" rx="2.5"/><path d="M9.5 6h5"/><circle cx="12" cy="17" r="1.6"/></svg></span>Device</div><div class="v">A <strong>D'CENT Biometric Wallet</strong> or a <strong>DCENT X</strong>. Get one at the <a href="https://store-kr.dcentwallet.com/pages/dcent-biometric-crypto-wallet" target="_blank" rel="noopener">D'CENT store</a>.</div></div>
   <div class="rq"><div class="k"><span class="ico"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3c2.5 2.5 2.5 15 0 18M12 3c-2.5 2.5-2.5 15 0 18"/></svg></span>Browser</div><div class="v">WebHID and Web Bluetooth run only in <strong>Chromium-based</strong> browsers — Chrome, Edge, Brave, Opera. Firefox and Safari are not supported.</div></div>
   <div class="rq"><div class="k"><span class="ico"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9 12a3 3 0 0 1 3-3h3a3 3 0 0 1 0 6h-1.5"/><path d="M15 12a3 3 0 0 1-3 3H9a3 3 0 0 1 0-6h1.5"/></svg></span>Connection</div><div class="v"><strong>USB</strong> (WebHID) or <strong>Bluetooth</strong> (Web Bluetooth), selected with <a href="#/set-transport"><code>setTransport()</code></a>. No bridge program to install.</div></div>
-  <div class="rq"><div class="k"><span class="ico"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="7" width="10" height="10" rx="1.5"/><path d="M10 3v3M14 3v3M10 18v3M14 18v3M3 10h3M3 14h3M18 10h3M18 14h3"/></svg></span>Firmware</div><div class="v">Some networks and methods require a minimum firmware version. An unsupported request returns the firmware-update error, and the bridge prompts to update.</div></div>
+  <div class="rq"><div class="k"><span class="ico"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="7" width="10" height="10" rx="1.5"/><path d="M10 3v3M14 3v3M10 18v3M14 18v3M3 10h3M3 14h3M18 10h3M18 14h3"/></svg></span>Firmware</div><div class="v">Some networks and methods require a minimum firmware version, listed per model — <strong>D'CENT Biometric Wallet</strong> (1.x~2.x line) and <strong>DCENT X</strong> (1.x line, from <code>1.0.0</code>). The two lines are separate and not comparable. An unsupported request returns the firmware-update error, and the bridge prompts to update.</div></div>
 </div>
 
 <h2>Install</h2>
@@ -1064,10 +1078,10 @@ ko:`
 
 <h2>요구사항</h2>
 <div class="reqs">
-  <div class="rq"><div class="k"><span class="ico"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="2" width="12" height="20" rx="2.5"/><path d="M9.5 6h5"/><circle cx="12" cy="17" r="1.6"/></svg></span>기기</div><div class="v"><strong>D'CENT 바이오메트릭 월렛</strong>이 필요합니다. <a href="https://store-kr.dcentwallet.com/pages/dcent-biometric-crypto-wallet" target="_blank" rel="noopener">D'CENT 스토어</a>에서 구매할 수 있습니다.</div></div>
+  <div class="rq"><div class="k"><span class="ico"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="2" width="12" height="20" rx="2.5"/><path d="M9.5 6h5"/><circle cx="12" cy="17" r="1.6"/></svg></span>기기</div><div class="v"><strong>D'CENT Biometric Wallet</strong>(바이오메트릭 월렛) 또는 <strong>DCENT X</strong>가 필요합니다. <a href="https://store-kr.dcentwallet.com/pages/dcent-biometric-crypto-wallet" target="_blank" rel="noopener">D'CENT 스토어</a>에서 구매할 수 있습니다.</div></div>
   <div class="rq"><div class="k"><span class="ico"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3c2.5 2.5 2.5 15 0 18M12 3c-2.5 2.5-2.5 15 0 18"/></svg></span>브라우저</div><div class="v">WebHID와 Web Bluetooth는 <strong>Chromium 계열</strong> 브라우저 — Chrome, Edge, Brave, Opera — 에서만 동작합니다. Firefox / Safari는 미지원입니다.</div></div>
   <div class="rq"><div class="k"><span class="ico"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9 12a3 3 0 0 1 3-3h3a3 3 0 0 1 0 6h-1.5"/><path d="M15 12a3 3 0 0 1-3 3H9a3 3 0 0 1 0-6h1.5"/></svg></span>연결 방식</div><div class="v"><strong>USB</strong>(WebHID) 또는 <strong>블루투스</strong>(Web Bluetooth)를 <a href="#/set-transport"><code>setTransport()</code></a>로 선택합니다. 설치할 브리지 프로그램이 없습니다.</div></div>
-  <div class="rq"><div class="k"><span class="ico"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="7" width="10" height="10" rx="1.5"/><path d="M10 3v3M14 3v3M10 18v3M14 18v3M3 10h3M3 14h3M18 10h3M18 14h3"/></svg></span>펌웨어</div><div class="v">일부 네트워크·메서드는 최소 펌웨어 버전이 필요합니다. 미지원 요청은 펌웨어 업데이트 에러를 반환하고, 브리지가 업데이트를 안내합니다.</div></div>
+  <div class="rq"><div class="k"><span class="ico"><svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="7" width="10" height="10" rx="1.5"/><path d="M10 3v3M14 3v3M10 18v3M14 18v3M3 10h3M3 14h3M18 10h3M18 14h3"/></svg></span>펌웨어</div><div class="v">일부 네트워크·메서드는 최소 펌웨어 버전이 필요하며, 모델별로 나눠 표기합니다 — <strong>D'CENT Biometric Wallet</strong>(1.x~2.x 라인), <strong>DCENT X</strong>(1.x 라인, <code>1.0.0</code>부터). 두 라인은 별개이며 서로 비교하는 값이 아닙니다. 미지원 요청은 펌웨어 업데이트 에러를 반환하고, 브리지가 업데이트를 안내합니다.</div></div>
 </div>
 
 <h2>설치</h2>
@@ -1417,43 +1431,43 @@ search:'sign method chainId payload keyPath transaction signTransaction signMess
 /* ===== Support Matrix ===== */
 window.MATRIX=[
  {n:"Ethereum / EVM",id:"chain-ethereum",cid:"eip155:1/slip44:60",kp:"m/44'/60'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:1,sTD:1,sD:0,sA:0},
- {n:"Kaia",id:"chain-kaia",cid:"eip155:8217/slip44:60",kp:"m/44'/60'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:1,sTD:1,sD:0,sA:0,fw:"1.5.1"},
+ {n:"Kaia",id:"chain-kaia",cid:"eip155:8217/slip44:60",kp:"m/44'/60'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:1,sTD:1,sD:0,sA:0,fw:{bio:"1.5.1",x:"1.0.0"}},
  {n:"XDC (XinFin)",id:"chain-ethereum",cid:"eip155:50/slip44:60",kp:"m/44'/550'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0},
- {n:"Conflux",id:"chain-conflux",cid:"conflux:cfx/slip44:503",kp:"m/44'/60'/<span class=tok-acc>&lt;accountIdx&gt;</span>'",af:"base32",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:"2.18.3"},
- {n:"Bitcoin",id:"chain-bitcoin",cid:"bip122:000000000019d6689c085ae165831e93/slip44:0",kp:"m/44'/0'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"legacy / segwit-native",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:"1.0.0"},
- {n:"Bitcoin Cash",id:"chain-bitcoincash",cid:"bip122:000000000000000000651ef99cb9fcbe/slip44:145",kp:"m/44'/145'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"cashaddr",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:"1.5.1"},
- {n:"Litecoin",id:"chain-litecoin",cid:"bip122:12a765e31ffd4059bada1e25190f6e98/slip44:2",kp:"m/44'/2'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"legacy",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:"1.5.1"},
- {n:"Dogecoin",id:"chain-dogecoin",cid:"bip122:1a91e3dace36e2be3bf030a65679fe82/slip44:3",kp:"m/44'/3'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"legacy",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:"2.3.0"},
- {n:"Dash",id:"chain-dash",cid:"bip122:00000ffd590b1485b3caadc19b22e637/slip44:5",kp:"m/44'/5'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"legacy",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:"1.5.1"},
+ {n:"Conflux",id:"chain-conflux",cid:"conflux:cfx/slip44:503",kp:"m/44'/60'/<span class=tok-acc>&lt;accountIdx&gt;</span>'",af:"base32",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:{bio:"2.18.3",x:"1.0.0"}},
+ {n:"Bitcoin",id:"chain-bitcoin",cid:"bip122:000000000019d6689c085ae165831e93/slip44:0",kp:"m/44'/0'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"legacy / segwit-native",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:{bio:"1.0.0",x:"1.0.0"}},
+ {n:"Bitcoin Cash",id:"chain-bitcoincash",cid:"bip122:000000000000000000651ef99cb9fcbe/slip44:145",kp:"m/44'/145'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"cashaddr",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:{bio:"1.5.1",x:"1.0.0"}},
+ {n:"Litecoin",id:"chain-litecoin",cid:"bip122:12a765e31ffd4059bada1e25190f6e98/slip44:2",kp:"m/44'/2'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"legacy",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:{bio:"1.5.1",x:"1.0.0"}},
+ {n:"Dogecoin",id:"chain-dogecoin",cid:"bip122:1a91e3dace36e2be3bf030a65679fe82/slip44:3",kp:"m/44'/3'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"legacy",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:{bio:"2.3.0",x:"1.0.0"}},
+ {n:"Dash",id:"chain-dash",cid:"bip122:00000ffd590b1485b3caadc19b22e637/slip44:5",kp:"m/44'/5'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"legacy",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:{bio:"1.5.1",x:"1.0.0"}},
  {n:"eCash",id:"chain-ecash",cid:"bip122:000000000019d6689c085ae165831e93/slip44:145",kp:"m/44'/145'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"cashaddr",sT:1,sM:0,sTD:0,sD:0,sA:0},
  {n:"Zcash",id:"chain-zcash",cid:"bip122:00040fe8ec8471911baa1db1266ea15d/slip44:133",kp:"m/44'/133'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"transparent (t-addr)",sT:1,sM:0,sTD:0,sD:0,sA:0},
  {n:"Bitcoin Gold",id:"chain-bitcoingold",cid:"bip122:00000000e9fba3b4a12d04c0a48d70d5/slip44:156",kp:"m/44'/156'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"legacy",sT:1,sM:0,sTD:0,sD:0,sA:0},
  {n:"DigiByte",id:"chain-digibyte",cid:"bip122:7497ea1b465eb39f1c8f507bc877078f/slip44:20",kp:"m/44'/20'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"legacy / segwit-native",sT:1,sM:0,sTD:0,sD:0,sA:0},
  {n:"Ravencoin",id:"chain-ravencoin",cid:"bip122:0000006b444bc2f2ffe627be9d9e7e7a/slip44:175",kp:"m/44'/175'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"legacy",sT:1,sM:0,sTD:0,sD:0,sA:0},
  {n:"Horizen",id:"chain-horizen",cid:"bip122:0007104ccda289427919efc39dc9e4d4/slip44:121",kp:"m/44'/121'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"legacy",sT:0,sM:0,sTD:0,sD:0,sA:0},
- {n:"Solana",id:"chain-solana",cid:"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501",kp:"m/44'/501'/<span class=tok-acc>&lt;accountIdx&gt;</span>'",af:"—",sT:1,sM:1,sTD:0,sD:0,sA:0,fw:"2.16.5"},
- {n:"Cardano",id:"chain-cardano",cid:"cip34:1-764824073",kp:"m/44'/1815'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:1,sA:0,fw:"2.7.0"},
- {n:"Cosmos",id:"chain-cosmos",cid:"cosmos:cosmoshub-4/slip44:118",kp:"m/44'/118'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:"2.21.0"},
+ {n:"Solana",id:"chain-solana",cid:"solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501",kp:"m/44'/501'/<span class=tok-acc>&lt;accountIdx&gt;</span>'",af:"—",sT:1,sM:1,sTD:0,sD:0,sA:0,fw:{bio:"2.16.5",x:"1.0.0"}},
+ {n:"Cardano",id:"chain-cardano",cid:"cip34:1-764824073",kp:"m/44'/1815'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:1,sA:0,fw:{bio:"2.7.0",x:"1.0.0"}},
+ {n:"Cosmos",id:"chain-cosmos",cid:"cosmos:cosmoshub-4/slip44:118",kp:"m/44'/118'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:{bio:"2.21.0",x:"1.0.0"}},
  {n:"BNB Beacon Chain",id:"chain-cosmos",cid:"cosmos:Binance-Chain-Tigris/slip44:714",kp:"m/44'/714'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0},
  {n:"Coreum",id:"chain-cosmos",cid:"cosmos:coreum-mainnet-1/slip44:990",kp:"m/44'/990'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0},
  {n:"Hippo Protocol",id:"chain-cosmos",cid:"cosmos:hippo-protocol-1/slip44:118",kp:"m/44'/118'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0},
- {n:"XRP",id:"chain-xrp",cid:"xrpl:0/slip44:144",kp:"m/44'/144'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:"2.4.0"},
- {n:"Xahau",id:"chain-xahau",cid:"xahau:mainnet/slip44:144",kp:"m/44'/144'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:"2.32.0"},
- {n:"Tron",id:"chain-tron",cid:"tron:0x2b6653dc/slip44:195",kp:"m/44'/195'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:"2.3.0"},
- {n:"Stellar",id:"chain-stellar",cid:"stellar:pubnet/slip44:148",kp:"m/44'/148'/<span class=tok-acc>&lt;accountIdx&gt;</span>'",af:"—",sT:1,sM:1,sTD:0,sD:0,sA:1,fw:"2.20.0"},
- {n:"Polkadot",id:"chain-polkadot",cid:"polkadot:91b171bb158e2d3848fa23a9f1c25182/slip44:354",kp:"m/44'/354'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:"2.19.1"},
- {n:"Astar",id:"chain-polkadot",cid:"polkadot:9eb76c5184c4ab8679d2d5d819fdf90b/slip44:810",kp:"m/44'/810'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:1,sTD:0,sD:0,sA:0,fw:"2.30.0"},
- {n:"Shibuya (Astar testnet)",id:"chain-polkadot",cid:"polkadot:ddb89643205c8fe1c79afeb31f48d50f/slip44:810",kp:"m/44'/810'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:1,sTD:0,sD:0,sA:0,fw:"2.30.0"},
- {n:"Creditcoin",id:"chain-polkadot",cid:"polkadot:6673c7e2c2b7bde45a60c71ef70d9c7c/slip44:354",kp:"m/44'/354'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:1,sTD:0,sD:0,sA:0,fw:"2.30.0"},
- {n:"NEAR",id:"chain-near",cid:"near:mainnet/slip44:397",kp:"m/44'/397'/<span class=tok-acc>&lt;accountIdx&gt;</span>'",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:"2.24.0"},
- {n:"Hedera",id:"chain-hedera",cid:"hedera:mainnet/slip44:3030",kp:"m/44'/3030'/<span class=tok-acc>&lt;accountIdx&gt;</span>'",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:"2.19.3"},
- {n:"VeChain",id:"chain-vechain",cid:"vechain:b1ac3413d346d43539627e6be7ec1b4a/slip44:818",kp:"m/44'/60'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:"2.23.4"},
- {n:"Filecoin",id:"chain-filecoin",cid:"fil:f/slip44:461",kp:"m/44'/461'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:"2.33.0"},
- {n:"Tezos",id:"chain-tezos",cid:"tezos:NetXdQprcVkpaWU/slip44:1729",kp:"m/44'/1729'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0'",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:"2.24.1"},
- {n:"Stacks",id:"chain-stacks",cid:"stacks:1/slip44:5757",kp:"m/44'/5757'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:"2.14.1"},
- {n:"Algorand",id:"chain-algorand",cid:"algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k/slip44:283",kp:"m/44'/283'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:"2.29.0"},
- {n:"Constellation",id:"chain-constellation",cid:"constellation:mainnet/slip44:1137",kp:"m/44'/1137'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:"2.34.0"},
- {n:"HAVAH",id:"chain-havah",cid:"havah:mainnet/slip44:858",kp:"m/44'/858'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:"2.26.0"},
+ {n:"XRP",id:"chain-xrp",cid:"xrpl:0/slip44:144",kp:"m/44'/144'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:{bio:"2.4.0",x:"1.0.0"}},
+ {n:"Xahau",id:"chain-xahau",cid:"xahau:mainnet/slip44:144",kp:"m/44'/144'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:{bio:"2.32.0",x:"1.0.0"}},
+ {n:"Tron",id:"chain-tron",cid:"tron:0x2b6653dc/slip44:195",kp:"m/44'/195'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:{bio:"2.3.0",x:"1.0.0"}},
+ {n:"Stellar",id:"chain-stellar",cid:"stellar:pubnet/slip44:148",kp:"m/44'/148'/<span class=tok-acc>&lt;accountIdx&gt;</span>'",af:"—",sT:1,sM:1,sTD:0,sD:0,sA:1,fw:{bio:"2.20.0",x:"1.0.0"}},
+ {n:"Polkadot",id:"chain-polkadot",cid:"polkadot:91b171bb158e2d3848fa23a9f1c25182/slip44:354",kp:"m/44'/354'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:{bio:"2.19.1",x:"1.0.0"}},
+ {n:"Astar",id:"chain-polkadot",cid:"polkadot:9eb76c5184c4ab8679d2d5d819fdf90b/slip44:810",kp:"m/44'/810'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:1,sTD:0,sD:0,sA:0,fw:{bio:"2.30.0",x:"1.0.0"}},
+ {n:"Shibuya (Astar testnet)",id:"chain-polkadot",cid:"polkadot:ddb89643205c8fe1c79afeb31f48d50f/slip44:810",kp:"m/44'/810'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:1,sTD:0,sD:0,sA:0,fw:{bio:"2.30.0",x:"1.0.0"}},
+ {n:"Creditcoin",id:"chain-polkadot",cid:"polkadot:6673c7e2c2b7bde45a60c71ef70d9c7c/slip44:354",kp:"m/44'/354'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:1,sTD:0,sD:0,sA:0,fw:{bio:"2.30.0",x:"1.0.0"}},
+ {n:"NEAR",id:"chain-near",cid:"near:mainnet/slip44:397",kp:"m/44'/397'/<span class=tok-acc>&lt;accountIdx&gt;</span>'",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:{bio:"2.24.0",x:"1.0.0"}},
+ {n:"Hedera",id:"chain-hedera",cid:"hedera:mainnet/slip44:3030",kp:"m/44'/3030'/<span class=tok-acc>&lt;accountIdx&gt;</span>'",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:{bio:"2.19.3",x:"1.0.0"}},
+ {n:"VeChain",id:"chain-vechain",cid:"vechain:b1ac3413d346d43539627e6be7ec1b4a/slip44:818",kp:"m/44'/60'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:{bio:"2.23.4",x:"1.0.0"}},
+ {n:"Filecoin",id:"chain-filecoin",cid:"fil:f/slip44:461",kp:"m/44'/461'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:{bio:"2.33.0",x:"1.0.0"}},
+ {n:"Tezos",id:"chain-tezos",cid:"tezos:NetXdQprcVkpaWU/slip44:1729",kp:"m/44'/1729'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0'",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:{bio:"2.24.1",x:"1.0.0"}},
+ {n:"Stacks",id:"chain-stacks",cid:"stacks:1/slip44:5757",kp:"m/44'/5757'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:{bio:"2.14.1",x:"1.0.0"}},
+ {n:"Algorand",id:"chain-algorand",cid:"algorand:wGHE2Pwdvd7S12BL5FaOP20EGYesN73k/slip44:283",kp:"m/44'/283'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:{bio:"2.29.0",x:"1.0.0"}},
+ {n:"Constellation",id:"chain-constellation",cid:"constellation:mainnet/slip44:1137",kp:"m/44'/1137'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:{bio:"2.34.0",x:"1.0.0"}},
+ {n:"HAVAH",id:"chain-havah",cid:"havah:mainnet/slip44:858",kp:"m/44'/858'/<span class=tok-acc>&lt;accountIdx&gt;</span>'/0/0",af:"—",sT:1,sM:0,sTD:0,sD:0,sA:0,fw:{bio:"2.26.0",x:"1.0.0"}},
 ];
 DOC.register('support-matrix',{title:'Support Matrix',breadcrumb:'Support Matrix',
 search:'support matrix network method chainId addressFormat filter search signTransaction signMessage signTypedData signData signAuthEntry',html:`
@@ -1473,10 +1487,10 @@ search:'support matrix network method chainId addressFormat filter search signTr
 <div style="overflow-x:auto">
 <table class="matrix"><thead><tr>
   <th>Network</th><th>chainId</th><th>keyPath</th><th>addrFmt</th>
-  <th title="signTransaction">sTx</th><th title="signMessage">sMsg</th><th title="signTypedData">sTyped</th><th title="signData">sData</th><th title="signAuthEntry">sAuth</th><th title="minimum device firmware — model-specific">Min FW</th><th></th>
+  <th title="signTransaction">sTx</th><th title="signMessage">sMsg</th><th title="signTypedData">sTyped</th><th title="signData">sData</th><th title="signAuthEntry">sAuth</th><th title="minimum firmware — D'CENT Biometric Wallet">Min FW · D'CENT Biometric Wallet</th><th title="minimum firmware — DCENT X">Min FW · DCENT X</th><th></th>
 </tr></thead><tbody id="mx-body"></tbody></table></div>
 <p class="muted" id="mx-count" style="font-size:12.5px"></p>
-<div class="note info"><span class="ni">i</span><div>chainId values are abbreviated for width; full values are on each network page and in <code>playground/chains.json</code> (151 entries \u2014 the matrix lists mainnets and EVM testnets; 24 non-EVM testnets and Kaia Kairos live only in that file). <strong>Min FW</strong> = minimum device firmware (model-specific); <code>—</code> = not yet specified.</div></div><div class="note info"><span class="ni">i</span><div><strong>Shared family payloads:</strong> every EVM network uses the Ethereum payload (<a href="#/chain-evm-list">Supported EVM Chains</a>); all Cosmos networks use the Cosmos path (<a href="#/chain-cosmos-list">Supported Cosmos Networks</a>); Astar / Shibuya / Creditcoin use the Polkadot / Substrate path (<a href="#/chain-polkadot-list">Supported Substrate Networks</a>). Bitcoin-family coins (eCash, Zcash, Bitcoin Gold, DigiByte, Ravencoin, Horizen) each have their own page but share the UTXO signing shape.</div></div>`,
+<div class="note info"><span class="ni">i</span><div>chainId values are abbreviated for width; full values are on each network page and in <code>playground/chains.json</code> (151 entries \u2014 the matrix lists mainnets and EVM testnets; 24 non-EVM testnets and Kaia Kairos live only in that file). <strong>Min FW</strong> = minimum device firmware, listed per model — <strong>D'CENT Biometric Wallet</strong> (1.x~2.x line) and <strong>DCENT X</strong> (1.x line). The two columns are separate version lines and are <em>not</em> comparable with each other; <code>—</code> = not yet specified.</div></div><div class="note info"><span class="ni">i</span><div><strong>Shared family payloads:</strong> every EVM network uses the Ethereum payload (<a href="#/chain-evm-list">Supported EVM Chains</a>); all Cosmos networks use the Cosmos path (<a href="#/chain-cosmos-list">Supported Cosmos Networks</a>); Astar / Shibuya / Creditcoin use the Polkadot / Substrate path (<a href="#/chain-polkadot-list">Supported Substrate Networks</a>). Bitcoin-family coins (eCash, Zcash, Bitcoin Gold, DigiByte, Ravencoin, Horizen) each have their own page but share the UTXO signing shape.</div></div>`,
 mount(){
   const body=document.getElementById('mx-body');const q=document.getElementById('mx-q');const m=document.getElementById('mx-m');
   const cnt=document.getElementById('mx-count');
@@ -1495,7 +1509,7 @@ mount(){
       <td><a href="#/${r.id}">${r.n}</a></td>
       <td><code>${r.cid}</code></td><td><code>${r.kp}</code></td><td>${r.af}</td>
       <td>${yn(r.sT)}</td><td>${yn(r.sM)}</td><td>${yn(r.sTD)}</td><td>${yn(r.sD)}</td><td>${yn(r.sA)}</td>
-      <td class="m-fw">${r.fw||'—'}</td>
+      <td class="m-fw">${(r.fw&&r.fw.bio)||'—'}</td><td class="m-fw">${(r.fw&&r.fw.x)||'—'}</td>
       <td class="m-link"><a href="#/${r.id}">View →</a></td></tr>`).join('');
     cnt.textContent=rows.length+' of '+ALL.length+' networks ('+(window.EVMCHAINS||[]).length+' EVM networks + '+(MATRIX.length-1)+' other networks)';
   }
@@ -2127,9 +2141,9 @@ search:'getPublicKey publicKey payment stake drep cardano governance keyPath acc
 <p class="lede">Retrieves account public keys for <strong>any supported chain</strong>. Most chains return a single <code>{ keyPath, publicKey }</code> for the path you asked for; <strong>Cardano</strong> returns its <code>payment</code>, <code>stake</code> and <code>drep</code> (governance) keys as a bundle in one call. This verb was split out of <code>getAddress</code>, which no longer returns any public key: <code>getAddress</code> now returns the address plus a <code>rewardAddress</code> (stake address — Cardano only).</p>
 <div class="note info"><span class="ni">i</span><div>D'CENT's Cardano derives on <strong>purpose 44'</strong> (<code>m/44'/1815'/…</code>), matching its getAddress path — <em>not</em> CIP-1852 <code>1852'</code>. The <code>1852'</code> purpose is reserved for future / external CIP-1852 key paths a dApp may pass explicitly.</div></div><div class="note delta"><span class="ni">◆</span><div><strong>All families are supported.</strong> The response is a union of two shapes — <strong>Cardano</strong> returns the <code>{ payment, stake, drep }</code> role bundle, every other family returns a single <code>{ keyPath, publicKey }</code>. Branch on the <code>chainId</code> you passed in. <em>Previously this verb was Cardano-only and other chains returned <code>method_not_found</code> (-32601); that is no longer the case.</em></div></div>
 <h2>Requirements</h2>
-<p>Minimum <strong>D'CENT Biometric Wallet</strong> firmware for each method. Below this the request returns the firmware-update error (<code>5005</code>) and the bridge prompts to update.</p>
-<div style="overflow-x:auto"><table class="params"><thead><tr><th>Method</th><th>Min firmware</th></tr></thead><tbody>
-<tr><td><code>getPublicKey</code></td><td><code>2.35.0</code> or higher <span class="muted">— every chain, including Cardano</span></td></tr>
+<p>Minimum firmware for each method. The two models are on different version lines, so <strong>D'CENT Biometric Wallet</strong> and <strong>DCENT X</strong> are listed separately (the numbers are not comparable across models). Below this the request returns the firmware-update error (<code>5005</code>) and the bridge prompts to update.</p>
+<div style="overflow-x:auto"><table class="params"><thead><tr><th>Method</th><th>D'CENT Biometric Wallet</th><th>DCENT X</th></tr></thead><tbody>
+<tr><td><code>getPublicKey</code></td><td><code>2.35.0</code> or higher <span class="muted">— every chain, including Cardano</span></td><td><code>1.0.0</code> or higher</td></tr>
 </tbody></table></div>
 <h2 id="getpublickey-params">Parameters</h2>
 <table class="params"><thead><tr><th>Field</th><th>Type</th><th>Required</th><th>Source</th><th>Description</th></tr></thead><tbody>
@@ -2182,9 +2196,9 @@ ko:`
 <p class="lede"><strong>모든 지원 체인</strong>의 계정 공개키를 조회합니다. 대부분의 체인은 요청한 경로의 <code>{ keyPath, publicKey }</code> 하나를 반환하고, <strong>Cardano</strong>만 <code>payment</code>·<code>stake</code>·<code>drep</code>(거버넌스) 키를 번들로 한 번에 반환합니다. 이 verb는 <code>getAddress</code>에서 분리되었으며, <code>getAddress</code>는 더 이상 공개키를 반환하지 않습니다(주소 + <code>rewardAddress</code>(stake 주소, Cardano 전용) 반환).</p>
 <div class="note info"><span class="ni">i</span><div>D'CENT의 Cardano는 getAddress와 동일하게 <strong>purpose 44'</strong>(<code>m/44'/1815'/…</code>)로 파생합니다 — CIP-1852의 <code>1852'</code>가 <em>아닙니다</em>. <code>1852'</code> purpose는 향후/외부 CIP-1852 keyPath(앱이 명시적으로 전달)를 위해 예약되어 있습니다.</div></div><div class="note delta"><span class="ni">◆</span><div><strong>모든 family를 지원합니다.</strong> 응답은 두 shape의 union입니다 — <strong>Cardano</strong>는 <code>{ payment, stake, drep }</code> role 번들, <strong>그 외 전 family</strong>는 단일 <code>{ keyPath, publicKey }</code>. 호출 시 넘긴 <code>chainId</code>로 분기하세요. <em>이전에는 Cardano 전용이었고 다른 체인은 <code>method_not_found</code>(-32601)을 반환했으나, 더 이상 그렇지 않습니다.</em></div></div>
 <h2>요구사항</h2>
-<p>메서드별 최소 <strong>D'CENT Biometric Wallet</strong> 펌웨어 버전입니다. 미달 시 펌웨어 업데이트 에러(<code>5005</code>)를 반환하고 브리지가 업데이트를 안내합니다.</p>
-<div style="overflow-x:auto"><table class="params"><thead><tr><th>메서드</th><th>최소 펌웨어</th></tr></thead><tbody>
-<tr><td><code>getPublicKey</code></td><td><code>2.35.0</code> 이상 <span class="muted">— Cardano 포함 전 체인</span></td></tr>
+<p>메서드별 최소 펌웨어 버전입니다. 모델마다 버전 라인이 달라 <strong>D'CENT Biometric Wallet</strong>과 <strong>DCENT X</strong>를 각각 표기합니다(서로 비교하는 값이 아닙니다). 미달 시 펌웨어 업데이트 에러(<code>5005</code>)를 반환하고 브리지가 업데이트를 안내합니다.</p>
+<div style="overflow-x:auto"><table class="params"><thead><tr><th>메서드</th><th>D'CENT Biometric Wallet</th><th>DCENT X</th></tr></thead><tbody>
+<tr><td><code>getPublicKey</code></td><td><code>2.35.0</code> 이상 <span class="muted">— Cardano 포함 전 체인</span></td><td><code>1.0.0</code> 이상</td></tr>
 </tbody></table></div>
 <h2 id="getpublickey-params">파라미터</h2>
 <table class="params"><thead><tr><th>Field</th><th>Type</th><th>Required</th><th>Source</th><th>설명</th></tr></thead><tbody>
@@ -2656,10 +2670,10 @@ await dcent.getAddress(coinType, path, prefix?)</pre></div>
 <div style="overflow-x:auto">
 <table class="matrix"><thead><tr>
   <th>네트워크</th><th>chainId</th><th>keyPath</th><th>주소형식</th>
-  <th title="signTransaction">sTx</th><th title="signMessage">sMsg</th><th title="signTypedData">sTyped</th><th title="signData">sData</th><th title="signAuthEntry">sAuth</th><th title="minimum device firmware — model-specific">Min FW</th><th></th>
+  <th title="signTransaction">sTx</th><th title="signMessage">sMsg</th><th title="signTypedData">sTyped</th><th title="signData">sData</th><th title="signAuthEntry">sAuth</th><th title="최소 펌웨어 — D'CENT Biometric Wallet">Min FW · D'CENT Biometric Wallet</th><th title="최소 펌웨어 — DCENT X">Min FW · DCENT X</th><th></th>
 </tr></thead><tbody id="mx-body"></tbody></table></div>
 <p class="muted" id="mx-count" style="font-size:12.5px"></p>
-<div class="note info"><span class="ni">i</span><div>chainId 값은 폭 때문에 축약되어 있습니다. 전체 값은 각 네트워크 페이지와 <code>playground/chains.json</code>(151개)에 있습니다. <strong>Min FW</strong> = 최소 기기 펌웨어(모델별); <code>—</code> = 미지정.</div></div><div class="note info"><span class="ni">i</span><div><strong>공유 family payload:</strong> 모든 EVM 네트워크는 Ethereum payload(<a href="#/chain-evm-list">지원 EVM 체인</a>)를, 모든 Cosmos 네트워크는 Cosmos 경로(<a href="#/chain-cosmos-list">지원 Cosmos 네트워크</a>)를, Astar / Shibuya / Creditcoin은 Polkadot / Substrate 경로(<a href="#/chain-polkadot-list">지원 Substrate 네트워크</a>)를 사용합니다. Bitcoin 계열 코인(eCash, Zcash, Bitcoin Gold, DigiByte, Ravencoin, Horizen)은 각각 자체 페이지를 가지며 UTXO 서명 shape을 공유합니다.</div></div>`},
+<div class="note info"><span class="ni">i</span><div>chainId 값은 폭 때문에 축약되어 있습니다. 전체 값은 각 네트워크 페이지와 <code>playground/chains.json</code>(151개)에 있습니다. <strong>Min FW</strong> = 최소 기기 펌웨어이며 모델별로 나눠 표기합니다 — <strong>D'CENT Biometric Wallet</strong>(1.x~2.x 라인), <strong>DCENT X</strong>(1.x 라인). 두 컬럼은 서로 다른 버전 라인이라 <em>서로 비교하는 값이 아닙니다</em>. <code>—</code> = 미지정.</div></div><div class="note info"><span class="ni">i</span><div><strong>공유 family payload:</strong> 모든 EVM 네트워크는 Ethereum payload(<a href="#/chain-evm-list">지원 EVM 체인</a>)를, 모든 Cosmos 네트워크는 Cosmos 경로(<a href="#/chain-cosmos-list">지원 Cosmos 네트워크</a>)를, Astar / Shibuya / Creditcoin은 Polkadot / Substrate 경로(<a href="#/chain-polkadot-list">지원 Substrate 네트워크</a>)를 사용합니다. Bitcoin 계열 코인(eCash, Zcash, Bitcoin Gold, DigiByte, Ravencoin, Horizen)은 각각 자체 페이지를 가지며 UTXO 서명 shape을 공유합니다.</div></div>`},
 });
 </script>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -2935,7 +2935,7 @@ search:'getDeviceInfo device id firmware label connectType fingerprint coin_list
 <tr><td><code>coin_list</code></td><td class="type">{ name }[]?</td><td>Installed coin apps</td></tr>
 <tr><td><code>fingerprint</code></td><td class="type">{ max, enrolled }?</td><td>Biometric slots</td></tr>
 <tr><td><code>isAttached</code></td><td class="type">boolean?</td><td>Whether a device is attached</td></tr>
-<tr><td><code>deviceModel</code></td><td class="type">string?</td><td>Connected hardware model — <code>'DCENT-X'</code> for DCENT X, <code>undefined</code> for a D'CENT Biometric Wallet or a bridge that does not report the model. <strong>⚠️ Currently always <code>undefined</code></strong> — the bridge does not populate this field yet.</td></tr>
+<tr><td><code>deviceModel</code></td><td class="type">string?</td><td>Connected hardware model — <code>'DCENT-X'</code> for a DCENT X; <code>undefined</code> for a D'CENT Biometric Wallet or a bridge that does not report the model.</td></tr>
 </tbody></table>
 <h2>Request / Response</h2>
 <div class="io-pair"><div class="io-label">Request</div>
@@ -2945,7 +2945,7 @@ const label = res.body.parameter?.label      // typed access</pre></div>
 <div class="io-label">Response</div>
 <div class="code"><div class="cb-head"><span>json</span><button class="copy">Copy</button></div>
 <pre>{\n  \"header\": {\n    \"version\": \"1.0\",\n    \"status\": \"success\"\n  },\n  \"body\": {\n    \"command\": \"getDeviceInfo\",\n    \"parameter\": {\n      \"deviceId\": \"…\",\n      \"version\": \"2.x.x\",\n      \"ksm_version\": \"1.x.x\",\n      \"label\": \"My D'CENT\",\n      \"connectType\": \"usb\",\n      \"coin_list\": [\n        {\n          \"name\": \"ETHEREUM\"\n        }\n      ],\n      \"fingerprint\": {\n        \"max\": 10,\n        \"enrolled\": 2\n      }\n    }\n  }\n}</pre></div></div>
-<div class="note info"><span class="ni">i</span><div><code>deviceModel</code> is absent from this example on purpose — the bridge does not populate it yet, so it is <strong>always <code>undefined</code></strong> today. When a DCENT X reports its model the field arrives as <code>"deviceModel": "DCENT-X"</code>.</div></div><div class="note tip"><span class="ni">✓</span><div>Cache the result — device info rarely changes within a session.</div></div>
+<div class="note info"><span class="ni">i</span><div>This example is a <strong>D'CENT Biometric Wallet</strong>, which does not report a model — so <code>deviceModel</code> is absent. A <strong>DCENT X</strong> returns <code>"deviceModel": "DCENT-X"</code> in the same object.</div></div><div class="note tip"><span class="ni">✓</span><div>Cache the result — device info rarely changes within a session.</div></div>
 <div class="related"><a href="#/info">→ info</a><a href="#/set-label">→ setLabel</a><a href="#/v1response">→ V1Response</a></div>`});
 
 DOC.register('info',{title:'info',breadcrumb:'<span>Core API</span> / Device API / info',
@@ -3276,7 +3276,7 @@ Object.assign(window.KO, {
 <tr><td><code>coin_list</code></td><td class="type">{ name }[]?</td><td>설치된 코인 앱</td></tr>
 <tr><td><code>fingerprint</code></td><td class="type">{ max, enrolled }?</td><td>생체 슬롯</td></tr>
 <tr><td><code>isAttached</code></td><td class="type">boolean?</td><td>기기 부착 여부</td></tr>
-<tr><td><code>deviceModel</code></td><td class="type">string?</td><td>연결된 하드웨어 모델 — DCENT X는 <code>'DCENT-X'</code>, D'CENT Biometric Wallet 또는 모델을 보고하지 않는 브리지는 <code>undefined</code>. <strong>⚠️ 현재는 항상 <code>undefined</code></strong>입니다 — 브리지가 아직 이 값을 채우지 않습니다.</td></tr>
+<tr><td><code>deviceModel</code></td><td class="type">string?</td><td>연결된 하드웨어 모델 — DCENT X는 <code>'DCENT-X'</code>, D'CENT Biometric Wallet 또는 모델을 보고하지 않는 브리지는 <code>undefined</code>.</td></tr>
 </tbody></table>
 <h2>요청 / 응답</h2>
 <div class="io-pair"><div class="io-label">요청</div>
@@ -3286,7 +3286,7 @@ const label = res.body.parameter?.label      // typed 접근</pre></div>
 <div class="io-label">응답</div>
 <div class="code"><div class="cb-head"><span>json</span><button class="copy">복사</button></div>
 <pre>{\n  \"header\": {\n    \"version\": \"1.0\",\n    \"status\": \"success\"\n  },\n  \"body\": {\n    \"command\": \"getDeviceInfo\",\n    \"parameter\": {\n      \"deviceId\": \"…\",\n      \"version\": \"2.x.x\",\n      \"ksm_version\": \"1.x.x\",\n      \"label\": \"My D'CENT\",\n      \"connectType\": \"usb\",\n      \"coin_list\": [\n        {\n          \"name\": \"ETHEREUM\"\n        }\n      ],\n      \"fingerprint\": {\n        \"max\": 10,\n        \"enrolled\": 2\n      }\n    }\n  }\n}</pre></div></div>
-<div class="note info"><span class="ni">i</span><div>이 예제에 <code>deviceModel</code>이 없는 것은 의도적입니다 — 브리지가 아직 이 값을 채우지 않아 <strong>현재는 항상 <code>undefined</code></strong>입니다. DCENT X가 모델을 보고하면 <code>"deviceModel": "DCENT-X"</code>로 전달됩니다.</div></div><div class="note tip"><span class="ni">✓</span><div>결과를 캐시하세요 — 세션 내 기기 정보는 거의 바뀌지 않습니다.</div></div>
+<div class="note info"><span class="ni">i</span><div>이 예제는 모델을 보고하지 않는 <strong>D'CENT Biometric Wallet</strong>이라 <code>deviceModel</code>이 없습니다. <strong>DCENT X</strong>는 같은 객체에 <code>"deviceModel": "DCENT-X"</code>를 담아 반환합니다.</div></div><div class="note tip"><span class="ni">✓</span><div>결과를 캐시하세요 — 세션 내 기기 정보는 거의 바뀌지 않습니다.</div></div>
 <div class="related"><a href="#/info">→ info</a><a href="#/set-label">→ setLabel</a><a href="#/v1response">→ V1Response</a></div>`},
 
 'info':{bcko:'<span>Core API</span> / Device API / info',ko:`

--- a/docs/index.html
+++ b/docs/index.html
@@ -2935,6 +2935,7 @@ search:'getDeviceInfo device id firmware label connectType fingerprint coin_list
 <tr><td><code>coin_list</code></td><td class="type">{ name }[]?</td><td>Installed coin apps</td></tr>
 <tr><td><code>fingerprint</code></td><td class="type">{ max, enrolled }?</td><td>Biometric slots</td></tr>
 <tr><td><code>isAttached</code></td><td class="type">boolean?</td><td>Whether a device is attached</td></tr>
+<tr><td><code>deviceModel</code></td><td class="type">string?</td><td>Connected hardware model — <code>'DCENT-X'</code> for DCENT X, <code>undefined</code> for a D'CENT Biometric Wallet or a bridge that does not report the model. <strong>⚠️ Currently always <code>undefined</code></strong> — the bridge does not populate this field yet.</td></tr>
 </tbody></table>
 <h2>Request / Response</h2>
 <div class="io-pair"><div class="io-label">Request</div>
@@ -2944,7 +2945,7 @@ const label = res.body.parameter?.label      // typed access</pre></div>
 <div class="io-label">Response</div>
 <div class="code"><div class="cb-head"><span>json</span><button class="copy">Copy</button></div>
 <pre>{\n  \"header\": {\n    \"version\": \"1.0\",\n    \"status\": \"success\"\n  },\n  \"body\": {\n    \"command\": \"getDeviceInfo\",\n    \"parameter\": {\n      \"deviceId\": \"…\",\n      \"version\": \"2.x.x\",\n      \"ksm_version\": \"1.x.x\",\n      \"label\": \"My D'CENT\",\n      \"connectType\": \"usb\",\n      \"coin_list\": [\n        {\n          \"name\": \"ETHEREUM\"\n        }\n      ],\n      \"fingerprint\": {\n        \"max\": 10,\n        \"enrolled\": 2\n      }\n    }\n  }\n}</pre></div></div>
-<div class="note tip"><span class="ni">✓</span><div>Cache the result — device info rarely changes within a session.</div></div>
+<div class="note info"><span class="ni">i</span><div><code>deviceModel</code> is absent from this example on purpose — the bridge does not populate it yet, so it is <strong>always <code>undefined</code></strong> today. When a DCENT X reports its model the field arrives as <code>"deviceModel": "DCENT-X"</code>.</div></div><div class="note tip"><span class="ni">✓</span><div>Cache the result — device info rarely changes within a session.</div></div>
 <div class="related"><a href="#/info">→ info</a><a href="#/set-label">→ setLabel</a><a href="#/v1response">→ V1Response</a></div>`});
 
 DOC.register('info',{title:'info',breadcrumb:'<span>Core API</span> / Device API / info',
@@ -3275,6 +3276,7 @@ Object.assign(window.KO, {
 <tr><td><code>coin_list</code></td><td class="type">{ name }[]?</td><td>설치된 코인 앱</td></tr>
 <tr><td><code>fingerprint</code></td><td class="type">{ max, enrolled }?</td><td>생체 슬롯</td></tr>
 <tr><td><code>isAttached</code></td><td class="type">boolean?</td><td>기기 부착 여부</td></tr>
+<tr><td><code>deviceModel</code></td><td class="type">string?</td><td>연결된 하드웨어 모델 — DCENT X는 <code>'DCENT-X'</code>, D'CENT Biometric Wallet 또는 모델을 보고하지 않는 브리지는 <code>undefined</code>. <strong>⚠️ 현재는 항상 <code>undefined</code></strong>입니다 — 브리지가 아직 이 값을 채우지 않습니다.</td></tr>
 </tbody></table>
 <h2>요청 / 응답</h2>
 <div class="io-pair"><div class="io-label">요청</div>
@@ -3284,7 +3286,7 @@ const label = res.body.parameter?.label      // typed 접근</pre></div>
 <div class="io-label">응답</div>
 <div class="code"><div class="cb-head"><span>json</span><button class="copy">복사</button></div>
 <pre>{\n  \"header\": {\n    \"version\": \"1.0\",\n    \"status\": \"success\"\n  },\n  \"body\": {\n    \"command\": \"getDeviceInfo\",\n    \"parameter\": {\n      \"deviceId\": \"…\",\n      \"version\": \"2.x.x\",\n      \"ksm_version\": \"1.x.x\",\n      \"label\": \"My D'CENT\",\n      \"connectType\": \"usb\",\n      \"coin_list\": [\n        {\n          \"name\": \"ETHEREUM\"\n        }\n      ],\n      \"fingerprint\": {\n        \"max\": 10,\n        \"enrolled\": 2\n      }\n    }\n  }\n}</pre></div></div>
-<div class="note tip"><span class="ni">✓</span><div>결과를 캐시하세요 — 세션 내 기기 정보는 거의 바뀌지 않습니다.</div></div>
+<div class="note info"><span class="ni">i</span><div>이 예제에 <code>deviceModel</code>이 없는 것은 의도적입니다 — 브리지가 아직 이 값을 채우지 않아 <strong>현재는 항상 <code>undefined</code></strong>입니다. DCENT X가 모델을 보고하면 <code>"deviceModel": "DCENT-X"</code>로 전달됩니다.</div></div><div class="note tip"><span class="ni">✓</span><div>결과를 캐시하세요 — 세션 내 기기 정보는 거의 바뀌지 않습니다.</div></div>
 <div class="related"><a href="#/info">→ info</a><a href="#/set-label">→ setLabel</a><a href="#/v1response">→ V1Response</a></div>`},
 
 'info':{bcko:'<span>Core API</span> / Device API / info',ko:`

--- a/docs/index.html
+++ b/docs/index.html
@@ -2916,7 +2916,7 @@ search:'core api overview connection device account sign methods',html:`
 <div class="related"><a href="#/set-transport">→ setTransport</a><a href="#/get-address">→ getAddress</a><a href="#/sign">→ sign()</a></div>`});
 
 DOC.register('get-device-info',{title:'getDeviceInfo',breadcrumb:'<span>Core API</span> / Device API / getDeviceInfo',
-search:'getDeviceInfo device id firmware label connectType fingerprint coin_list DeviceInfoPayload',html:`
+search:'getDeviceInfo device id firmware label connectType fingerprint coin_list DeviceInfoPayload deviceModel DCENT-X DCENT X hardware model 기기 모델',html:`
 <h1 class="pt">getDeviceInfo</h1>
 <p class="lede">Retrieves information about the connected D'CENT hardware wallet — device id, firmware version, label, and active transport. Returns a typed <code>V1Response&lt;DeviceInfoPayload&gt;</code>, so fields like <code>parameter.label</code> are directly accessible.</p>
 <h2>Summary</h2>

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "check:payload-contract": "node scripts/check-payload-contract-coverage.mjs",
     "check:payload-shape": "node scripts/check-payload-contract-shape.mjs",
     "check:index-refs": "node scripts/check-index-html-preset-refs.mjs",
-    "check:docs": "yarn lint:md && yarn check:payload-contract && yarn check:payload-shape && yarn check:index-refs && yarn check:index-dup && yarn check:index-pages",
+    "check:docs": "yarn lint:md && yarn check:payload-contract && yarn check:payload-shape && yarn check:index-refs && yarn check:index-dup && yarn check:index-pages && yarn check:index-fw-models",
+    "check:index-fw-models": "node scripts/check-index-html-fw-models.mjs",
     "check:index-dup": "node scripts/check-index-html-duplicate-keys.mjs",
     "tsc": "tsc --noEmit",
     "check:index-pages": "node scripts/check-index-html-page-refs.mjs"

--- a/scripts/check-index-html-fw-models.mjs
+++ b/scripts/check-index-html-fw-models.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+/**
+ * docs/index.html 의 **펌웨어 표 모델 축(bio / x) 전수 검사** (m09-04-28).
+ *
+ * 왜 필요한가 — DCENT X 는 펌웨어 `1.x` 라인이고 D'CENT Biometric Wallet 은 `1.x~2.x` 라인이다.
+ * 두 값을 **한 컬럼**에 합치면 X 사용자에게 "내 펌웨어 1.0.0 < 2.35.0 → 미지원"으로 읽혀,
+ * 실제로는 지원되는 기능을 안 쓰게 된다. 그래서 표의 값은 `{bio, x}` **두 키가 항상 함께**여야 하고,
+ * 한쪽만 채운 상태는 사람 눈에 안 띈다(120셀 + 27행 규모). 이 게이트가 그 누락을 대신 본다.
+ *
+ * 🔴 정적 grep 이 아니라 **문서를 실제로 실행**해서(jsdom) `window.FWREQ` / `window.MATRIX` 를 읽는다 —
+ *    MATRIX 값에는 `<span class=tok-acc>` HTML 이 섞여 있어 정규식 절단이 취약하다.
+ *    형제 선례: `check-index-html-page-refs.mjs`(문서 실행 후 `window.PAGES` 읽기).
+ *
+ * objective m09-04-28 테스트 항목 매핑:
+ *   T-DOC-MODEL-01 → (a) FWREQ 전수      T-DOC-MODEL-02 → (b) MATRIX(fw 보유 행)
+ *   T-DOC-MODEL-03 → (c)/(d) EN·KO 4블록 + Min FW 헤더 2개
+ *   T-DOC-MODEL-04 → 뮤테이션 검출(이 스크립트를 대상으로 objective §8 3번 명령이 수행)
+ *   T-DOC-SYNC-01  → `yarn check:docs` 체인에 배선됨
+ *
+ * 검사 4종:
+ *   (a) FWREQ — 전 체인 × 전 메서드 행의 값이 `{bio, x}` 두 키를 non-empty 로 보유
+ *   (b) MATRIX — **`fw` 키가 있는 행만** 대상. `fw` 부재 행은 지금도 `—` 로 렌더되므로 skip
+ *       (전 행에 `fw` 를 강제하면 현재 통과 중인 행이 곧바로 실패한다)
+ *   (c) 하드코딩 Requirements/요구사항 블록 — EN/KO **각각** 두 모델 이름을 모두 포함
+ *       (EN 만 고치고 KO 를 빠뜨린 상태를 잡는 것이 이 검사의 목적 — 실사고 선례가 있다)
+ *   (d) Support Matrix 표 헤더 — EN/KO 각각 모델별 `Min FW` 컬럼 2개 보유
+ */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { JSDOM, VirtualConsole } from 'jsdom'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const INDEX = resolve(here, '../docs/index.html')
+
+/** 모델 라벨 — 문서 전체에서 이 표기를 정본으로 쓴다 (dcentx-model-id-naming 과 짝). */
+const BIO = "D'CENT Biometric Wallet"
+const X = 'DCENT X'
+
+const html = readFileSync(INDEX, 'utf8')
+
+// jsdom 미구현 브라우저 API(`window.scrollTo` 등)만 삼킨다. 삼킨 탓에 데이터가 비면
+// 아래 fail-closed 가드가 잡는다 — "조용히 아무것도 검사 안 함"을 만들지 않는다.
+const virtualConsole = new VirtualConsole()
+virtualConsole.on('jsdomError', () => {})
+
+const dom = new JSDOM(html, {
+  runScripts: 'dangerously',
+  pretendToBeVisual: true,
+  url: 'https://example.org/',
+  virtualConsole,
+})
+const w = dom.window
+await new Promise((r) => setTimeout(r, 300))
+
+const failures = []
+
+/** `{bio, x}` 두 키가 non-empty string 인지. 위반 사유 문자열, 정상이면 null. */
+function badModelPair(v) {
+  if (v === null || typeof v !== 'object' || Array.isArray(v)) return `모델 객체가 아님 (${JSON.stringify(v)})`
+  const missing = ['bio', 'x'].filter((k) => typeof v[k] !== 'string' || v[k].trim() === '')
+  return missing.length > 0 ? `${missing.join(' / ')} 키 누락 또는 빈 값 (${JSON.stringify(v)})` : null
+}
+
+// ── (a) FWREQ ────────────────────────────────────────────────────────────────
+const fwreq = w.FWREQ
+let fwreqCells = 0
+if (fwreq === null || typeof fwreq !== 'object' || Object.keys(fwreq).length === 0) {
+  failures.push('window.FWREQ 가 비어 있다 — 문서 스크립트 실행 실패로 검사가 성립하지 않는다.')
+} else {
+  for (const [chainId, rows] of Object.entries(fwreq)) {
+    if (!Array.isArray(rows) || rows.length === 0) {
+      failures.push(`FWREQ["${chainId}"] 가 비어 있다`)
+      continue
+    }
+    for (const row of rows) {
+      const method = Array.isArray(row) ? row[0] : '(unknown)'
+      const bad = Array.isArray(row) ? badModelPair(row[1]) : '행이 배열이 아님'
+      if (bad) failures.push(`FWREQ["${chainId}"] ${method}: ${bad}`)
+      else fwreqCells += 1
+    }
+  }
+}
+
+// ── (b) MATRIX (fw 보유 행만) ────────────────────────────────────────────────
+const matrix = w.MATRIX
+let matrixChecked = 0
+let matrixSkipped = 0
+if (!Array.isArray(matrix) || matrix.length === 0) {
+  failures.push('window.MATRIX 가 비어 있다 — 문서 스크립트 실행 실패로 검사가 성립하지 않는다.')
+} else {
+  for (const row of matrix) {
+    if (row?.fw === undefined) {
+      matrixSkipped += 1 // 지금도 `—` 로 렌더된다 — 2컬럼 전환 대상이 아니다
+      continue
+    }
+    const bad = badModelPair(row.fw)
+    if (bad) failures.push(`MATRIX "${row?.n ?? row?.id ?? '(unnamed)'}" fw: ${bad}`)
+    else matrixChecked += 1
+  }
+}
+
+// ── (c) 하드코딩 Requirements / 요구사항 블록 (EN·KO 각각) ────────────────────
+const pages = w.PAGES ?? {}
+const reqBlocks = []
+for (const [id, page] of Object.entries(pages)) {
+  for (const field of ['html', 'ko']) {
+    const src = page?.[field]
+    if (typeof src !== 'string') continue
+    const re = /<h2[^>]*>(?:Requirements|요구사항)<\/h2>/g
+    let m
+    while ((m = re.exec(src)) !== null) {
+      const start = m.index
+      const nextH2 = src.indexOf('<h2', start + m[0].length)
+      reqBlocks.push({ id, field, body: src.slice(start, nextH2 === -1 ? src.length : nextH2) })
+    }
+  }
+}
+// fail-closed — 블록을 하나도 못 찾으면 "위반 0건"이 공허하게 통과한다.
+if (reqBlocks.length < 4) {
+  failures.push(
+    `하드코딩 Requirements 블록을 ${reqBlocks.length}개만 찾았다 (기대 4개 이상: overview EN/KO + get-publickey EN/KO). ` +
+      '블록이 사라졌거나 마크업이 바뀌었다면 이 검사를 먼저 갱신할 것.',
+  )
+}
+for (const field of ['html', 'ko']) {
+  if (!reqBlocks.some((b) => b.field === field)) {
+    failures.push(`${field === 'ko' ? 'KO' : 'EN'} 쪽 Requirements 블록이 하나도 없다 — 한쪽 언어가 통째로 빠졌다.`)
+  }
+}
+/** 한 조각(표 헤더 / 카드)이 한 모델만 말하고 있으면 위반. 둘 다 없으면 비대상(무관 조각). */
+function missingModelLabels(fragment) {
+  const has = { [BIO]: fragment.includes(BIO), [X]: fragment.includes(X) }
+  if (!has[BIO] && !has[X]) return null
+  return [BIO, X].filter((label) => !has[label])
+}
+
+for (const b of reqBlocks) {
+  // 블록 전체에 두 모델이 다 있어야 한다 (통째로 단일 모델로 되돌린 상태를 잡는다)
+  const missing = [BIO, X].filter((label) => !b.body.includes(label))
+  if (missing.length > 0) {
+    failures.push(`Requirements 블록 [${b.id}.${b.field}] 에 모델 표기 누락: ${missing.join(' / ')}`)
+  }
+
+  // 🔴 블록 전체 containment 만으로는 부족하다 — 표 헤더에서 X 컬럼만 지워도 lead 문단에 이름이
+  //    남아 블록 단위로는 통과한다. 그래서 **조각 단위**로 "한쪽만 말하는 상태"를 금지한다.
+  for (const [, thead] of b.body.matchAll(/<thead>([\s\S]*?)<\/thead>/g)) {
+    const m = missingModelLabels(thead)
+    if (m === null) {
+      failures.push(`Requirements 표 헤더 [${b.id}.${b.field}] 에 모델 컬럼이 없다 — 2모델 표가 아니다.`)
+    } else if (m.length > 0) {
+      failures.push(`Requirements 표 헤더 [${b.id}.${b.field}] 에 모델 컬럼 누락: ${m.join(' / ')}`)
+    }
+  }
+  for (const [, card] of b.body.matchAll(/<div class="rq">([\s\S]*?)(?=<div class="rq">|<\/div>\s*$)/g)) {
+    const m = missingModelLabels(card)
+    if (m !== null && m.length > 0) {
+      failures.push(`Requirements 카드 [${b.id}.${b.field}] 가 한 모델만 언급한다 — 누락: ${m.join(' / ')}`)
+    }
+  }
+}
+
+// ── (d) Support Matrix 헤더 (EN·KO 각각 모델별 Min FW 컬럼) ──────────────────
+const matrixHeaders = []
+for (const [id, page] of Object.entries(pages)) {
+  for (const field of ['html', 'ko']) {
+    const src = page?.[field]
+    // `table class="matrix"` 는 EVM/Cosmos/Substrate 목록 표도 쓴다 — 그쪽엔 펌웨어 컬럼이 없다.
+    // 대상은 **`Min FW` 컬럼을 가진 표**(Support Matrix EN/KO)뿐이다.
+    if (typeof src !== 'string' || !src.includes('table class="matrix"') || !src.includes('Min FW')) continue
+    matrixHeaders.push({ id, field, src })
+  }
+}
+if (matrixHeaders.length < 2) {
+  failures.push(
+    `Support Matrix 표를 ${matrixHeaders.length}개만 찾았다 (기대 2개 이상: EN/KO). 마크업이 바뀌었다면 이 검사를 먼저 갱신할 것.`,
+  )
+}
+for (const h of matrixHeaders) {
+  const missing = [`Min FW · ${BIO}`, `Min FW · ${X}`].filter((label) => !h.src.includes(label))
+  if (missing.length > 0) {
+    failures.push(`Support Matrix 헤더 [${h.id}.${h.field}] 에 모델 컬럼 누락: ${missing.join(' / ')}`)
+  }
+}
+
+if (failures.length > 0) {
+  console.error('✗ docs/index.html 펌웨어 표 모델 축(bio/x) 검사 실패')
+  for (const f of failures) console.error(`  - ${f}`)
+  process.exit(1)
+}
+
+console.log(
+  `✓ docs/index.html 펌웨어 모델 축 — FWREQ ${fwreqCells}행(체인 ${Object.keys(fwreq).length}) · ` +
+    `MATRIX ${matrixChecked}행 검사 / ${matrixSkipped}행 skip(fw 미지정) · ` +
+    `Requirements 블록 ${reqBlocks.length} · Support Matrix 헤더 ${matrixHeaders.length}`,
+)

--- a/scripts/check-index-html-fw-models.mjs
+++ b/scripts/check-index-html-fw-models.mjs
@@ -17,13 +17,30 @@
  *   T-DOC-MODEL-04 → 뮤테이션 검출(이 스크립트를 대상으로 objective §8 3번 명령이 수행)
  *   T-DOC-SYNC-01  → `yarn check:docs` 체인에 배선됨
  *
- * 검사 4종:
+ * 🔴 그리고 "찾은 것의 모양"만 보지 않는다 — **모수(母數)에 floor** 를 건다. 모양만 보면
+ *    "보호 대상을 지우면 초록"이 성립하고(체인 삭제 / `fw` 키 삭제 / `<thead>` 통째 삭제),
+ *    그게 빨간 게이트를 만난 사람이 실제로 택하는 경로다. 크로스 리뷰 R1 에서 이 클래스로
+ *    6종의 뮤테이션이 전부 통과했다(M11~M16).
+ *
+ * objective m09-04-28 테스트 항목 매핑:
+ *   T-DOC-MODEL-01 → (a) FWREQ 전수      T-DOC-MODEL-02 → (b) MATRIX(fw 보유 행)
+ *   T-DOC-MODEL-03 → (c)/(d)/(e) EN·KO 4블록 + Min FW 헤더 2개 + 동적 렌더러
+ *   T-DOC-MODEL-04 → 뮤테이션 검출(이 스크립트를 대상으로 objective §8 3번 명령이 수행)
+ *   T-DOC-SYNC-01  → `yarn check:docs` 체인에 배선됨
+ *
+ * 검사 5종:
  *   (a) FWREQ — 전 체인 × 전 메서드 행의 값이 `{bio, x}` 두 키를 non-empty 로 보유
- *   (b) MATRIX — **`fw` 키가 있는 행만** 대상. `fw` 부재 행은 지금도 `—` 로 렌더되므로 skip
- *       (전 행에 `fw` 를 강제하면 현재 통과 중인 행이 곧바로 실패한다)
- *   (c) 하드코딩 Requirements/요구사항 블록 — EN/KO **각각** 두 모델 이름을 모두 포함
+ *              + 체인/행 수 floor (삭제로 초록 만들기 차단)
+ *   (b) MATRIX — `fw` 키가 있는 행은 `{bio, x}` 필수. `fw` 부재는 **allowlist 안에서만** 허용
+ *              (지금도 `—` 로 렌더되는 11행) + 행 수·검사 행 수 floor
+ *   (c) 하드코딩 Requirements/요구사항 블록 — EN/KO **각각** 두 모델 이름 보유.
+ *       블록 containment 뿐 아니라 **DOM 파싱 후 조각 단위**(`thead` / `.rq` 카드)로 본다.
+ *       정규식으로 자르지 않는 이유: `<thead class="…">` 처럼 속성 하나만 붙어도 리터럴 매칭이
+ *       전량 무력화되고 검사가 0건으로 조용히 통과한다(M12/M13). 펌웨어 카드는 두 모델 **필수**,
+ *       그 밖의 카드는 "한 모델만 말하는 상태"를 금지한다.
  *       (EN 만 고치고 KO 를 빠뜨린 상태를 잡는 것이 이 검사의 목적 — 실사고 선례가 있다)
  *   (d) Support Matrix 표 헤더 — EN/KO 각각 모델별 `Min FW` 컬럼 2개 보유
+ *   (e) 동적 렌더러 `injectFwReq` — EN/KO 각각 **실제 호출**해 주입된 `<thead>` 를 단언
  */
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
@@ -62,6 +79,33 @@ function badModelPair(v) {
   return missing.length > 0 ? `${missing.join(' / ')} 키 누락 또는 빈 값 (${JSON.stringify(v)})` : null
 }
 
+/* 🔴 모수(母數) floor — "찾은 것의 모양"만 보면 **보호 대상을 지우는 것**이 게이트를 초록으로
+   만드는 가장 쉬운 길이 된다(빨간 게이트를 만난 사람이 실제로 택하는 경로다). 그래서 아래 하한을
+   함께 단언한다. 값이 정당하게 늘면 이 상수를 올리는 것이 리뷰 대상이 된다 — 줄이는 쪽은 막는다.
+
+   ※ "FWREQ 에 id 가 있는 MATRIX 행은 fw 필수" 같은 구조적 교차 단언은 **이 문서엔 성립하지 않는다**:
+     Ethereum/EVM·XDC(id=chain-ethereum), BNB Beacon Chain·Coreum·Hippo(id=chain-cosmos)는 FWREQ 키를
+     공유하면서도 정당하게 fw 가 없다(패밀리 페이지를 공유하는 행). 그래서 fw 부재는 **이름 allowlist**
+     로 고정한다 — 가드되던 행에서 fw 를 지우면 allowlist 밖이라 즉시 실패한다. */
+const MIN_FWREQ_CHAINS = 25
+const MIN_FWREQ_ROWS = 60
+const MIN_MATRIX_ROWS = 38
+const MIN_MATRIX_FW_ROWS = 27
+/** fw 가 정당하게 없는 행(= 지금도 `—` 로 렌더). MATRIX 의 `n` 은 38행 전부 고유하다. */
+const MATRIX_FW_EXEMPT = new Set([
+  'Ethereum / EVM',
+  'XDC (XinFin)',
+  'eCash',
+  'Zcash',
+  'Bitcoin Gold',
+  'DigiByte',
+  'Ravencoin',
+  'Horizen',
+  'BNB Beacon Chain',
+  'Coreum',
+  'Hippo Protocol',
+])
+
 // ── (a) FWREQ ────────────────────────────────────────────────────────────────
 const fwreq = w.FWREQ
 let fwreqCells = 0
@@ -80,6 +124,14 @@ if (fwreq === null || typeof fwreq !== 'object' || Object.keys(fwreq).length ===
       else fwreqCells += 1
     }
   }
+  // floor — 체인/행을 **지워서** 초록을 만드는 경로를 막는다
+  const chainCount = Object.keys(fwreq).length
+  if (chainCount < MIN_FWREQ_CHAINS) {
+    failures.push(`FWREQ 체인이 ${chainCount}개다 — 최소 ${MIN_FWREQ_CHAINS}개여야 한다(체인이 삭제됐다).`)
+  }
+  if (fwreqCells < MIN_FWREQ_ROWS) {
+    failures.push(`FWREQ 메서드 행이 ${fwreqCells}개다 — 최소 ${MIN_FWREQ_ROWS}개여야 한다(행이 삭제됐다).`)
+  }
 }
 
 // ── (b) MATRIX (fw 보유 행만) ────────────────────────────────────────────────
@@ -90,29 +142,49 @@ if (!Array.isArray(matrix) || matrix.length === 0) {
   failures.push('window.MATRIX 가 비어 있다 — 문서 스크립트 실행 실패로 검사가 성립하지 않는다.')
 } else {
   for (const row of matrix) {
+    const name = row?.n ?? row?.id ?? '(unnamed)'
     if (row?.fw === undefined) {
-      matrixSkipped += 1 // 지금도 `—` 로 렌더된다 — 2컬럼 전환 대상이 아니다
+      // 🔴 skip 은 **allowlist 안에서만** 허용한다. 그러지 않으면 "fw 키를 지우면 검사 대상에서
+      //    빠진다" 가 되어, 게이트를 초록으로 만드는 가장 쉬운 방법이 보호 대상 삭제가 된다.
+      if (MATRIX_FW_EXEMPT.has(name)) matrixSkipped += 1
+      else failures.push(`MATRIX "${name}" 에 fw 가 없다 — 지금까지 fw 를 갖던 행이다(삭제됐거나 오타).`)
       continue
     }
     const bad = badModelPair(row.fw)
-    if (bad) failures.push(`MATRIX "${row?.n ?? row?.id ?? '(unnamed)'}" fw: ${bad}`)
+    if (bad) failures.push(`MATRIX "${name}" fw: ${bad}`)
     else matrixChecked += 1
+  }
+  // floor — 행 자체를 지우는 경로를 막는다
+  if (matrix.length < MIN_MATRIX_ROWS) {
+    failures.push(`MATRIX 가 ${matrix.length}행이다 — 최소 ${MIN_MATRIX_ROWS}행이어야 한다(행이 삭제됐다).`)
+  }
+  if (matrixChecked < MIN_MATRIX_FW_ROWS) {
+    failures.push(
+      `MATRIX 에서 fw 를 검사한 행이 ${matrixChecked}개다 — 최소 ${MIN_MATRIX_FW_ROWS}개여야 한다(fw 가 사라졌다).`,
+    )
   }
 }
 
 // ── (c) 하드코딩 Requirements / 요구사항 블록 (EN·KO 각각) ────────────────────
+// 🔴 정규식으로 자르지 않는다 — `<thead class="...">` 처럼 속성 하나만 붙어도 리터럴 매칭이
+//    전량 무력화되고(검사 0건 = 조용한 통과), `.rq` 카드의 끝 앵커도 뒤에 형제가 붙는 순간
+//    무너진다. 문서를 이미 jsdom 으로 실행하고 있으므로 **DOM 으로 파싱**한다.
 const pages = w.PAGES ?? {}
 const reqBlocks = []
 for (const [id, page] of Object.entries(pages)) {
   for (const field of ['html', 'ko']) {
     const src = page?.[field]
     if (typeof src !== 'string') continue
-    const re = /<h2[^>]*>(?:Requirements|요구사항)<\/h2>/g
-    let m
-    while ((m = re.exec(src)) !== null) {
-      const start = m.index
-      const nextH2 = src.indexOf('<h2', start + m[0].length)
-      reqBlocks.push({ id, field, body: src.slice(start, nextH2 === -1 ? src.length : nextH2) })
+    const frag = JSDOM.fragment(src)
+    for (const h2 of frag.querySelectorAll('h2')) {
+      const heading = h2.textContent.trim()
+      if (heading !== 'Requirements' && heading !== '요구사항') continue
+      // 다음 h2 전까지의 형제를 블록으로 모은다. 원본을 옮기지 않도록 clone 해서 담는다.
+      const box = frag.ownerDocument.createElement('div')
+      for (let el = h2.nextElementSibling; el !== null && el.tagName !== 'H2'; el = el.nextElementSibling) {
+        box.appendChild(el.cloneNode(true))
+      }
+      reqBlocks.push({ id, field, box })
     }
   }
 }
@@ -128,34 +200,64 @@ for (const field of ['html', 'ko']) {
     failures.push(`${field === 'ko' ? 'KO' : 'EN'} 쪽 Requirements 블록이 하나도 없다 — 한쪽 언어가 통째로 빠졌다.`)
   }
 }
-/** 한 조각(표 헤더 / 카드)이 한 모델만 말하고 있으면 위반. 둘 다 없으면 비대상(무관 조각). */
-function missingModelLabels(fragment) {
-  const has = { [BIO]: fragment.includes(BIO), [X]: fragment.includes(X) }
-  if (!has[BIO] && !has[X]) return null
-  return [BIO, X].filter((label) => !has[label])
+/** 두 모델 중 이 조각에 없는 이름들. */
+function absentLabels(text) {
+  return [BIO, X].filter((label) => !text.includes(label))
 }
+/** 한 조각이 한 모델만 말하고 있으면 그 누락분. 둘 다 없으면 `null`(모델 무관 조각). */
+function partialModelLabels(text) {
+  const absent = absentLabels(text)
+  return absent.length === 1 ? absent : null
+}
+const FW_CARD_KEY = /^(Firmware|펌웨어)$/
 
 for (const b of reqBlocks) {
+  const where = `[${b.id}.${b.field}]`
+  const blockText = b.box.textContent
+
   // 블록 전체에 두 모델이 다 있어야 한다 (통째로 단일 모델로 되돌린 상태를 잡는다)
-  const missing = [BIO, X].filter((label) => !b.body.includes(label))
+  const missing = absentLabels(blockText)
   if (missing.length > 0) {
-    failures.push(`Requirements 블록 [${b.id}.${b.field}] 에 모델 표기 누락: ${missing.join(' / ')}`)
+    failures.push(`Requirements 블록 ${where} 에 모델 표기 누락: ${missing.join(' / ')}`)
+  }
+
+  const theads = b.box.querySelectorAll('thead')
+  const cards = b.box.querySelectorAll('.rq')
+  // fail-closed — 표도 카드도 없으면 아래 조각 검사가 전부 0건으로 공허하게 통과한다.
+  if (theads.length === 0 && cards.length === 0) {
+    failures.push(`Requirements 블록 ${where} 에 표(thead)도 카드(.rq)도 없다 — 구조가 사라졌다.`)
+  }
+  // 표가 있는데 헤더가 없으면(<thead> 통째 삭제) 그것도 실패다.
+  if (b.box.querySelector('table') !== null && theads.length === 0) {
+    failures.push(`Requirements 블록 ${where} 의 표에 <thead> 가 없다 — 모델 컬럼 검사가 성립하지 않는다.`)
   }
 
   // 🔴 블록 전체 containment 만으로는 부족하다 — 표 헤더에서 X 컬럼만 지워도 lead 문단에 이름이
-  //    남아 블록 단위로는 통과한다. 그래서 **조각 단위**로 "한쪽만 말하는 상태"를 금지한다.
-  for (const [, thead] of b.body.matchAll(/<thead>([\s\S]*?)<\/thead>/g)) {
-    const m = missingModelLabels(thead)
-    if (m === null) {
-      failures.push(`Requirements 표 헤더 [${b.id}.${b.field}] 에 모델 컬럼이 없다 — 2모델 표가 아니다.`)
-    } else if (m.length > 0) {
-      failures.push(`Requirements 표 헤더 [${b.id}.${b.field}] 에 모델 컬럼 누락: ${m.join(' / ')}`)
+  //    남아 블록 단위로는 통과한다. 그래서 **조각 단위**로 본다.
+  for (const thead of theads) {
+    const absent = absentLabels(thead.textContent)
+    if (absent.length > 0) {
+      failures.push(`Requirements 표 헤더 ${where} 에 모델 컬럼 누락: ${absent.join(' / ')}`)
     }
   }
-  for (const [, card] of b.body.matchAll(/<div class="rq">([\s\S]*?)(?=<div class="rq">|<\/div>\s*$)/g)) {
-    const m = missingModelLabels(card)
-    if (m !== null && m.length > 0) {
-      failures.push(`Requirements 카드 [${b.id}.${b.field}] 가 한 모델만 언급한다 — 누락: ${m.join(' / ')}`)
+  // 펌웨어 카드는 **두 모델 필수**다. 라벨을 둘 다 지워 "your device" 류로 되돌리는 회귀를
+  // "모델 무관 조각"으로 봐주면 안 되는 유일한 카드이기 때문이다.
+  const fwCards = [...cards].filter((c) => FW_CARD_KEY.test((c.querySelector('.k')?.textContent ?? '').trim()))
+  if (cards.length > 0 && fwCards.length === 0) {
+    failures.push(`Requirements 카드 ${where} 에 펌웨어(Firmware/펌웨어) 카드가 없다 — 앵커가 사라졌다.`)
+  }
+  for (const card of fwCards) {
+    const absent = absentLabels(card.textContent)
+    if (absent.length > 0) {
+      failures.push(`Requirements 펌웨어 카드 ${where} 에 모델 표기 누락: ${absent.join(' / ')}`)
+    }
+  }
+  // 나머지 카드(기기 카드 등)는 "한 모델만 말하는 상태"만 금지 — 모델 무관 카드(브라우저/연결)는 비대상
+  for (const card of cards) {
+    if (fwCards.includes(card)) continue
+    const partial = partialModelLabels(card.textContent)
+    if (partial !== null) {
+      failures.push(`Requirements 카드 ${where} 가 한 모델만 언급한다 — 누락: ${partial.join(' / ')}`)
     }
   }
 }

--- a/scripts/check-index-html-fw-models.mjs
+++ b/scripts/check-index-html-fw-models.mjs
@@ -11,16 +11,20 @@
  *    MATRIX 값에는 `<span class=tok-acc>` HTML 이 섞여 있어 정규식 절단이 취약하다.
  *    형제 선례: `check-index-html-page-refs.mjs`(문서 실행 후 `window.PAGES` 읽기).
  *
- * objective m09-04-28 테스트 항목 매핑:
- *   T-DOC-MODEL-01 → (a) FWREQ 전수      T-DOC-MODEL-02 → (b) MATRIX(fw 보유 행)
- *   T-DOC-MODEL-03 → (c)/(d) EN·KO 4블록 + Min FW 헤더 2개
- *   T-DOC-MODEL-04 → 뮤테이션 검출(이 스크립트를 대상으로 objective §8 3번 명령이 수행)
- *   T-DOC-SYNC-01  → `yarn check:docs` 체인에 배선됨
- *
  * 🔴 그리고 "찾은 것의 모양"만 보지 않는다 — **모수(母數)에 floor** 를 건다. 모양만 보면
  *    "보호 대상을 지우면 초록"이 성립하고(체인 삭제 / `fw` 키 삭제 / `<thead>` 통째 삭제),
  *    그게 빨간 게이트를 만난 사람이 실제로 택하는 경로다. 크로스 리뷰 R1 에서 이 클래스로
  *    6종의 뮤테이션이 전부 통과했다(M11~M16).
+ *
+ * ⚖️ **이 게이트의 범위 — 실수를 막고, 의도적 우회는 막지 않는다** (크로스 리뷰 R2 판정).
+ *    floor 는 "총량"을 보지 identity 를 보지 않는다. 그래서 원리적으로는 우회가 가능하다:
+ *    메서드 행을 지우는 대신 **중복 이름으로 치환**해 60행을 유지하거나, 체인 표시명을
+ *    allowlist 의 다른 이름으로 **rename 하면서 동시에 원래 그 이름 행에 fw 를 보충**하면 통과한다.
+ *    그 상태까지 막으려면 체인별 메서드 집합을 상수로 박아 exact 비교해야 하는데, 체인·메서드가
+ *    추가될 때마다 상수를 갱신해야 해 상시 유지보수 비용이 붙는다. 이 게이트가 막으려는 것은
+ *    **"2모델 전환을 부분적으로만 하는 실수"** 이고 위 경로는 실수로 도달하지 않으므로,
+ *    비용 대비 이득이 맞지 않아 **의도적으로 범위 밖에 둔다.** 우회하려면 floor 상수나 allowlist 를
+ *    함께 고쳐야 하고, 그건 diff 에 드러나 사람 리뷰가 본다.
  *
  * objective m09-04-28 테스트 항목 매핑:
  *   T-DOC-MODEL-01 → (a) FWREQ 전수      T-DOC-MODEL-02 → (b) MATRIX(fw 보유 행)
@@ -33,14 +37,21 @@
  *              + 체인/행 수 floor (삭제로 초록 만들기 차단)
  *   (b) MATRIX — `fw` 키가 있는 행은 `{bio, x}` 필수. `fw` 부재는 **allowlist 안에서만** 허용
  *              (지금도 `—` 로 렌더되는 11행) + 행 수·검사 행 수 floor
+ *   (b2) FWNOTE — 체인별 note 8건의 EN/KO 가 "어느 모델 기준인지" 를 밝히는가
  *   (c) 하드코딩 Requirements/요구사항 블록 — EN/KO **각각** 두 모델 이름 보유.
- *       블록 containment 뿐 아니라 **DOM 파싱 후 조각 단위**(`thead` / `.rq` 카드)로 본다.
+ *       블록 containment 뿐 아니라 **DOM 파싱 후 조각 단위**(`thead` / `.rq` 카드 / lead 산문)로 본다.
  *       정규식으로 자르지 않는 이유: `<thead class="…">` 처럼 속성 하나만 붙어도 리터럴 매칭이
- *       전량 무력화되고 검사가 0건으로 조용히 통과한다(M12/M13). 펌웨어 카드는 두 모델 **필수**,
- *       그 밖의 카드는 "한 모델만 말하는 상태"를 금지한다.
+ *       전량 무력화되고 검사가 0건으로 조용히 통과한다(M12/M13).
+ *       기기/펌웨어 카드는 두 모델 **필수**(둘 다 지워 "your device" 로 되돌리는 회귀 차단),
+ *       그 밖의 카드는 "한 모델만 말하는 상태" 금지.
  *       (EN 만 고치고 KO 를 빠뜨린 상태를 잡는 것이 이 검사의 목적 — 실사고 선례가 있다)
- *   (d) Support Matrix 표 헤더 — EN/KO 각각 모델별 `Min FW` 컬럼 2개 보유
- *   (e) 동적 렌더러 `injectFwReq` — EN/KO 각각 **실제 호출**해 주입된 `<thead>` 를 단언
+ *   (d) Support Matrix 표 헤더 + 하단 note 산문 — EN/KO 각각
+ *   (e) 동적 렌더러 `injectFwReq` — EN/KO 각각 **실제 호출**해 `<thead>` + lead 산문 + note 렌더를 단언
+ *   (f) Support Matrix **row 렌더러** — 실제 렌더한 행의 `.m-fw` 셀이 정확히 2개이고 헤더와 컬럼 수가
+ *       맞는지, `[object Object]` 가 없는지 (데이터·헤더만 보면 row 렌더러 회귀를 통째로 놓친다)
+ *
+ * 🧭 **산문(prose)도 검사 대상이다** — 표만 지키면 "표는 2컬럼인데 설명은 단일 모델"이 남는다.
+ *    설명이 오해의 1차 진입점이므로 lead·note·FWNOTE 를 표와 같은 급으로 본다 (크로스 리뷰 R2).
  */
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
@@ -165,6 +176,28 @@ if (!Array.isArray(matrix) || matrix.length === 0) {
   }
 }
 
+// ── (b2) FWNOTE — 체인별 보충 설명이 어느 모델 기준인지 밝히는가 ───────────────
+// FWNOTE 의 버전(예: BSC `2.6.1`)은 전부 Biometric 라인 값이다. "어느 모델 기준"이 빠지면
+// X 사용자가 자기 `1.0.0` 과 비교해 미지원으로 읽는다 — 표를 2컬럼으로 바꾼 이유와 같은 오해다.
+let fwnoteChecked = 0
+const fwnote = w.FWNOTE
+if (fwnote === null || typeof fwnote !== 'object' || Object.keys(fwnote).length === 0) {
+  failures.push('window.FWNOTE 가 비어 있다 — 문서 스크립트 실행 실패 또는 note 가 통째로 삭제됐다.')
+} else {
+  for (const [chainId, note] of Object.entries(fwnote)) {
+    for (const lang of ['en', 'ko']) {
+      const text = note?.[lang]
+      if (typeof text !== 'string' || text.length === 0) {
+        failures.push(`FWNOTE["${chainId}"].${lang} 가 비어 있다.`)
+        continue
+      }
+      const absent = absentLabels(text)
+      if (absent.length > 0) failures.push(`FWNOTE["${chainId}"].${lang} 에 모델 기준 표기 누락: ${absent.join(' / ')}`)
+      else fwnoteChecked += 1
+    }
+  }
+}
+
 // ── (c) 하드코딩 Requirements / 요구사항 블록 (EN·KO 각각) ────────────────────
 // 🔴 정규식으로 자르지 않는다 — `<thead class="...">` 처럼 속성 하나만 붙어도 리터럴 매칭이
 //    전량 무력화되고(검사 0건 = 조용한 통과), `.rq` 카드의 끝 앵커도 뒤에 형제가 붙는 순간
@@ -209,7 +242,20 @@ function partialModelLabels(text) {
   const absent = absentLabels(text)
   return absent.length === 1 ? absent : null
 }
-const FW_CARD_KEY = /^(Firmware|펌웨어)$/
+/**
+ * 두 모델을 **반드시 함께** 말해야 하는 카드의 `.k` 라벨.
+ *
+ * 펌웨어 카드만 넣으면 형제인 기기(Device) 카드에서 라벨을 **둘 다** 지웠을 때
+ * "모델 무관 조각"으로 접혀 통과한다(크로스 리뷰 R2). 두 카드 모두 현재 dual-model 조각이므로
+ * 함께 앵커한다. 그리고 **두 앵커가 각각 존재하는지**를 따로 본다 — 하나만 세면 그 카드의 `.k` 를
+ * rename 하는 것만으로 그 카드가 검사에서 빠지는데, 다른 앵커가 남아 있어 fail-closed 가드가
+ * 발동하지 않는다(자가 검증 M14r'').
+ */
+const DUAL_MODEL_CARD_ANCHORS = {
+  기기: /^(Device|기기)$/,
+  펌웨어: /^(Firmware|펌웨어)$/,
+}
+const DUAL_MODEL_CARD_KEY = /^(Firmware|펌웨어|Device|기기)$/
 
 for (const b of reqBlocks) {
   const where = `[${b.id}.${b.field}]`
@@ -240,21 +286,38 @@ for (const b of reqBlocks) {
       failures.push(`Requirements 표 헤더 ${where} 에 모델 컬럼 누락: ${absent.join(' / ')}`)
     }
   }
-  // 펌웨어 카드는 **두 모델 필수**다. 라벨을 둘 다 지워 "your device" 류로 되돌리는 회귀를
-  // "모델 무관 조각"으로 봐주면 안 되는 유일한 카드이기 때문이다.
-  const fwCards = [...cards].filter((c) => FW_CARD_KEY.test((c.querySelector('.k')?.textContent ?? '').trim()))
-  if (cards.length > 0 && fwCards.length === 0) {
-    failures.push(`Requirements 카드 ${where} 에 펌웨어(Firmware/펌웨어) 카드가 없다 — 앵커가 사라졌다.`)
-  }
-  for (const card of fwCards) {
-    const absent = absentLabels(card.textContent)
-    if (absent.length > 0) {
-      failures.push(`Requirements 펌웨어 카드 ${where} 에 모델 표기 누락: ${absent.join(' / ')}`)
+  // 기기/펌웨어 카드는 **두 모델 필수**다. 라벨을 둘 다 지워 "your device" 류로 되돌리는 회귀를
+  // "모델 무관 조각"으로 봐주면 안 되는 카드들이기 때문이다.
+  const dualCards = [...cards].filter((c) =>
+    DUAL_MODEL_CARD_KEY.test((c.querySelector('.k')?.textContent ?? '').trim()),
+  )
+  if (cards.length > 0) {
+    // 앵커는 **각각** 있어야 한다 — 하나만 세면 그 카드의 `.k` 를 rename 하는 것만으로 검사에서
+    // 빠지는데 다른 앵커가 남아 fail-closed 가 발동하지 않는다.
+    for (const [anchorName, re] of Object.entries(DUAL_MODEL_CARD_ANCHORS)) {
+      if (![...cards].some((c) => re.test((c.querySelector('.k')?.textContent ?? '').trim()))) {
+        failures.push(`Requirements 카드 ${where} 에 ${anchorName} 카드가 없다 — 앵커가 사라졌거나 이름이 바뀌었다.`)
+      }
     }
   }
-  // 나머지 카드(기기 카드 등)는 "한 모델만 말하는 상태"만 금지 — 모델 무관 카드(브라우저/연결)는 비대상
+  for (const card of dualCards) {
+    const absent = absentLabels(card.textContent)
+    if (absent.length > 0) {
+      const key = (card.querySelector('.k')?.textContent ?? '').trim()
+      failures.push(`Requirements ${key} 카드 ${where} 에 모델 표기 누락: ${absent.join(' / ')}`)
+    }
+  }
+  // (g1) 표가 있는 블록은 **표를 설명하는 산문(lead)** 도 두 모델을 말해야 한다.
+  //      표만 지키면 "표는 2컬럼인데 설명이 단일 모델"인 상태가 남고, 산문이 오해의 1차 진입점이다.
+  if (b.box.querySelector('table') !== null) {
+    const paras = [...b.box.querySelectorAll('p')]
+    if (!paras.some((p) => absentLabels(p.textContent).length === 0)) {
+      failures.push(`Requirements lead 산문 ${where} 에 두 모델을 함께 말하는 문단이 없다.`)
+    }
+  }
+  // 나머지 카드는 "한 모델만 말하는 상태"만 금지 — 모델 무관 카드(브라우저/연결)는 비대상
   for (const card of cards) {
-    if (fwCards.includes(card)) continue
+    if (dualCards.includes(card)) continue
     const partial = partialModelLabels(card.textContent)
     if (partial !== null) {
       failures.push(`Requirements 카드 ${where} 가 한 모델만 언급한다 — 누락: ${partial.join(' / ')}`)
@@ -282,6 +345,12 @@ for (const h of matrixHeaders) {
   const missing = [`Min FW · ${BIO}`, `Min FW · ${X}`].filter((label) => !h.src.includes(label))
   if (missing.length > 0) {
     failures.push(`Support Matrix 헤더 [${h.id}.${h.field}] 에 모델 컬럼 누락: ${missing.join(' / ')}`)
+  }
+  // (g2) 표 아래 note 산문 — "두 컬럼은 서로 다른 버전 라인" 설명이 사라지면 사용자는 두 값을
+  //      비교 가능한 값으로 읽는다(이 objective 가 막으려는 바로 그 오해다).
+  const notes = [...JSDOM.fragment(h.src).querySelectorAll('.note')]
+  if (!notes.some((n) => absentLabels(n.textContent).length === 0)) {
+    failures.push(`Support Matrix note 산문 [${h.id}.${h.field}] 에 두 모델을 함께 말하는 설명이 없다.`)
   }
 }
 
@@ -322,7 +391,68 @@ if (typeof w.injectFwReq !== 'function') {
       } else {
         rendererChecked += 1
       }
+      // (g3) 같은 렌더러의 **형제 표면** — lead 산문과 FWNOTE note. 헤더만 단언하면 산문에서
+      //      모델 이름이 빠져도 안 잡힌다(축 (e)를 헤더로만 좁힌 것이 R2 지적의 클래스였다).
+      const lead = host.querySelector('p')
+      if (lead === null || absentLabels(lead.textContent).length > 0) {
+        failures.push(`injectFwReq(${lang}) lead 산문에 두 모델을 함께 말하는 설명이 없다 — 체인 페이지 전부에 영향.`)
+      }
+      if (w.FWNOTE?.[sampleChain] !== undefined && host.querySelector('.note') === null) {
+        failures.push(`injectFwReq(${lang}) 가 FWNOTE(${sampleChain}) 를 렌더하지 않았다 — note 경로가 끊겼다.`)
+      }
     }
+  }
+}
+
+// ── (f) Support Matrix **row 렌더러** ────────────────────────────────────────
+// (d)는 헤더 문자열, (b)는 데이터만 본다 — 그 사이의 **row 렌더러**(`.m-fw` 셀)는 무방비였다.
+// 옛 단일 셀 `${r.fw||'—'}` 로 되돌리면 헤더는 2컬럼인데 body 는 1셀이라 컬럼이 밀리고 사용자는
+// `[object Object]` 를 본다 — (a)~(e) 는 그것을 못 본다(크로스 리뷰 R2). 축 (e)와 같은 방식으로
+// **실제 렌더 결과**를 단언한다. EN/KO 는 `mount()` 를 공유하므로 렌더러는 한 번만 검사하면 된다
+// (언어별 헤더 문자열은 (d)가 EN/KO 각각 본다).
+let matrixRowsChecked = 0
+{
+  w.location.hash = '#/support-matrix'
+  try {
+    w.dispatchEvent(new w.Event('hashchange'))
+  } catch (e) {
+    failures.push(`support-matrix 라우팅 실패: ${e && e.message ? e.message : String(e)}`)
+  }
+  await new Promise((r) => setTimeout(r, 200))
+
+  const table = w.document.querySelector('table.matrix')
+  const headerCells = table === null ? 0 : table.querySelectorAll('thead th').length
+  const rows = table === null ? [] : [...table.querySelectorAll('tbody tr')]
+  // fail-closed — 0행이면 아래 셀 검사가 전부 공허하게 통과한다.
+  if (rows.length === 0) {
+    failures.push('Support Matrix 가 한 행도 렌더되지 않았다 — row 렌더러 검사가 성립하지 않는다.')
+  }
+  for (const row of rows) {
+    const label = row.querySelector('td')?.textContent?.trim() ?? '(unnamed)'
+    const fwCells = row.querySelectorAll('td.m-fw')
+    if (fwCells.length !== 2) {
+      failures.push(`Support Matrix row "${label}" 의 .m-fw 셀이 ${fwCells.length}개다 — 모델별 2개여야 한다.`)
+      break // 렌더러는 전 행 공통이라 첫 위반이면 충분하다 (38행 × 같은 메시지 방지)
+    }
+    if (row.querySelectorAll('td').length !== headerCells) {
+      failures.push(
+        `Support Matrix row "${label}" 의 셀 수(${row.querySelectorAll('td').length})가 헤더(${headerCells})와 다르다 — 컬럼이 밀렸다.`,
+      )
+      break
+    }
+    if (row.textContent.includes('[object Object]')) {
+      failures.push(`Support Matrix row "${label}" 에 [object Object] 가 렌더됐다 — fw 객체를 그대로 출력하고 있다.`)
+      break
+    }
+    matrixRowsChecked += 1
+  }
+  // 값이 실제로 bio/x 로 갈라져 나오는지 — 두 셀이 전부 `—` 인 행만 있으면 렌더가 데이터를 잃은 것이다.
+  const versionRow = rows.find((r) => {
+    const c = r.querySelectorAll('td.m-fw')
+    return c.length === 2 && /\d+\.\d+\.\d+/.test(c[0].textContent) && /\d+\.\d+\.\d+/.test(c[1].textContent)
+  })
+  if (rows.length > 0 && versionRow === undefined) {
+    failures.push('Support Matrix 에 bio/x 두 셀이 모두 버전으로 채워진 행이 하나도 없다 — 렌더가 fw 값을 잃었다.')
   }
 }
 
@@ -334,7 +464,7 @@ if (failures.length > 0) {
 
 console.log(
   `✓ docs/index.html 펌웨어 모델 축 — FWREQ ${fwreqCells}행(체인 ${Object.keys(fwreq).length}) · ` +
-    `MATRIX ${matrixChecked}행 검사 / ${matrixSkipped}행 skip(fw 미지정) · ` +
+    `MATRIX ${matrixChecked}행 검사 / ${matrixSkipped}행 skip(fw 미지정) · FWNOTE ${fwnoteChecked}건(EN·KO) · ` +
     `Requirements 블록 ${reqBlocks.length} · Support Matrix 헤더 ${matrixHeaders.length} · ` +
-    `injectFwReq 렌더 ${rendererChecked}/2 (EN·KO)`,
+    `injectFwReq 렌더 ${rendererChecked}/2 (EN·KO) · Support Matrix row ${matrixRowsChecked}행 렌더 검사`,
 )

--- a/scripts/check-index-html-fw-models.mjs
+++ b/scripts/check-index-html-fw-models.mjs
@@ -50,6 +50,12 @@
  *   (f) Support Matrix **row 렌더러** — 실제 렌더한 행의 `.m-fw` 셀이 정확히 2개이고 헤더와 컬럼 수가
  *       맞는지, `[object Object]` 가 없는지 (데이터·헤더만 보면 row 렌더러 회귀를 통째로 놓친다)
  *
+ * 🧭 **방향(bio↔x)도 검사 대상이다** — 라벨이 "있는가"만 보면 두 컬럼을 **맞바꿔도** 통과한다.
+ *    swap 은 템플릿 복붙에서 나오는 **실수**라 위 "의도적 우회는 범위 밖" 선언이 덮지 못하고,
+ *    착지하면 X 사용자가 "DCENT X" 컬럼에서 Biometric 라인 값을 읽어 **단일 컬럼 시절보다 나쁘다**.
+ *    판별자는 값이다 — `x` 는 전 항목 `1.0.0`, `bio` 는 대부분 다르다. 데이터(x 불변식) · 헤더 순서 ·
+ *    body 셀을 **인덱스**로 단언한다 (크로스 리뷰 R3).
+ *
  * 🧭 **산문(prose)도 검사 대상이다** — 표만 지키면 "표는 2컬럼인데 설명은 단일 모델"이 남는다.
  *    설명이 오해의 1차 진입점이므로 lead·note·FWNOTE 를 표와 같은 급으로 본다 (크로스 리뷰 R2).
  */
@@ -88,6 +94,30 @@ function badModelPair(v) {
   if (v === null || typeof v !== 'object' || Array.isArray(v)) return `모델 객체가 아님 (${JSON.stringify(v)})`
   const missing = ['bio', 'x'].filter((k) => typeof v[k] !== 'string' || v[k].trim() === '')
   return missing.length > 0 ? `${missing.join(' / ')} 키 누락 또는 빈 값 (${JSON.stringify(v)})` : null
+}
+
+/**
+ * 🧭 **방향(direction) 축** — 라벨이 "들어있는가"만 보면 bio↔x 를 **맞바꿔도** 통과한다.
+ * 그 상태는 X 사용자가 "DCENT X" 컬럼에서 Biometric 라인의 `2.35.0` 을 읽고 미지원으로 판단하게
+ * 만들어, 이 objective 가 대체한 단일 컬럼 상태보다 **더 나쁘다**. swap 은 템플릿 복붙에서 나오는
+ * **실수**라 헤더의 "의도적 우회는 범위 밖" 선언이 덮지 못한다 (크로스 리뷰 R3).
+ * 판별자는 **값**이다 — `x` 는 전 항목 `'1.0.0'` 이고 `bio` 는 대부분 다르다.
+ */
+const X_VALUE = '1.0.0'
+
+/**
+ * 표 헤더에서 모델 컬럼의 **순서**를 단언한다 (BIO 가 먼저, X 가 나중).
+ * @returns {{bioIdx:number, xIdx:number}|null} 열거 불가면 null
+ */
+function assertModelColumnOrder(cells, where, out) {
+  const texts = [...cells].map((c) => c.textContent)
+  const bioIdx = texts.findIndex((t) => t.includes(BIO))
+  const xIdx = texts.findIndex((t) => t.includes(X))
+  if (bioIdx === -1 || xIdx === -1) return null // 부재는 다른 검사가 이미 잡는다
+  if (bioIdx > xIdx) {
+    out.push(`${where}: 모델 컬럼 순서가 뒤집혔다 — ${BIO} 가 ${xIdx + 1}번째 뒤(${bioIdx + 1}번째)에 있다.`)
+  }
+  return { bioIdx, xIdx }
 }
 
 /* 🔴 모수(母數) floor — "찾은 것의 모양"만 보면 **보호 대상을 지우는 것**이 게이트를 초록으로
@@ -132,7 +162,11 @@ if (fwreq === null || typeof fwreq !== 'object' || Object.keys(fwreq).length ===
       const method = Array.isArray(row) ? row[0] : '(unknown)'
       const bad = Array.isArray(row) ? badModelPair(row[1]) : '행이 배열이 아님'
       if (bad) failures.push(`FWREQ["${chainId}"] ${method}: ${bad}`)
-      else fwreqCells += 1
+      else if (row[1].x !== X_VALUE) {
+        // 방향 축 — bio↔x 를 맞바꾸면 x 가 bio 라인 값(2.x)이 된다. X 값이 정당하게 갈라지는 날이
+        // 오면 이 단언이 먼저 빨개져서 게이트를 함께 갱신하게 만든다(fail-closed).
+        failures.push(`FWREQ["${chainId}"] ${method}: x 값이 "${row[1].x}" 다 — X 는 전 항목 "${X_VALUE}" 여야 한다(bio↔x 뒤바뀜?).`)
+      } else fwreqCells += 1
     }
   }
   // floor — 체인/행을 **지워서** 초록을 만드는 경로를 막는다
@@ -163,7 +197,9 @@ if (!Array.isArray(matrix) || matrix.length === 0) {
     }
     const bad = badModelPair(row.fw)
     if (bad) failures.push(`MATRIX "${name}" fw: ${bad}`)
-    else matrixChecked += 1
+    else if (row.fw.x !== X_VALUE) {
+      failures.push(`MATRIX "${name}" fw.x 가 "${row.fw.x}" 다 — X 는 전 항목 "${X_VALUE}" 여야 한다(bio↔x 뒤바뀜?).`)
+    } else matrixChecked += 1
   }
   // floor — 행 자체를 지우는 경로를 막는다
   if (matrix.length < MIN_MATRIX_ROWS) {
@@ -284,6 +320,23 @@ for (const b of reqBlocks) {
     const absent = absentLabels(thead.textContent)
     if (absent.length > 0) {
       failures.push(`Requirements 표 헤더 ${where} 에 모델 컬럼 누락: ${absent.join(' / ')}`)
+      continue
+    }
+    // 방향 축 — 헤더 순서 + 그 순서에 맞는 body 값
+    const order = assertModelColumnOrder(thead.querySelectorAll('th'), `Requirements 표 헤더 ${where}`, failures)
+    if (order === null) continue
+    const table = thead.closest('table')
+    for (const row of table?.querySelectorAll('tbody tr') ?? []) {
+      const tds = row.querySelectorAll('td')
+      const xCell = tds[order.xIdx]
+      if (xCell === undefined) continue
+      if (!xCell.textContent.includes(X_VALUE)) {
+        failures.push(
+          `Requirements 표 ${where} 의 X 컬럼에 "${xCell.textContent.trim().slice(0, 24)}" 가 있다 — ` +
+            `X 는 "${X_VALUE}" 여야 한다(bio↔x 셀이 뒤바뀌었을 수 있다).`,
+        )
+        break
+      }
     }
   }
   // 기기/펌웨어 카드는 **두 모델 필수**다. 라벨을 둘 다 지워 "your device" 류로 되돌리는 회귀를
@@ -346,6 +399,12 @@ for (const h of matrixHeaders) {
   if (missing.length > 0) {
     failures.push(`Support Matrix 헤더 [${h.id}.${h.field}] 에 모델 컬럼 누락: ${missing.join(' / ')}`)
   }
+  // 방향 축 — 두 컬럼의 **순서**. 라벨 존재만 보면 맞바꿔도 통과한다.
+  const bioAt = h.src.indexOf(`Min FW · ${BIO}`)
+  const xAt = h.src.indexOf(`Min FW · ${X}`)
+  if (bioAt !== -1 && xAt !== -1 && bioAt > xAt) {
+    failures.push(`Support Matrix 헤더 [${h.id}.${h.field}] 의 모델 컬럼 순서가 뒤집혔다 — ${BIO} 가 먼저여야 한다.`)
+  }
   // (g2) 표 아래 note 산문 — "두 컬럼은 서로 다른 버전 라인" 설명이 사라지면 사용자는 두 값을
   //      비교 가능한 값으로 읽는다(이 objective 가 막으려는 바로 그 오해다).
   const notes = [...JSDOM.fragment(h.src).querySelectorAll('.note')]
@@ -364,7 +423,12 @@ let rendererChecked = 0
 if (typeof w.injectFwReq !== 'function') {
   failures.push('window.injectFwReq 가 함수가 아니다 — 렌더러가 사라졌거나 스크립트 실행이 깨졌다.')
 } else {
-  const sampleChain = Object.keys(fwreq ?? {})[0]
+  // 방향 축을 실제로 판별하려면 **bio !== x 인 행**이 있는 체인을 골라야 한다. bio 와 x 가 같은
+  // 체인을 쓰면 셀을 맞바꿔도 출력이 바이트 단위로 같아 어떤 단언으로도 못 잡는다
+  // (`review-finding-class-closure` — 값의 차이가 유일한 판별자).
+  const fwreqEntries = Object.entries(fwreq ?? {})
+  const sampleChain =
+    fwreqEntries.find(([, rows]) => rows.some((r) => r?.[1]?.bio !== r?.[1]?.x))?.[0] ?? fwreqEntries[0]?.[0]
   if (!sampleChain) {
     failures.push('injectFwReq 렌더 검사를 돌릴 FWREQ 체인이 없다 — (a) 검사와 함께 실패한 상태다.')
   } else {
@@ -389,6 +453,23 @@ if (typeof w.injectFwReq !== 'function') {
       if (missing.length > 0) {
         failures.push(`injectFwReq(${lang}) 표 헤더에 모델 컬럼 누락: ${missing.join(' / ')} — 체인 페이지 전부에 영향.`)
       } else {
+        // 방향 축 ① 헤더 순서
+        const order = assertModelColumnOrder(thead.querySelectorAll('th'), `injectFwReq(${lang}) 표 헤더`, failures)
+        // 방향 축 ② body 셀 — bio !== x 인 행을 데이터에서 골라 **인덱스로** 대조
+        const dataRows = fwreq[sampleChain] ?? []
+        const dataIdx = dataRows.findIndex((r) => r?.[1]?.bio !== r?.[1]?.x)
+        const domRow = host.querySelectorAll('table.params tbody tr')[dataIdx]
+        if (order !== null && dataIdx !== -1 && domRow !== undefined) {
+          const tds = domRow.querySelectorAll('td')
+          const expect = dataRows[dataIdx][1]
+          const method = dataRows[dataIdx][0]
+          if (!tds[order.bioIdx]?.textContent.includes(expect.bio)) {
+            failures.push(`injectFwReq(${lang}) ${sampleChain} ${method} 의 ${BIO} 셀이 "${expect.bio}" 가 아니다 — bio↔x 뒤바뀜.`)
+          }
+          if (!tds[order.xIdx]?.textContent.includes(expect.x)) {
+            failures.push(`injectFwReq(${lang}) ${sampleChain} ${method} 의 ${X} 셀이 "${expect.x}" 가 아니다 — bio↔x 뒤바뀜.`)
+          }
+        }
         rendererChecked += 1
       }
       // (g3) 같은 렌더러의 **형제 표면** — lead 산문과 FWNOTE note. 헤더만 단언하면 산문에서
@@ -445,6 +526,25 @@ let matrixRowsChecked = 0
       break
     }
     matrixRowsChecked += 1
+  }
+  // 방향 축 — `fw.bio !== fw.x` 인 MATRIX 행을 골라 **셀 인덱스**로 대조한다.
+  // (셀이 2개 있는지만 보면 두 셀을 맞바꿔도 통과한다.)
+  const dirRow = (w.MATRIX ?? []).find((r) => r?.fw?.bio !== undefined && r.fw.bio !== r.fw.x)
+  if (dirRow !== undefined) {
+    const domRow = rows.find((r) => r.querySelector('td')?.textContent?.trim() === dirRow.n)
+    if (domRow === undefined) {
+      failures.push(`Support Matrix 에 "${dirRow.n}" 행이 렌더되지 않았다 — 방향 축 검사가 성립하지 않는다.`)
+    } else {
+      const cells = domRow.querySelectorAll('td.m-fw')
+      if (cells.length === 2) {
+        if (!cells[0].textContent.includes(dirRow.fw.bio)) {
+          failures.push(`Support Matrix "${dirRow.n}" 의 1번째 .m-fw 셀이 ${BIO} 값("${dirRow.fw.bio}")이 아니다 — bio↔x 뒤바뀜.`)
+        }
+        if (!cells[1].textContent.includes(dirRow.fw.x)) {
+          failures.push(`Support Matrix "${dirRow.n}" 의 2번째 .m-fw 셀이 ${X} 값("${dirRow.fw.x}")이 아니다 — bio↔x 뒤바뀜.`)
+        }
+      }
+    }
   }
   // 값이 실제로 bio/x 로 갈라져 나오는지 — 두 셀이 전부 `—` 인 행만 있으면 렌더가 데이터를 잃은 것이다.
   const versionRow = rows.find((r) => {

--- a/scripts/check-index-html-fw-models.mjs
+++ b/scripts/check-index-html-fw-models.mjs
@@ -183,6 +183,47 @@ for (const h of matrixHeaders) {
   }
 }
 
+// ── (e) 동적 렌더러 injectFwReq (EN·KO 각각) ─────────────────────────────────
+// 🔴 노출 면적이 가장 큰 표면이다 — 이 렌더러 하나가 **FWREQ 를 가진 25개 체인 페이지 전부**의
+//    Requirements 표 헤더를 만든다. 헤더 상수(`bh`/`xh`)가 비면 25페이지에서 모델 컬럼이
+//    통째로 사라지는데, (a)~(d) 는 그것을 못 본다(하드코딩 4블록 + Support Matrix 2개만 본다).
+//    그래서 소스 문자열이 아니라 **렌더러를 실제로 호출**해 나온 `<thead>` 를 단언한다 —
+//    상수만 남고 실제 사용이 끊긴 경우까지 잡힌다.
+let rendererChecked = 0
+if (typeof w.injectFwReq !== 'function') {
+  failures.push('window.injectFwReq 가 함수가 아니다 — 렌더러가 사라졌거나 스크립트 실행이 깨졌다.')
+} else {
+  const sampleChain = Object.keys(fwreq ?? {})[0]
+  if (!sampleChain) {
+    failures.push('injectFwReq 렌더 검사를 돌릴 FWREQ 체인이 없다 — (a) 검사와 함께 실패한 상태다.')
+  } else {
+    for (const ko of [false, true]) {
+      const lang = ko ? 'KO' : 'EN'
+      const host = w.document.createElement('div')
+      // injectFwReq 는 `.method-chips` 를 앵커로 `afterend` 삽입한다 — 부모가 있어야 한다.
+      host.innerHTML = '<div class="method-chips"></div>'
+      try {
+        w.injectFwReq(host, sampleChain, ko)
+      } catch (e) {
+        failures.push(`injectFwReq(${lang}) 렌더 중 예외: ${e && e.message ? e.message : String(e)}`)
+        continue
+      }
+      const thead = host.querySelector('table.params thead')
+      if (thead === null) {
+        // fail-closed — 표가 안 나오면 아래 라벨 검사가 "위반 0건"으로 공허하게 통과한다.
+        failures.push(`injectFwReq(${lang}) 가 Requirements 표를 렌더하지 않았다 (체인 ${sampleChain}).`)
+        continue
+      }
+      const missing = [BIO, X].filter((label) => !thead.textContent.includes(label))
+      if (missing.length > 0) {
+        failures.push(`injectFwReq(${lang}) 표 헤더에 모델 컬럼 누락: ${missing.join(' / ')} — 체인 페이지 전부에 영향.`)
+      } else {
+        rendererChecked += 1
+      }
+    }
+  }
+}
+
 if (failures.length > 0) {
   console.error('✗ docs/index.html 펌웨어 표 모델 축(bio/x) 검사 실패')
   for (const f of failures) console.error(`  - ${f}`)
@@ -192,5 +233,6 @@ if (failures.length > 0) {
 console.log(
   `✓ docs/index.html 펌웨어 모델 축 — FWREQ ${fwreqCells}행(체인 ${Object.keys(fwreq).length}) · ` +
     `MATRIX ${matrixChecked}행 검사 / ${matrixSkipped}행 skip(fw 미지정) · ` +
-    `Requirements 블록 ${reqBlocks.length} · Support Matrix 헤더 ${matrixHeaders.length}`,
+    `Requirements 블록 ${reqBlocks.length} · Support Matrix 헤더 ${matrixHeaders.length} · ` +
+    `injectFwReq 렌더 ${rendererChecked}/2 (EN·KO)`,
 )

--- a/src/sign/types.ts
+++ b/src/sign/types.ts
@@ -249,8 +249,13 @@ export interface DeviceInfoPayload {
  * 컴파일 타임 계약 고정 — `deviceId` / `version` / `deviceModel` 이 wire 키다.
  *
  * `tsconfig.json` 의 `include` 는 `src/**` 뿐이라 `tests/**` 는 `tsc` 가 보지 않고,
- * 단위 테스트도 babel-jest 라 타입 주석이 지워진다(크로스 리뷰 지적). 따라서 이름이 되돌아가는
- * 회귀는 **여기서만** 컴파일 에러로 잡힌다. 필드명을 v1 이름으로 되돌리면 이 선언이 깨진다.
+ * 단위 테스트도 babel-jest 라 타입 주석이 지워진다(크로스 리뷰 지적).
+ *
+ * ⚠️ 이 선언이 잡는 범위 (실측, 크로스 리뷰 R1):
+ *  - **부분 rename** — 인터페이스 필드만 바꾸고 이 리터럴을 그대로 두면 `TS2561` 로 잡힌다.
+ *  - **일관 rename** — 인터페이스와 이 리터럴을 **함께** 바꾸면 `yarn tsc` 는 exit 0 이다.
+ *    그 회귀는 `T-U-DEVMODEL-01`(tests/unit/v2/sign/info.test.ts)이 이 파일의 소스를 직접 읽어
+ *    `deviceModel` 키 존재를 단언하는 것으로 잡는다. 둘은 짝이며 어느 한쪽만으로는 부족하다.
  */
 const _deviceInfoWireKeyContract: DeviceInfoPayload = { deviceId: '', version: '', deviceModel: '' }
 void _deviceInfoWireKeyContract

--- a/src/sign/types.ts
+++ b/src/sign/types.ts
@@ -226,15 +226,32 @@ export interface DeviceInfoPayload {
   connectType?: 'usb' | 'ble'
   /** 디바이스 부착 여부 */
   isAttached?: boolean
+  /**
+   * 연결된 하드웨어 모델 식별자 (m09-04-28).
+   *
+   * - `'DCENT-X'` — DCENT X (펌웨어 1.x 라인)
+   * - `undefined` — D'CENT Biometric Wallet(V1, 펌웨어 1.x~2.x 라인) 또는 모델을 보고하지 않는 옛 bridge
+   *
+   * NOTE(decision-anchor: dcentx-model-id-naming): 값 표기를 wm(`BleDeviceModel`,
+   * `hw/ble-device-configs.ts`)의 `'DCENT-X'`(하이픈)에 맞춘다 — 모바일 앱의
+   * `'BIO' | 'DCENT_X'`(언더바)와 **일부러 다르다**. 웹 SDK의 모델 값은 wm transport가
+   * 그대로 흘려보내는 값이고, 중간에서 재매핑하면 (a) wm이 모델을 추가할 때마다 매핑
+   * 테이블이 drift하고 (b) 매핑 누락 시 알 수 없는 모델이 조용히 `undefined`(=Biometric)로
+   * 접혀 **X에 Biometric 게이트가 적용되는 오판**이 생긴다. 모바일과 통일하려고 이 값을
+   * `'DCENT_X'`로 바꾸지 말 것 (2026-08-07 사용자 결정).
+   *
+   * connector는 이 값을 **relay만** 한다 — 판정(게이트/캐퍼빌리티)은 bridge 소관이다.
+   */
+  deviceModel?: string
 }
 
 /**
- * 컴파일 타임 계약 고정 — `deviceId` / `version` 이 wire 키다.
+ * 컴파일 타임 계약 고정 — `deviceId` / `version` / `deviceModel` 이 wire 키다.
  *
  * `tsconfig.json` 의 `include` 는 `src/**` 뿐이라 `tests/**` 는 `tsc` 가 보지 않고,
  * 단위 테스트도 babel-jest 라 타입 주석이 지워진다(크로스 리뷰 지적). 따라서 이름이 되돌아가는
  * 회귀는 **여기서만** 컴파일 에러로 잡힌다. 필드명을 v1 이름으로 되돌리면 이 선언이 깨진다.
  */
-const _deviceInfoWireKeyContract: DeviceInfoPayload = { deviceId: '', version: '' }
+const _deviceInfoWireKeyContract: DeviceInfoPayload = { deviceId: '', version: '', deviceModel: '' }
 void _deviceInfoWireKeyContract
 /* eslint-enable camelcase */

--- a/tests/unit/v2/sign/info.test.ts
+++ b/tests/unit/v2/sign/info.test.ts
@@ -16,6 +16,9 @@
  *    맞춰 default-generic을 쓰는 info()로 대상 변경.)
  */
 
+import { readFileSync } from 'fs'
+import { resolve as resolvePath } from 'path'
+
 import { info, getDeviceInfo, getAccountInfo } from '../../../../src/sign/info'
 import type { DeviceInfoPayload } from '../../../../src/sign/types'
 import { ensureSingleton, _resetForTesting } from '../../../../src/singleton'
@@ -111,6 +114,7 @@ describe('T-U-TYPE-* — DeviceInfoPayload / V1Response generic 타입 계약', 
         ksm_version: 'v1.0',
         state: 'initialised',
         isAttached: true,
+        deviceModel: 'DCENT-X',
       },
     })
     const resp = await getDeviceInfo()
@@ -124,6 +128,7 @@ describe('T-U-TYPE-* — DeviceInfoPayload / V1Response generic 타입 계약', 
     expect(resp.body.parameter?.ksm_version).toBe('v1.0')
     expect(resp.body.parameter?.state).toBe('initialised')
     expect(resp.body.parameter?.isAttached).toBe(true)
+    expect(resp.body.parameter?.deviceModel).toBe('DCENT-X')
   })
 
   test('T-U-TYPE-03: V1Response generic default — 타입 인자 없는 호출자(info())는 Record<string,unknown>', async () => {
@@ -135,5 +140,55 @@ describe('T-U-TYPE-* — DeviceInfoPayload / V1Response generic 타입 계약', 
     // info()는 V1Response(default generic)을 반환 — 임의 키 접근 가능
     const resp = await info()
     expect(resp.body.parameter?.foo).toBe('bar')
+  })
+})
+
+// ── T-U-DEVMODEL-* — deviceModel(모델 축) relay 계약 (m09-04-28) ────────────────
+// connector 는 모델을 **판정하지 않고 relay 만** 한다. 값을 채우는 것은 bridge(m13-02-10).
+describe('T-U-DEVMODEL-* — DeviceInfoPayload.deviceModel relay 계약', () => {
+  test('T-U-DEVMODEL-01: _deviceInfoWireKeyContract 가 deviceModel 을 wire 키로 고정', () => {
+    // babel-jest 는 타입을 지우므로 아래 할당은 문서화 + 런타임 스모크다.
+    const payload: DeviceInfoPayload = { deviceId: 'D1', version: '1.0.0', deviceModel: 'DCENT-X' }
+    expect(payload.deviceModel).toBe('DCENT-X')
+
+    // 진짜 compile-time 강제는 `yarn tsc`(include=src) 가 보는 src/sign/types.ts 의
+    // `_deviceInfoWireKeyContract` 다. 그 선언에서 키가 빠지면 여기서도 잡히도록 소스를 직접 읽는다
+    // (필드를 지우면 이 단언이 실패 → discriminating-test-required).
+    const src = readFileSync(resolvePath(__dirname, '../../../../src/sign/types.ts'), 'utf8')
+    const contract = /const _deviceInfoWireKeyContract: DeviceInfoPayload = \{([^}]*)\}/.exec(src)
+    expect(contract).not.toBeNull()
+    expect(contract?.[1]).toContain('deviceModel')
+    // 모델 값 표기 결정(하이픈 'DCENT-X')의 앵커 주석이 사라지지 않았는지도 함께 고정
+    expect(src).toContain('NOTE(decision-anchor: dcentx-model-id-naming)')
+  })
+
+  test('T-U-DEVMODEL-02: bridge 가 deviceModel 을 보내면 dApp payload 에 그대로 실린다', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r-model',
+      result: { deviceId: 'D-X-1', version: '1.0.0', deviceModel: 'DCENT-X' },
+    })
+
+    const resp = await getDeviceInfo()
+
+    // 재매핑 금지 — wm 표기('DCENT-X', 하이픈)가 그대로 dApp 까지 간다
+    expect(resp.body.parameter?.deviceModel).toBe('DCENT-X')
+    expect(resp.body.parameter?.version).toBe('1.0.0')
+  })
+
+  test('T-U-DEVMODEL-03: 옛 bridge(deviceModel 부재) 도 throw 없이 나머지 필드가 전달된다', async () => {
+    const { transport } = ensureSingleton()
+    jest.spyOn(transport, 'send').mockResolvedValue({
+      id: 'r-nomodel',
+      result: { deviceId: 'D-BIO-1', version: '2.35.0', label: 'bio' },
+    })
+
+    const resp = await getDeviceInfo()
+
+    expect(resp.header.status).toBe('success')
+    expect(resp.body.parameter?.deviceModel).toBeUndefined()
+    expect(resp.body.parameter?.deviceId).toBe('D-BIO-1')
+    expect(resp.body.parameter?.version).toBe('2.35.0')
+    expect(resp.body.parameter?.label).toBe('bio')
   })
 })


### PR DESCRIPTION
## Summary

DCENT X(펌웨어 `1.0.0`) 출시에 맞춰 connector의 **공개 타입과 개발자 문서**를 "단일 펌웨어
버전 라인(2.x)" 전제에서 **2모델 축**(`D'CENT Biometric Wallet` / `DCENT X`)으로 전환한다.
현재 문서의 최소 펌웨어 표는 전부 V1 라인 값이라, X 사용자가 보면 "내 펌웨어 1.0.0인데
2.35.0이 필요하네 → 못 쓰는구나"로 오해한다.

## Objective

- **ID**: `m09-04-28-connector-dcentx-model-axis-and-docs`
- **Jira**: [DC-3889](https://iotrust.atlassian.net/browse/DC-3889)
- **Epic**: `m09-04` (base = `epic/DC-2223_m09-04-connector-v2-cleanup`)
- **File**: `objectives/m09-04-28-...md` (부모 리포 — 자식 리포 리뷰어는 접근 불가, 하단에 전문 embed)

## Scope

- `src/sign/types.ts`의 `DeviceInfoPayload`에 optional `deviceModel` 필드 추가 (+ 컴파일 타임 계약 고정)
- `docs/index.html`의 `window.FWREQ` 값 구조를 모델별 2컬럼(`{bio, x}`)으로 전환 (25개 체인)
- `docs/index.html`의 `window.MATRIX` 각 행 `fw:`를 모델별 2컬럼으로 전환 + Support Matrix 렌더 갱신
- `injectFwReq()` 렌더러를 2모델 표로 변경 (EN/KO lead 문구 포함)
- 하드코딩 Requirements 표 4곳(EN 2 / KO 2)을 2모델 표로 갱신
- `window.FWNOTE` 8건에 "Biometric Wallet 기준" 명시
- 신규 검증 스크립트 `scripts/check-index-html-fw-models.mjs` + `check:docs` 배선
- 결정 근거 앵커 주석 2곳 삽입 (`decision-anchor-comment` 룰)

## Non-scope

- **bridge의 게이트/배선 변경** — [[m13-02-10-bridge-dcentx-capability-model-axis]]가 담당.
  본 objective는 `deviceModel`을 **타입으로 수용**만 하고, 그 값을 실제로 채우는 것은 bridge다
  (optional 필드라 race-safe — 옛 bridge 응답에서는 `undefined`).
- **`genuineState` / `onboardingStep` 필드 문서 동기화 + USB 승인 게이트 에러 코드 카탈로그** —
  [[b13-01-connector-docs-sync-dcentx-fields]]가 담당. 같은 `docs/index.html`을 건드리지만
  **축이 다르다**(그쪽은 응답 필드 + 에러 코드, 이쪽은 펌웨어 버전 표).
- **외부 리포 `github.com/DcentWallet/info`의 `firmwareVersion.md`** — 본 문서 표의 출처이며
  거기에도 모델 축이 필요하나 워크스페이스 밖이라 협의 항목으로 남긴다 (§10 참고).
- **X 전용 신규 메서드/체인 추가** — X 1.0.0은 기존 기능을 전부 내장한다는 전제이므로 이번엔
  값만 채운다. X 전용 기능이 생기면 그때 `bio: NOT_SUPPORT` 행을 추가한다.
- **connector 런타임 로직 변경** — connector에는 펌웨어 게이트가 없다(전부 bridge 소관).
  `getDeviceInfo` 응답은 shape-agnostic하게 relay되므로 relay 코드 변경 0건.

## Automated Verification

`uap-verify-objective` **PASS** — 8/8 명령 exit 0, T-XX 9/9 PASS (UNCOVERED·BLOCKED·ORPHAN 0).

baseline-checks (CI `build-and-test.yml`와 동일 조합) 로컬 선행 실행 결과:

| check | 결과 |
|---|---|
| `yarn lint` | ✅ exit 0 |
| `yarn check:docs` | ✅ exit 0 (신규 `check:index-fw-models` 포함) |
| `yarn build` | ✅ exit 0 |
| `yarn unit-v2` | ✅ 37 suites / **765 tests** (기존 762 + 신규 3) |
| `yarn unit-mock` | ✅ 11 suites / 69 tests |

신규 게이트 출력:

```
✓ docs/index.html 펌웨어 모델 축 — FWREQ 60행(체인 25) · MATRIX 27행 검사 / 11행 skip(fw 미지정)
  · Requirements 블록 4 · Support Matrix 헤더 2 · injectFwReq 렌더 2/2 (EN·KO)
```

## Mutation Matrix (게이트 검출력 증명)

이 PR은 **문서 게이트를 새로 만든다** — 게이트가 실제로 위반을 잡는지 뮤테이션으로 증명했다
(`review-finding-class-closure` §3: "고쳤다"가 아니라 "되돌리면 잡힌다"가 증거).

| 축 | 뮤테이션 | 검출 |
|---|---|---|
| (a) FWREQ | `x` 키 제거 / `bio` 키 제거 | ✅ ✅ |
| (b) MATRIX | `fw.x` 제거 | ✅ |
| (c) Requirements | 카드 EN/KO · thead EN/KO 에서 `DCENT X` 제거 (4종) | ✅ ×4 |
| (d) Support Matrix | `Min FW · DCENT X` 헤더 EN/KO 제거 | ✅ ✅ |
| (e) 동적 렌더러 | `xh=''` / `bh=''` / 상수는 두고 사용만 끊기 / 표 미주입 / KO leg 전용 | ✅ ×5 |

**축 (e)는 리뷰 중 발견된 갭이다.** 초판 게이트는 (a)~(d)만 검사했는데, `injectFwReq`의 헤더 상수
`xh`가 비면 **FWREQ를 가진 25개 체인 페이지 전부**에서 X 컬럼 헤더가 사라지는데도 통과했다.
하드코딩 4블록보다 노출 면적이 큰 표면이 무방비였다 → 렌더러를 **실제 호출**해 `<thead>`를
단언하도록 추가(소스 문자열 검사는 "상수는 남고 사용만 끊긴" 경우를 못 잡는다).

## T-XX Coverage

9/9 PASS — T-U-DEVMODEL-01~03 (타입 계약 / relay / backward-compat),
T-DOC-MODEL-01~04 (FWREQ / MATRIX / EN·KO 4블록 / 뮤테이션 검출), T-DOC-SYNC-01, T-R-ANCHOR-01.

## Implementation Engine

이 PR은 `uap-execute-objective`(uap-native 엔진)로 실행되었으며, objective §4 기반 unit 리스트를
unit 단위로 구현/테스트/커밋하고 Unit Coverage Check를 통과했습니다.

## Review Gate

이 리포는 `claude-review.yml`이 없어 **로컬 Codex ↔ Claude 크로스 리뷰**가 게이트입니다
(`review-gate-by-repo`). 결과는 별도 코멘트로 기록됩니다.

## Checklist

- [x] Automated verification (`uap-verify-objective` PASS)
- [x] 구현 엔진 게이트 PASS (Unit Coverage Check)
- [x] baseline-checks 5종 로컬 통과 (CI 동일 조합)
- [x] 게이트 뮤테이션 검출력 증명 (14종)
- [ ] CI 통과 (PR 생성 후 확인)
- [ ] 로컬 크로스 리뷰 합의
- [ ] 사람 머지

---

## 상세 자료 (전문)

<details>
<summary><b>📄 Full Objective Specification</b></summary>

---
id: m09-04-28-connector-dcentx-model-axis-and-docs
status: IN_PROGRESS
type: feature
target-repo: dcent-web-connector
cycle: 09
epic: m09-04
base-branch: epic/DC-2223_m09-04-connector-v2-cleanup
depends-on: []
related:
  - m13-02-10-bridge-dcentx-capability-model-axis
  - b13-01-connector-docs-sync-dcentx-fields
  - m13-02-00-bridge-device-connection-and-genuine-check
source: ['ad-hoc']

jira: DC-3889
branch: DC-3889_m09-04-28-connector-dcentx-model-axis-and-docs
base-ref: origin/epic/DC-2223_m09-04-connector-v2-cleanup
base-ref-commit: 4f5c4f68dbfd7c2e547bef37c70a0b6a3064d87f
story-point: 5
reviewers: [kekim-iotrust, hyochulan-iotrust]  # epic child — PR에는 지정하지 않음 (feedback-epic-child-no-reviewers)

in_progress_since: 2026-08-07 14:46 KST
pr:
pr_number:
merged_to_epic_at:
---

## 1. 목적

DCENT X(펌웨어 `1.0.0`) 출시에 맞춰 connector의 **공개 타입과 개발자 문서**를 "단일 펌웨어
버전 라인(2.x)" 전제에서 **2모델 축**(`D'CENT Biometric Wallet` / `DCENT X`)으로 전환한다.
현재 문서의 최소 펌웨어 표는 전부 V1 라인 값이라, X 사용자가 보면 "내 펌웨어 1.0.0인데
2.35.0이 필요하네 → 못 쓰는구나"로 오해한다.

## 2. 스코프

- `src/sign/types.ts`의 `DeviceInfoPayload`에 optional `deviceModel` 필드 추가 (+ 컴파일 타임 계약 고정)
- `docs/index.html`의 `window.FWREQ` 값 구조를 모델별 2컬럼(`{bio, x}`)으로 전환 (25개 체인)
- `docs/index.html`의 `window.MATRIX` 각 행 `fw:`를 모델별 2컬럼으로 전환 + Support Matrix 렌더 갱신
- `injectFwReq()` 렌더러를 2모델 표로 변경 (EN/KO lead 문구 포함)
- 하드코딩 Requirements 표 4곳(EN 2 / KO 2)을 2모델 표로 갱신
- `window.FWNOTE` 8건에 "Biometric Wallet 기준" 명시
- 신규 검증 스크립트 `scripts/check-index-html-fw-models.mjs` + `check:docs` 배선
- 결정 근거 앵커 주석 2곳 삽입 (`decision-anchor-comment` 룰)

## 3. 비스코프

- **bridge의 게이트/배선 변경** — [[m13-02-10-bridge-dcentx-capability-model-axis]]가 담당.
  본 objective는 `deviceModel`을 **타입으로 수용**만 하고, 그 값을 실제로 채우는 것은 bridge다
  (optional 필드라 race-safe — 옛 bridge 응답에서는 `undefined`).
- **`genuineState` / `onboardingStep` 필드 문서 동기화 + USB 승인 게이트 에러 코드 카탈로그** —
  [[b13-01-connector-docs-sync-dcentx-fields]]가 담당. 같은 `docs/index.html`을 건드리지만
  **축이 다르다**(그쪽은 응답 필드 + 에러 코드, 이쪽은 펌웨어 버전 표).
- **외부 리포 `github.com/DcentWallet/info`의 `firmwareVersion.md`** — 본 문서 표의 출처이며
  거기에도 모델 축이 필요하나 워크스페이스 밖이라 협의 항목으로 남긴다 (§10 참고).
- **X 전용 신규 메서드/체인 추가** — X 1.0.0은 기존 기능을 전부 내장한다는 전제이므로 이번엔
  값만 채운다. X 전용 기능이 생기면 그때 `bio: NOT_SUPPORT` 행을 추가한다.
- **connector 런타임 로직 변경** — connector에는 펌웨어 게이트가 없다(전부 bridge 소관).
  `getDeviceInfo` 응답은 shape-agnostic하게 relay되므로 relay 코드 변경 0건.

## 4. 상세 설계

### Spec Coverage Matrix

| Spec § | Source ref | Coverage depth | Owner | Layer role | Scope evidence | Tests | Status |
|---|---|---|---|---|---|---|---|
| SPEC-03 | 모델 정보가 dApp까지 전달되는 배선 | infra-only | m09-04-28 (본 objective) | connector-export | `DeviceInfoPayload.deviceModel` 타입 계약 + `_deviceInfoWireKeyContract` 컴파일 가드. 값 생산은 [[m13-02-10-bridge-dcentx-capability-model-axis]] | T-U-DEVMODEL-01, T-U-DEVMODEL-02 | mapped |
| SPEC-04 | 문서 펌웨어 표 2모델 분리 (사용자 결정 2026-08-07) | effect-complete | m09-04-28 (본 objective) | docs | `docs/index.html` 6개 지점 전수 갱신 + `check:docs`에 모델 컬럼 전수 검사 스크립트 배선 | T-DOC-MODEL-01~04, T-DOC-SYNC-01 | mapped |
| SPEC-01 | 버전 라인 교차 비교 제거 | out-of-scope | — | — | connector에 펌웨어 게이트가 없다(실측 grep 0건). bridge 소관 → [[m13-02-10-bridge-dcentx-capability-model-axis]] | — | out-of-scope |
| SPEC-02 | X는 walletconnect 항상 허용 | out-of-scope | — | — | `deviceSupport.ts` 게이트는 bridge 소유 → [[m13-02-10-bridge-dcentx-capability-model-axis]] | — | out-of-scope |
| SPEC-05 | 시뮬레이터에서 X 모델 재현 | out-of-scope | — | — | 시뮬레이터/swproxy는 bridge 소유 → [[m13-02-10-bridge-dcentx-capability-model-axis]] | — | out-of-scope |

> SPEC-03이 `infra-only`인 이유: connector는 `deviceModel`을 **relay만** 한다. dApp이 실제로
> 값을 받는 효과는 bridge가 필드를 채워야 성립하므로 effect owner는 m13-02-10이다. 본 objective는
> "옛 bridge가 안 보내도 타입이 깨지지 않는다"까지가 책임 범위 (race-safe-cross-repo).

### 인터페이스 / 타입

```ts
// src/sign/types.ts — DeviceInfoPayload (기존 203-229행)
export interface DeviceInfoPayload {
  deviceId?: string
  version?: string
  ksm_version?: string
  state?: string
  coin_list?: Array<{ name: string }>
  fingerprint?: { max: number; enrolled: number }
  label?: string
  connectType?: 'usb' | 'ble'
  isAttached?: boolean

  /**
   * (신규) 연결된 하드웨어 모델 식별자.
   *
   * - `'DCENT-X'` — DCENT X (펌웨어 1.x 라인)
   * - `undefined` — D'CENT Biometric Wallet (V1, 펌웨어 1.x~2.x 라인) 또는 모델 미보고 bridge
   *
   * NOTE(decision-anchor: dcentx-model-id-naming): 값 표기를 wm(`BleDeviceModel`,
   * `hw/ble-device-configs.ts`)의 `'DCENT-X'`(하이픈)에 맞춘다 — 모바일 앱의
   * `'BIO' | 'DCENT_X'`(언더바)와 **일부러 다르다**. 웹 SDK의 모델 값은 wm transport가
   * 그대로 흘려보내는 값이고, 중간에서 재매핑하면 (a) wm이 모델을 추가할 때마다 매핑
   * 테이블이 drift하고 (b) 매핑 누락 시 알 수 없는 모델이 조용히 `undefined`(=Biometric)로
   * 접혀 **X에 Biometric 게이트가 적용되는 오판**이 생긴다. 모바일과 통일하려고 이 값을
   * `'DCENT_X'`로 바꾸지 말 것 (2026-08-07 사용자 결정).
   */
  deviceModel?: string
}

/**
 * 컴파일 타임 계약 고정 — 기존 `deviceId`/`version`에 `deviceModel`을 추가한다.
 * 필드명이 사라지거나 이름이 바뀌면 여기서만 컴파일 에러로 잡힌다 (tests/는 tsc가 보지 않음).
 */
const _deviceInfoWireKeyContract: DeviceInfoPayload = {
  deviceId: '',
  version: '',
  deviceModel: '',
}
```

### 데이터 구조

`docs/index.html`의 두 전역 데이터 구조를 모델별 2컬럼으로 전환한다.

**(1) `window.FWREQ`** — 체인 페이지의 Requirements 표 데이터 (663-688행)

```js
// AS-IS — 단일 값 (전부 D'CENT Biometric Wallet 라인)
"chain-cardano":[["getAddress","2.7.0"],["signData","2.35.0"], ...]

// TO-BE — 모델별 2컬럼
"chain-cardano":[
  ["getAddress", {bio:"2.7.0",  x:"1.0.0"}],
  ["signData",   {bio:"2.35.0", x:"1.0.0"}],
  ...
]
```

- 값 규약: `{bio, x}` **두 키 모두 필수**. 누락은 검증 스크립트가 exit 1로 차단
  (모바일 방안 A의 "컬럼 누락 = TS 컴파일 에러"를 JS/HTML 문서에서 재현하는 수단)
- X 초기값: **전 항목 `"1.0.0"`** — X 1.0.0은 기존 기능을 전부 내장한다. **잠정치가 아니라 확정값**이다
  (사용자 확인 2026-08-07). 원본 설계문서 §6이 이를 "미결"로 남긴 것은 모바일 쪽 기준이며, 웹 문서는
  이 확인을 근거로 확정 표기한다 — 따라서 "검증 필요" 배지를 달지 않는다
  (`feedback-docs-must-match-real-behavior`는 *미확인* 값에 적용되는 지시이고, 이 값은 확인됨)
- **출시 전 최종 검증은 별도 게이트**로 존재한다(펌웨어팀, X 출시 직전). 거기서 미지원 항목이
  나오면 그 행만 `x: "NOT_SUPPORTED"` 또는 실제 버전으로 갱신한다 — 본 objective의 DoD가 아니라
  **X 출시 게이트 항목**이다 (`fix-target-justification` 판정 2와 같은 취급)
- 3번째 원소(주석 객체 `{en, ko}`)는 기존 그대로 유지 — 인덱스가 밀리지 않는다
- **규모(실측 2026-08-07)**: 체인 **25개** / 메서드 행 **60개** → 채워야 할 셀 **120개**(bio 60 + x 60).
  3번째 원소(주석 객체)를 가진 행은 3개이며 인덱스가 밀리지 않도록 그대로 둔다

**(2) `window.MATRIX`** — Support Matrix의 `Min FW` 컬럼 (1420행~)

```js
// AS-IS
{n:"Cardano", id:"chain-cardano", ..., fw:"2.7.0"}

// TO-BE
{n:"Cardano", id:"chain-cardano", ..., fw:{bio:"2.7.0", x:"1.0.0"}}
```

- **규모(실측 2026-08-07, jsdom으로 `window.MATRIX` 직접 읽음)**: MATRIX **38행** 중 `fw` 값을
  가진 행은 **27행** → **전환 대상은 27행**이다. FWREQ 25개 체인은 전부 MATRIX id에 존재하고,
  MATRIX에만 있는 page id는 6개다.
- **`fw` 부재 11행은 손대지 않는다** — 지금도 `fw` 키 자체가 없어 `.m-fw` 셀이 `—`로 렌더된다
  (`docs/index.html:1498` `${r.fw||'—'}`). 2컬럼으로 바꾼 뒤에도 **두 셀 모두 `—`** 로 렌더되면
  되고, 빈 객체 `{bio:"",x:""}`를 억지로 채워 넣지 않는다.
  → 따라서 `check-index-html-fw-models.mjs`의 MATRIX 검사는 **"`fw` 키가 있는 행만"** 대상으로
  하고, `fw` 부재 행은 skip한다. 전 행에 `fw`를 강제하면 지금 통과하는 11행이 곧바로 실패한다.

### 신규 / 수정 파일

**신규**:
- `scripts/check-index-html-fw-models.mjs` — `window.FWREQ` / `window.MATRIX`의 전 항목이
  `{bio, x}` 두 키를 모두 가지는지, 하드코딩 Requirements 블록 4곳 + Support Matrix 헤더 2곳 +
  **동적 렌더러 `injectFwReq`(EN/KO)** 가 2모델 헤더를 가지는지 전수 검사. `check:docs`에 배선. (형제 3종 중 **jsdom 실행** 방식인 `check-index-html-page-refs.mjs`
  패턴을 따름 — 나머지 2종은 순수 문자열 검사라 객체 리터럴 추출의 선례가 아니다)

**수정**:
- `src/sign/types.ts:203-229` — `DeviceInfoPayload`에 `deviceModel?: string` + JSDoc 앵커 주석 추가
- `src/sign/types.ts:238` — `_deviceInfoWireKeyContract`에 `deviceModel: ''` 추가
- `docs/index.html:659-662` — 표 출처 주석에 "모델별 2컬럼" 규약 + `NOTE(decision-anchor: ...)` 명시
- `docs/index.html:663-688` — `window.FWREQ` 25개 체인 값을 `{bio, x}`로 전환
- `docs/index.html:689-698` — `window.FWNOTE` 8건에 "D'CENT Biometric Wallet 기준" 문구 추가 (EN/KO 각각)
- `docs/index.html:700-716` — `injectFwReq()` 렌더러: 표 헤더를 `메서드 | D'CENT Biometric Wallet | DCENT X` 3열로,
  lead 문구를 2모델 서술로 (EN/KO 둘 다 704-706행에 하드코딩되어 있음)
- `docs/index.html:1420~` — `window.MATRIX` 각 행 `fw:` 를 `{bio, x}`로 전환
- `docs/index.html:1498` — `.m-fw` 셀 렌더를 2셀로 분리
- `docs/index.html:1476` (EN) / `:2659` (KO) — Support Matrix `Min FW` 헤더를 2컬럼으로
- `docs/index.html:1479` (EN) / `:2662` (KO) — 하단 note의 "Min FW = ..." 설명을 2모델로
- `docs/index.html:951` (EN) / `:1065` (KO) / `:2129` (EN) / `:2184` (KO) — 하드코딩 Requirements 표 4곳
- `package.json:37` — `check:docs`에 `yarn check:index-fw-models` 추가

### 외부 의존성

없음. 신규 패키지 0건. 검증 스크립트는 Node 내장 모듈만 사용 (기존 `check-index-html-*.mjs` 동일).

### 에러 케이스

| 시나리오 | 처리 |
|---|---|
| `FWREQ` 항목에 `bio` 또는 `x` 키 누락 | 검증 스크립트 exit 1 + 누락 위치(체인 id + 메서드) 출력 — **silent pass 금지** |
| `MATRIX` 행에 `fw.bio` 또는 `fw.x` 누락 | 동일 |
| 하드코딩 Requirements 표에 2모델 헤더 부재 | 동일 (EN/KO 4곳 각각 판정 — 한쪽만 고친 상태를 잡는 것이 이 검사의 핵심) |
| 옛 bridge가 `deviceModel`을 안 보냄 | `undefined` → dApp은 "Biometric 또는 미보고"로 해석. optional이라 타입 에러 없음 (race-safe) |
| bridge가 미지의 모델 문자열을 보냄 | `deviceModel?: string`이라 타입 통과. connector는 relay만 하므로 판정 책임 없음 (판정은 bridge) |

### 코드 주석 (결정 근거 앵커링) — `decision-anchor-comment`

| 결정 요지 | 유형 | 앵커 사이트 | 주석 내용 |
|---|---|---|---|
| 모델 값 표기를 wm의 `'DCENT-X'`(하이픈)로 두고 모바일의 `'DCENT_X'`로 재매핑하지 않는다 | (b) 겉보기 유사 코드의 의도적 분리 | `src/sign/types.ts` → `DeviceInfoPayload.deviceModel` JSDoc | `NOTE(decision-anchor: dcentx-model-id-naming): ... 매핑 누락 시 미지 모델이 조용히 undefined(=Biometric)로 접혀 X에 Biometric 게이트가 적용되는 오판. 모바일과 통일하려고 'DCENT_X'로 바꾸지 말 것.` |
| 펌웨어 표를 단일 컬럼으로 되돌리지 않는다 (X/Biometric 버전 라인은 비교 불가) | (a) 자산/보안 인접 | `docs/index.html:659` `window.FWREQ` 직전 주석 | `NOTE(decision-anchor: dcentx-fw-table-two-columns): 두 모델의 버전 라인(1.x vs 2.x)은 같은 수직선에서 비교할 수 없다. 단일 컬럼으로 합치면 X 사용자에게 "1.0.0 < 2.35.0 → 미지원"으로 읽혀 지원 기능을 안 쓰게 만든다. bio/x 두 키는 항상 함께 유지 — check:index-fw-models가 강제.` |

### 의사 코드 — `scripts/check-index-html-fw-models.mjs`

```js
// 1) jsdom으로 docs/index.html을 **실제 실행**해 window.FWREQ / window.MATRIX를 읽는다.
//    형제 선례: check-index-html-page-refs.mjs (정규식이 아니라 문서 실행 후 window.MATRIX 읽기).
//    MATRIX 값에는 `<span class=tok-acc>` HTML이 섞여 있어(docs/index.html:1420~) 정규식 절단이
//    취약하다. preset-refs / duplicate-keys 2종은 순수 문자열 검사라 이 케이스의 선례가 아니다.
// 2) FWREQ: 모든 체인 × 모든 메서드 행의 r[1]이 객체이고 bio/x 두 키가 non-empty string인지
// 3) MATRIX: **fw 키가 있는 행만** 대상 — fw가 객체이고 bio/x 두 키가 non-empty string인지.
//    fw 부재 행(11건)은 skip (전 행 강제 시 현재 통과 중인 11행이 곧바로 실패)
// 4) 하드코딩 Requirements 블록: `<h2>Requirements</h2>` / `<h2>요구사항</h2>` 4개 블록 각각에 대해
//    'D'CENT Biometric Wallet' 와 'DCENT X' 가 둘 다 등장하는지
//    ⚠️ 실측 정정(2026-08-07): 4곳이 전부 <thead> 표는 아니다 — overview EN/KO 는 `.reqs` 카드,
//       getPublicKey EN/KO 만 <thead> 표다. 그리고 **블록 단위 containment 만으로는 부족**하다
//       (표 헤더에서 X 컬럼만 지워도 lead 문단에 이름이 남아 통과). 그래서 **조각 단위**로 본다:
//       <thead> 는 두 이름 필수, `.rq` 카드는 "한 모델만 언급하는 상태" 금지
// 5) Support Matrix 헤더: `Min FW` 컬럼을 가진 표(EN/KO 2곳)에 모델별 컬럼 2개가 있는지
//    (`table class="matrix"` 는 EVM/Cosmos/Substrate 목록 표도 쓰므로 `Min FW` 보유 표로 한정)
// 6) **동적 렌더러 injectFwReq (최대 노출 표면)**: FWREQ 를 가진 25개 체인 페이지 전부의 표 헤더를
//    이 렌더러 하나가 만든다. `.method-chips` 를 가진 합성 root 에 `injectFwReq(root, chainId, ko)` 를
//    **EN/KO 각각 실제 호출**해, 주입된 `table.params > thead` 에 두 모델 이름이 있는지 단언한다.
//    (소스 문자열 검사보다 강하다 — 상수만 남고 실제 사용이 끊겨도 잡힌다. 표가 안 나오면 fail-closed)
// 7) 위반 목록을 stderr로 출력하고 exit 1, 전부 통과면 exit 0
```

## 5. Pre-Plan 체크리스트

- [ ] `docs/index.html`의 `window.FWREQ` / `window.MATRIX` 라인 번호가 여전히 유효한지 재확인
      (같은 epic의 다른 child가 `docs/index.html`을 건드려 밀렸을 수 있음)
- [ ] [[b13-01-connector-docs-sync-dcentx-fields]]가 먼저 착수됐는지 확인 — 같은 파일을 건드리므로
      충돌 시 병합 순서 조율 (축은 다르나 파일은 같다)
- [ ] `main-repos/dcent-web-connector`의 base가 `epic/DC-2223_m09-04-connector-v2-cleanup`인지 확인
      (`origin/master`에는 `docs/`도 `DeviceInfoPayload`도 없다 — 2026-08-07 실측)
- [ ] X 값은 확정(`1.0.0`)이므로 착수 게이트가 아니다. 다만 **출시 전 최종 검증 결과**가 이미
      나왔다면 미지원 항목이 있는지만 확인해 해당 행에 반영 (없으면 그대로 진행)

## 6. 산출물

- **코드**: `src/sign/types.ts` (타입 + 컴파일 계약), `scripts/check-index-html-fw-models.mjs` (신규)
- **문서**: `docs/index.html` (6개 지점, EN/KO 양쪽)
- **배선**: `package.json`의 `check:docs`
- **테스트**: `tests/unit/v2/sign/` 하위 타입/relay 테스트

## 7. 테스트 항목 (회귀 방지)

### Unit (Jest, v2)

- [ ] T-U-DEVMODEL-01: `DeviceInfoPayload`에 `deviceModel` 필드 존재 — `_deviceInfoWireKeyContract`가
      `deviceModel: ''`를 포함한 채 컴파일 (필드 제거/개명 시 `tsc` 실패)
- [ ] T-U-DEVMODEL-02: `getDeviceInfo` 응답 relay — bridge가 `deviceModel: 'DCENT-X'`를 보내면
      dApp이 받는 payload에 그대로 실린다 (mock 왕복)
- [ ] T-U-DEVMODEL-03: `deviceModel` 부재(옛 bridge) — payload에 `deviceModel`이 없어도 relay가
      throw하지 않고 나머지 필드가 정상 전달된다 (race-safe backward-compat)

### Docs (검증 스크립트)

- [ ] T-DOC-MODEL-01: `window.FWREQ` 전 항목(**25체인 × 60행**)이 `{bio, x}` 두 키 보유 —
      한 항목이라도 누락 시 exit 1
- [ ] T-DOC-MODEL-02: `window.MATRIX`에서 **`fw` 키를 가진 행(27/38)** 의 `fw`가 `{bio, x}` 두 키 보유.
      `fw` 부재 11행은 **skip**(지금도 `—`로 렌더되며 전 행 강제 시 즉시 실패한다)
- [ ] T-DOC-MODEL-03: 2모델 헤더를 만드는 **모든 지점**이 두 모델 이름을 보유 —
      **EN만 고치고 KO를 빠뜨린 상태를 잡는 것이 이 케이스의 목적**. 원소 3축:
      (1) 하드코딩 Requirements 블록 **4곳**(overview EN/KO는 `.reqs` 카드, getPublicKey EN/KO는 `<thead>` 표)
      (2) Support Matrix `Min FW` 헤더 **2곳**(EN/KO)
      (3) **동적 렌더러 `injectFwReq`**(EN/KO 2분기) — FWREQ를 가진 **25개 체인 페이지 전부**의 표 헤더를
      만드는 최대 노출 표면. 렌더러를 **실제 호출**해 나온 `<thead>`를 단언한다(소스 문자열 검사보다 강함 —
      상수만 남고 사용이 끊긴 경우까지 잡힌다)
- [ ] T-DOC-MODEL-04: 뮤테이션 검출 — `FWREQ` 임의 1항목의 `x` 키를 지우면 스크립트가 exit 1
      (검사가 실제로 판별하는지 증명. `review-finding-class-closure` §3)
- [ ] T-DOC-SYNC-01: `yarn check:docs` 전체 통과 (기존 6종 + 신규 1종)

### Decision Anchor

- [ ] T-R-ANCHOR-01: `src/sign/types.ts`에 `NOTE(decision-anchor: dcentx-model-id-naming)`,
      `docs/index.html`에 `NOTE(decision-anchor: dcentx-fw-table-two-columns)` 주석 존재

## 8. 자동 검증 명령

### 실행 환경

- cwd: `main-repos/dcent-web-connector`
- 전제조건: `yarn install` 완료, 브랜치가 `epic/DC-2223_m09-04-connector-v2-cleanup` 기반

### 명령 목록

1. `yarn unit-v2`
   - **검증**: T-U-DEVMODEL-01, T-U-DEVMODEL-02, T-U-DEVMODEL-03
   - **기대**: exit 0, 전체 passed (기존 v2 단위 테스트 회귀 0 포함)
   - **주의**: `unit-v2` 스크립트가 이미 `tests/unit/v2`를 인자로 갖고 있어 경로를 덧붙이지 않는다

2. `node scripts/check-index-html-fw-models.mjs`
   - **검증**: T-DOC-MODEL-01, T-DOC-MODEL-02, T-DOC-MODEL-03
   - **기대**: exit 0, 위반 0건

3. `cp docs/index.html /tmp/idx.bak && python3 - <<'PY'
import re,io
p='docs/index.html'
s=io.open(p,encoding='utf-8').read()
s2,n=re.subn(r'\{bio:"([^"]+)",\s*x:"[^"]+"\}', r'{bio:"\1"}', s, count=1)
assert n==1, 'mutation anchor not found'
io.open(p,'w',encoding='utf-8').write(s2)
PY
! node scripts/check-index-html-fw-models.mjs; RC=$?; cp /tmp/idx.bak docs/index.html; test $RC -eq 0`
   - **검증**: T-DOC-MODEL-04 (뮤테이션 검출 — `x` 키를 지우면 검사가 실패해야 한다)
   - **기대**: exit 0 (= 스크립트가 뮤테이션을 잡았고 원본 복구 완료)
   - **주의**: bash escaping 사고를 피하려 python heredoc 사용 (`project_wm-1468-...` 선례)

4. `yarn check:docs`
   - **검증**: T-DOC-SYNC-01 (`docs-payload-fidelity` 룰)
   - **기대**: exit 0

5. `for f in src/sign/types.ts docs/index.html; do grep -Fq 'NOTE(decision-anchor:' "$f" || { echo "MISSING ANCHOR: $f"; exit 1; }; done`
   - **검증**: T-R-ANCHOR-01
   - **기대**: exit 0

6. `yarn tsc`
   - **검증**: 타입 안정성 (`DeviceInfoPayload` 계약 포함)
   - **기대**: exit 0 (baseline tsc 에러 0건 — 2026-08-07 실측)

7. `yarn lint`
   - **검증**: 코드 컨벤션
   - **기대**: exit 0

8. `git diff --stat origin/epic/DC-2223_m09-04-connector-v2-cleanup...HEAD -- ':!*.test.*' ':!*__fixtures__*' ':!*.snap' | tail -1`
   - **검증**: DoD 정량 기준 — diff < 600 LOC (테스트/fixture/snapshot 제외)
   - **기대**: 변경 LOC 합계가 600 미만
   - **주의**: `uap-prepare-objective` C13이 자동 시드한 명령 (2026-08-07)

## 9. Definition of Done

- [ ] 스코프 항목 모두 구현
- [ ] 테스트 항목 T-XX 모두 작성 + 통과 (T-U-DEVMODEL-01~03, T-DOC-MODEL-01~04, T-DOC-SYNC-01, T-R-ANCHOR-01)
- [ ] 결정 근거 앵커 주석 2곳 삽입 확인 — `NOTE(decision-anchor: ...)` 마커 + 금지 행동 포함
- [ ] `yarn tsc` 통과 (exit 0)
- [ ] `yarn lint` 통과
- [ ] `yarn check:docs` 통과 (신규 `check:index-fw-models` 포함)
- [ ] EN/KO 양쪽 커버리지는 **T-DOC-MODEL-03이 게이트**다 (4곳 전수 자동 검사).
      브라우저 육안 확인은 **비게이트 보조 단계** — 자동 검사가 통과한 뒤 렌더 결과를 한 번 훑는
      용도이며, 이것이 판정 근거가 되지는 않는다 (`automated-verification-required`).
      배경: m13-02에서 KO 수정이 중복 키에 가려 사용자에게 안 보인 사고가 있었고, 그때도 **자동
      검사(중복 키 검출)가 없었던 것**이 원인이었다
- [ ] PR 생성 (단일 PR, diff < 600 LOC)
- [ ] PR description에 objective ID, Jira 티켓, 자동 검증 결과 첨부
- [ ] Epic child이므로 **reviewer 미지정** (`feedback-epic-child-no-reviewers`)

## 10. 참고

- **Source**: 모바일 설계문서 `device-model-capability-structure.md` (2026-08-07, 방안 A 확정 —
  `RequiredDeviceVersion`의 값 타입을 모델별 컬럼으로 확장). 본 objective는 그 결정의 **웹 SDK 문서 축** 대응.
- **사용자 결정 (2026-08-07)**:
  - DCENT X는 **v2 bridge만 지원** — v1 bridge(`origin/master`)는 대상 아님
  - X의 `coin_list`는 정상 보고되고 거기에 `walletconnect` 항목만 없다 → X는 WC 항상 허용 (bridge 소관)
  - 모델 ID 네이밍은 **wm 방식** `'DCENT-X'`(하이픈). 모바일의 `BIO`/`DCENT_X`와 갈리는 것을 인지한 결정
  - 문서는 `D'CENT Biometric Wallet` / `DCENT X` 2모델로 분리, X 값은 전 항목 `1.0.0`
- **실측 근거 (2026-08-07)**:
  - connector에 펌웨어 게이트 **0건** — 전부 bridge 소관 (`grep -E "fwVersion|semver|compareVersion" src/` 무매치)
  - `docs/index.html`에 2.x 리터럴 **111건**
  - `origin/master`에는 `docs/`도 `DeviceInfoPayload`도 **없다** — 둘 다 `epic/DC-2223_m09-04`에만 존재
  - connector baseline `yarn tsc` 에러 **0건**
- **협의 항목 (워크스페이스 밖)**: 표의 출처인 `github.com/DcentWallet/info`의 `firmwareVersion.md`도
  모델 축이 필요하다. 그쪽이 갱신되기 전까지 본 문서의 X 값은 "X 1.0.0 = 전 기능 내장" 전제로 채운다.
- **관련 objective**: [[m13-02-10-bridge-dcentx-capability-model-axis]] (짝 — bridge 게이트/배선),
  [[b13-01-connector-docs-sync-dcentx-fields]] (같은 파일, 다른 축),
  [[m13-02-00-bridge-device-connection-and-genuine-check]] (X 기기 지원 epic)
- **적용 룰**:
  - `objectives-doc-format` — 문서 형식
  - `automated-verification-required` — connector "타입/문서만 변경" + "`type/` 변경" 조합
  - `objective-pr-granularity` — 1 objective = 1 PR
  - `cross-repo-interface-edit` — `DeviceInfoPayload`는 dApp이 의존하는 공개 타입. 필드 **추가**라
    backward-compatible → 단일 리포 PR로 진행 (룰의 "있고, backward-compatible" 분기)
  - `docs-payload-fidelity` — `docs/index.html` 변경 → `check:docs` 필수
  - `decision-anchor-comment` — 앵커 주석 2곳
  - `no-version-bump` — `package.json`의 `version` 필드 수정 금지 (`scripts`만 수정)
  - `objective-no-auto-merge` — epic child → epic branch 머지만 AI 허용

## RE-AUDIT-LOG

### 2026-08-07 — 게이트 갭 1건 (독립 뮤테이션 검증에서 발견, 닫음)

- **발견**: `check-index-html-fw-models.mjs`의 축 (a)~(d)는 검출력이 확인됐으나, `injectFwReq`의
  헤더 상수(`bh` / `xh`)는 무방비였다. `xh=''`로 바꿔도 게이트가 exit 0.
- **왜 중요한가**: 이 상수 하나가 **FWREQ를 가진 25개 체인 페이지 전부**의 Requirements 표 헤더를
  만든다 — 가드되던 하드코딩 4블록(overview 2 + getPublicKey 2)보다 노출 면적이 훨씬 크다.
- **클래스와 원소** (`review-finding-class-closure`): 클래스는 "2모델 헤더가 사라지면 잡힌다",
  원소는 **하드코딩 4 + Support Matrix 2 + 렌더러 1 = 7개**. 7번째가 안 닫혀 있었다.
- **조치**: 축 **(e) 동적 렌더러**를 게이트에 추가. `.method-chips`를 가진 합성 root에
  `injectFwReq(root, chainId, ko)`를 **EN/KO 각각 실제 호출**해 주입된 `<thead>`를 단언한다
  (표가 안 나오면 fail-closed). 반영 지점: §4 의사 코드 4~7번, §7 T-DOC-MODEL-03.
- **뮤테이션 자가 검증 14/14 검출**: (e) `xh=''` / `bh=''` / `<th>${xh}</th>` 제거 /
  `table.params`→`table.nope` / `xh=ko?'':'DCENT X'`(KO 분기 전용) + 기존 (a)~(d) 9종 회귀.
  모든 뮤테이션은 앵커 치환 여부(no-op 아님)를 assert로 함께 확인했다.

<!-- AUTO-ENRICHED:BEGIN -->
## Auto-enriched

_prepare-objective가 생성. 매 실행마다 이 블록은 regenerate된다. 이 블록 바깥은 건드리지 않는다._

**Generated**: 2026-08-07 KST
**Tool**: uap-prepare-objective v1
**Sources**: git history, cross-repo callers, test inventory

---

### Git History Context

#### src/sign/types.ts
- **Recent commits** (origin/epic/DC-2223_m09-04-connector-v2-cleanup, 최근 5개):
  - `e71a881` 2026-08-07 hjkim-iotrust: [DC-2223] feat(sync-account): 토큰을 서명 경로와 같은 descriptor 로 기술 + 식별자 검증 완화
  - `43a1857` 2026-07-23 hjkim-iotrust: [no-ticker] feat(sync): syncAccount 에 meta.addressFormat 통과 (BTC variant)
  - `2838a33` 2026-07-21 hjkim-iotrust: [DC-2223] fix(sdk-contract): getDeviceInfo 타입을 wire 키로 통일 + TRON form-D preset 필수 필드
  - `8ca2dbc` 2026-06-30 김현정(Hyunjung Kim): [DC-2862] m09-04-20: V2AccountMeta addressFormat shape B SYNC + playground 토큰 preset 확장 (#171)
  - `4c71bde` 2026-06-16 hjkim-iotrust: [DC-2700] refactor(sign): remove dead Session deviceId plumbing
- **Blame owners** (최근 1년): hjkim-iotrust 82%, 김현정(Hyunjung Kim) 9%, ke.kim-iotrust 9%
- **Open PRs touching this file**: `#177 [DC-2223] m09-04: connector v2 cleanup (epic → master)` (본 objective의 상위 epic PR)

> ⚠️ `2838a33`이 직전에 이 파일의 `getDeviceInfo` 타입을 **wire 키로 통일**했다. 본 objective의 `deviceModel`도 그 규약(wire 키 원문 유지, 재매핑 금지)과 같은 축이다 — §4 decision-anchor `dcentx-model-id-naming`과 정합.

#### docs/index.html
- **Recent commits** (최근 5개):
  - `a0115b6` 2026-08-07 hjkim-iotrust: [DC-2223] fix(docs-test): T-DOC-01 이 문서를 실제로 파싱하게 (크로스 리뷰 R4)
  - `78e7e3a` 2026-08-07 hjkim-iotrust: [DC-2223] fix(sync-account): 로컬 크로스 리뷰(Codex) 대응 — sanitize 3건 + 문서 중복 블록
  - `e71a881` 2026-08-07 hjkim-iotrust: [DC-2223] feat(sync-account): 토큰을 서명 경로와 같은 descriptor 로 기술 + 식별자 검증 완화
  - `5c7c440` 2026-08-06 hjkim-iotrust: [no-ticker] chore(playground): Horizen(ZEN) 서명 preset 제거 — 네이티브 체인 종료
  - `bcfa552` 2026-08-05 hjkim-iotrust: [DC-2223] docs(polkadot): "Ignored — live 재도출" 표기가 실제로는 거꾸로였던 것 정정
- **Blame owners** (최근 1년): hjkim-iotrust 97%, 김현정(Hyunjung Kim) 3%
- **Open PRs touching this file**: `#177` (epic PR)

> ⚠️ **최근 3일 내 4커밋** — 라인 번호가 밀렸을 가능성이 높다. Pre-Plan L232(라인 번호 재확인)를 착수 첫 단계로 수행할 것. 또한 `5c7c440`이 **Horizen(ZEN) preset을 제거**했으므로, FWREQ/MATRIX의 체인 모수(25/38)가 실측 시점(2026-08-07) 이후로도 유효한지 착수 시 재확인이 필요하다.

#### package.json
- **Recent commits** (최근 5개):
  - `4f5c4f6` 2026-08-07 hjkim-iotrust: [DC-2223] test(docs): 참조 id ↔ 등록 페이지 정합 게이트 신설 (정적 스캔의 오탐/미탐 둘 다 차단)
  - `78e7e3a` 2026-08-07 hjkim-iotrust: [DC-2223] fix(sync-account): 로컬 크로스 리뷰(Codex) 대응 — sanitize 3건 + 문서 중복 블록
  - `7b4e413` 2026-07-28 hjkim-iotrust: [no-ticker] feat(docs): docs/index.html preset 참조 정합성 자동 검증 추가
  - `52880ce` 2026-07-13 hjkim-iotrust: [no-ticker] ci: payload-contract shape 검증 추가 (doc↔preset 필드 대조)
  - `4e0a517` 2026-07-13 hjkim-iotrust: [no-ticker] docs: doc/ → docs/ 통합 + GitHub Pages 호스팅 전환
- **Blame owners** (최근 1년): hjkim-iotrust 59%, 김경은(Kyungeun Kim) 35%, ke.kim-iotrust 6%
- **Open PRs touching this file**: `#177` (epic PR) + dependabot PR 다수(`#187`/`#185`/`#183`/`#182`/`#174`/`#172`/`#170`/`#168`/`#134` — 전부 `dependencies` 블록만 건드리며 `scripts`와 무충돌)

> ℹ️ `check:docs` 체인의 최신 상태(실측 `4f5c4f6`): `lint:md → check:payload-contract → check:payload-shape → check:index-refs → check:index-dup → check:index-pages` **6종**. 본 objective가 `check:index-fw-models`를 7번째로 추가한다.

### Cross-repo Caller Inventory

_이 objective는 interface 파일을 편집하므로 다른 2개 리포에서 해당 심볼을 사용하는 곳을 나열한다 (cross-repo-interface-edit 룰)._

#### Symbol: `DeviceInfoPayload` (from dcent-web-connector)

**Callers in dcent-web-bridge** (0건): `none`

**Callers in dcent-wallet-models** (0건): `none`

> 두 리포 모두 connector의 타입명을 import하지 않는다 (bridge는 자체 `BridgeDeviceModel` 유니온 보유). 따라서 이번 optional 필드 추가는 **cross-repo 동반 PR 불필요** — `cross-repo-interface-edit` 룰의 "있고, backward-compatible" 분기가 아니라 "없음(안전)" 분기에 해당한다. 다만 `deviceModel` **값**의 생산자는 bridge이므로 짝 objective [[m13-02-10-bridge-dcentx-capability-model-axis]]와의 값 표기(`'DCENT-X'`) 일치는 여전히 계약이다.

### Existing Test Inventory

_objective의 "수정" 파일 주변에 이미 존재하는 테스트 자산. 새 T-XX 작성 시 중복 방지 + 패턴 참조용._

#### Tests adjacent to modified files

- `src/sign/types.ts`
  - Test: `tests/unit/v2/sign/info.test.ts` (7 cases) — **`DeviceInfoPayload` 계약 테스트의 기존 홈**
    - `describe('read-only info functions — m08-01-02.5')`
    - `test('T-U-INFO-01: info() → _call({method: "info"})')`
    - `test('T-U-DEVINFO-01: getDeviceInfo() → _call({method: "getDeviceInfo"})')`
    - `test('T-U-ACC-01: getAccountInfo() → _call({method: "getAccountInfo"})')`
    - `describe('T-U-TYPE-* — DeviceInfoPayload / V1Response generic 타입 계약')`
    - `test('T-U-TYPE-01: DeviceInfoPayload — 모든 필드 optional (타입 할당 + 런타임 스모크)')`
    - `test('T-U-TYPE-02: getDeviceInfo() 반환 타입이 V1Response<DeviceInfoPayload>로 narrowed (runtime + 전 필드)')`
    - `test('T-U-TYPE-03: V1Response generic default — 타입 인자 없는 호출자(info())는 Record<string,unknown>')`
  - Test: `tests/unit/v2/types-drift.test.ts` / `tests/unit/v2/types-mutation.test.ts` (enum drift·mutation 축 — `DeviceInfoPayload` 비대상)
- `docs/index.html`
  - `No test file found` (형제 테스트 없음 — 검증은 `scripts/check-index-html-*.mjs` + `yarn check:docs` 경로)
- `package.json`
  - `No test file found`

> 🔑 **T-U-DEVMODEL-01~03의 배치 권고**: `tests/unit/v2/sign/info.test.ts`의 기존 `T-U-TYPE-*` describe 블록이 이미 "`DeviceInfoPayload` 전 필드 optional + 반환 타입 narrowing" 을 박제하고 있다. 특히 `T-U-TYPE-02`가 **전 필드**를 훑으므로, `deviceModel` 추가 시 이 테스트를 함께 갱신하지 않으면 신규 필드가 커버리지 밖에 남는다. 신규 T-U-DEVMODEL-*는 같은 파일에 이어 붙이는 것이 중복 없이 자연스럽다.

#### Related fixtures
- `none` (수정 파일이 import하는 fixture 없음)

#### Related scripts (docs 검증 형제 — 신규 스크립트의 패턴 참조원)
- `scripts/check-index-html-page-refs.mjs` — **jsdom 실행 방식** (§4가 지목한 선례)
- `scripts/check-index-html-duplicate-keys.mjs` — 순수 문자열 검사
- `scripts/check-index-html-preset-refs.mjs` — 순수 문자열 검사
- `scripts/check-payload-contract-coverage.mjs` / `scripts/check-payload-contract-shape.mjs`
- devDependency `jsdom@^15.2.1` 설치 확인됨 ✅

<!-- AUTO-ENRICHED:END -->


</details>

<details>
<summary><b>🔍 Full Verification Report</b></summary>

# Verification Report — m09-04-28-connector-dcentx-model-axis-and-docs

**실행 시각**: 2026-08-07 15:12 KST
**Verdict**: PASS
**Jira**: DC-3889
**Branch**: DC-3889_m09-04-28-connector-dcentx-model-axis-and-docs
**Target Repo**: dcent-web-connector (cwd `main-repos/dcent-web-connector`, yarn)
**Base ref**: `origin/epic/DC-2223_m09-04-connector-v2-cleanup` (`4f5c4f6`)
**HEAD**: `6006f8b` (커밋 4건)

## 요약

- 총 명령: 8
- 통과: 8
- 실패: 0
- 타임아웃: 0
- 리뷰 필요: 0
- 실행 소요 시간: 약 12s (명령 합계)

**main 독립 실행 결과와의 대조**: `check:docs` 신규 게이트 출력 문자열 동일
(`FWREQ 60행(체인 25) · MATRIX 27행 검사 / 11행 skip · Requirements 블록 4 · Support Matrix 헤더 2 ·
injectFwReq 렌더 2/2 (EN·KO)`) · `yarn tsc` exit 0 동일 · `yarn lint` exit 0 동일 ·
`yarn unit-v2` 37 suites / 765 tests 동일 · diff 409 insertions / 84 deletions (5 files) 동일
→ **불일치 0건**.

## T-XX Coverage

**총 9개 T-XX** — PASS 9, FAIL 0, BLOCKED 0, UNCOVERED 0

등식 검증: 9 + 0 + 0 + 0 = 9 ✓

## 명령별 결과

### 1. `yarn unit-v2`

- **검증**: T-U-DEVMODEL-01, T-U-DEVMODEL-02, T-U-DEVMODEL-03
- **기대**: exit 0, 전체 passed
- **결과**: ✅ PASS
- **Exit code**: 0 / **Duration**: 3s
- **Output** (tail):
  ```
  Test Suites: 37 passed, 37 total
  Tests:       765 passed, 765 total
  Snapshots:   0 total
  Time:        2.257s
  Ran all test suites matching /tests\/unit\/v2/i.
  ```
- 매핑 T-XX 실재 확인: `tests/unit/v2/sign/info.test.ts:146-190`에
  `describe('T-U-DEVMODEL-* — DeviceInfoPayload.deviceModel relay 계약')` + 3개 test 존재
  (01 wire 키 계약 / 02 `'DCENT-X'` relay / 03 부재 시 backward-compat).

### 2. `node scripts/check-index-html-fw-models.mjs`

- **검증**: T-DOC-MODEL-01, T-DOC-MODEL-02, T-DOC-MODEL-03
- **기대**: exit 0, 위반 0건
- **결과**: ✅ PASS
- **Exit code**: 0 / **Duration**: 1s
- **Output**:
  ```
  ✓ docs/index.html 펌웨어 모델 축 — FWREQ 60행(체인 25) · MATRIX 27행 검사 / 11행 skip(fw 미지정)
    · Requirements 블록 4 · Support Matrix 헤더 2 · injectFwReq 렌더 2/2 (EN·KO)
  ```
- 모수 대조: objective §4 실측치(체인 25 / FWREQ 60행 / MATRIX 27행 검사 + 11행 skip /
  하드코딩 블록 4 / Support Matrix 헤더 2 / 렌더러 EN·KO 2)와 **전부 일치**.

### 3. mutation gate (`cp docs/index.html /tmp/idx.bak && python3 - <<'PY' … PY` + `! node scripts/check-index-html-fw-models.mjs; RC=$?; cp /tmp/idx.bak docs/index.html; test $RC -eq 0`)

- **검증**: T-DOC-MODEL-04
- **기대**: exit 0 (= 스크립트가 뮤테이션을 잡았고 원본 복구 완료)
- **결과**: ✅ PASS
- **Exit code**: 0 / **Duration**: 1s
- **Output** (변조 상태에서의 게이트 출력 — 이것이 검출 증거):
  ```
  ✗ docs/index.html 펌웨어 표 모델 축(bio/x) 검사 실패
    - FWREQ["chain-ethereum"] getAddress: x 키 누락 또는 빈 값 ({"bio":"1.0.0"})
  ```
- **뮤테이션 앵커 적중 확인**: python 쪽 `assert n==1`이 통과했으므로 치환이 no-op이 아니다
  (`review-finding-class-closure` §3의 "앵커가 실제로 치환됐는지" 요건 충족).
- **워킹트리 복구 확인**: 실행 직후 `git status --porcelain` **출력 0줄 (clean)**.
  `docs/index.html`이 원본으로 복구되었음을 확인 — 잔여 변조 없음.

### 4. `yarn check:docs`

- **검증**: T-DOC-SYNC-01
- **기대**: exit 0
- **결과**: ✅ PASS
- **Exit code**: 0 / **Duration**: 4s
- **Output** (체인 7종 전부 통과):
  ```
  lint:md               → Summary: 0 error(s)
  check:payload-contract→ payload-contract coverage OK: 20 families covered
  check:payload-shape   → payload-contract shape OK: 18 example block(s) matched their presets
  check:index-refs      → index.html preset refs OK: 16 candidate(s) checked, 0 dangling
  check:index-dup       → index.html duplicate keys OK: KO 27 / EN 57 고유 키
  check:index-pages     → ✓ 페이지 정합 — 등록 68 · NAV 33 · MATRIX 38 · STUBS 6 · METHODS 5 · 죽은 링크 0
  check:index-fw-models → ✓ 펌웨어 모델 축 (신규, 7번째)
  ```
- `package.json`의 `check:docs`에 `check:index-fw-models`가 **실제 배선**됨을 stdout으로 확인 (§2 배선 스코프 충족).

### 5. `for f in src/sign/types.ts docs/index.html; do grep -Fq 'NOTE(decision-anchor:' "$f" || { echo "MISSING ANCHOR: $f"; exit 1; }; done`

- **검증**: T-R-ANCHOR-01
- **기대**: exit 0
- **결과**: ✅ PASS
- **Exit code**: 0 / **Duration**: <1s / **Output**: (없음 = 두 파일 모두 앵커 보유)

### 6. `yarn tsc`

- **검증**: 타입 안정성 (`DeviceInfoPayload` 계약 포함)
- **기대**: exit 0
- **결과**: ✅ PASS
- **Exit code**: 0 / **Duration**: 1s / **Output**: `$ tsc --noEmit` → `Done in 0.54s.` (에러 0건)
- **커버 확인**: `yarn tsc --listFiles | grep -c 'src/sign/types.ts'` → **1**
  (tsconfig `include: ["src/**/*"]`, `exclude: tests/**/*`). `_deviceInfoWireKeyContract`가
  실제로 타입체크 대상 안에 있으므로 "필드 제거/개명 시 tsc 실패" 계약이 성립한다.

### 7. `yarn lint`

- **검증**: 코드 컨벤션
- **기대**: exit 0
- **결과**: ✅ PASS
- **Exit code**: 0 / **Duration**: 1s
- **Output**: `✖ 19 problems (0 errors, 19 warnings)` — 전부 `scripts/extract-chains.js`의
  **pre-existing** `key-spacing` 경고이며 본 objective의 변경 파일이 아니다. eslint exit 0.

### 8. `git diff --stat origin/epic/DC-2223_m09-04-connector-v2-cleanup...HEAD -- ':!*.test.*' ':!*__fixtures__*' ':!*.snap' | tail -1`

- **검증**: DoD 정량 기준 — diff < 600 LOC
- **기대**: 변경 LOC 합계 600 미만
- **결과**: ✅ PASS
- **Output**: `4 files changed, 354 insertions(+), 84 deletions(-)` → **438 LOC < 600**
- 참고(테스트 포함 전체): `5 files changed, 409 insertions(+), 84 deletions(-)`
  - `docs/index.html` 176 / `scripts/check-index-html-fw-models.mjs` 238(신규) /
    `src/sign/types.ts` 21 / `package.json` 3 / `tests/unit/v2/sign/info.test.ts` 55

## T-XX 상세 (deterministic 분류)

### PASS (9)
- T-U-DEVMODEL-01, T-U-DEVMODEL-02, T-U-DEVMODEL-03 (명령 #1)
- T-DOC-MODEL-01, T-DOC-MODEL-02, T-DOC-MODEL-03 (명령 #2)
- T-DOC-MODEL-04 (명령 #3, 뮤테이션 검출 확인)
- T-DOC-SYNC-01 (명령 #4)
- T-R-ANCHOR-01 (명령 #5)

### FAIL (0) / BLOCKED (0) / UNCOVERED (0) / ORPHAN (0)
- 없음. 명령 #6/#7/#8은 T-XX 매핑 없는 품질 속성 게이트(tsc / lint / LOC)로, orphan 집계 대상 아님.

## Step 5e — 멀티바이트 테스트 커버리지

**비적용**. 본 objective는 타입 필드 1개 추가 + 문서 표/검증 스크립트로, 런타임 encode/decode/
Buffer 경로를 만들지 않는다 (`docs/index.html`은 UTF-8 EN/KO 문자열을 그대로 담고, 신규 스크립트는
jsdom으로 문서를 실행해 객체를 읽을 뿐이다). T-MB-* 요구 없음 → COVERAGE_GAP 미부여.

## Step 5.5 — Visual Baseline PNG 개수 Gate

**SKIP** — `type: feature`(visual 아님) + target-repo가 `dcent-hybrid-webview-v2`가 아님 + visual spec 부재.

## Step 5.6 — Mock Drift Remediation Gate

**비적용** — objective 본문에 "실기기에서만 재현 / mock 환경에서는 통과" 류의 실기기-only 분류
신호가 없다 (문서·타입 축 objective). 게이트 미발동.

## Protocol Drift Pre-Check

- Exit: 0
- CRITICAL: 0 / WARN: 0 / INFO: 8
- Report: [objectives/.prepare/m09-04-28-connector-dcentx-model-axis-and-docs/protocol-drift.md](protocol-drift.md)
- 트리거 사유: 변경 hunk에 `result:` 키워드 1건(`tests/unit/v2/sign/info.test.ts`의 mock 응답).
  interface 경로(`src/transport/`, `src/queue/`, `src/index.ts`) 변경은 0건이며, 메서드 enum·
  envelope shape 변경 없음(테스트 mock 안의 payload 필드 추가뿐).
- 결과: 메서드 enum 11개 양쪽 일치, reserved `_handshake` 일치, connector-단독 envelope 필드 0건.
  INFO 8건은 전부 pre-existing (bridge-only `signData`/`signTypedData`/`signAuthEntry`/`_ping`,
  JSON-RPC 표준 `result`/`error`/`code`, connector 정규식 아티팩트).
- ⚠️ **후속 (본 objective 스코프 밖)**: `uap-protocol-drift` SKILL.md의 bridge 경로가 stale하다 —
  Step 4/5/6이 참조하는 `main-repos/dcent-web-bridge/src/`는 m09-05 모노레포 전환 후
  `apps/bridge/src/`로 이동했고 `MethodRegistry.register(...)` 등록 방식도 사라졌다
  (현행은 `DcentSdkClient.handleRequest`의 `method === '<name>'` 분기 + `LIFECYCLE_METHODS`).
  **원본 명령 그대로면 bridge 핸들러 목록이 빈 배열이 되어 connector 메서드 11개가 전부 CRITICAL
  오탐**된다. 이번 실행은 경로/패턴을 현행에 맞게 어댑테이션해 수행했고 그 사실을 protocol-drift.md에
  명시했다. 스킬 자체의 갱신은 별도 항목으로 남긴다.

## Step 6.5 — Scope Coherence Check

**스킵** — `source: ['ad-hoc']`. Jira 키/CS URL이 아니라 조회 가능한 티켓 본문이 없다
(사용자 결정 2026-08-07은 objective §10에 인라인되어 있으며, 그 결정 4건 —
v2 bridge 전용 / X는 WC 항상 허용 / 모델 ID `'DCENT-X'` 하이픈 / 문서 2모델 분리 + X 전 항목 `1.0.0` —
은 각각 §3 비스코프, §4 decision-anchor, §4 데이터 구조에 매핑되어 있다).

## 공유 유틸 동작 대조 (Step 7b)

- 대상 파일: `scripts/check-index-html-fw-models.mjs` (신규 1건)
- 판정: **비대상** — 룰의 대상 경로(`*/lib/utils/*.ts`, `*/ui/*.tsx`, `*/lib/hooks/*.ts`,
  `*/util/*.ts`, `*/helpers/*.ts`)에 해당하지 않는 빌드/문서 검증 스크립트.
- 참고: 형제 `scripts/check-index-html-*.mjs` 3종과 **검사 축이 다르다**(preset refs / duplicate
  keys / page refs vs 펌웨어 모델 컬럼). objective §4가 지목한 대로 jsdom 실행 패턴만 재사용했다.
- 결과: PASS (중복 구현 없음)

## AST 기반 검증 (Step 7d)

### Optional Parameter Wiring
- Verdict: **PASS** (`base_ref: origin/epic/DC-2223_m09-04-connector-v2-cleanup`)
- Findings: 0건

### Forbidden Test Patterns
- Verdict: **PASS**
- Findings: 0건 / Suppressed(사유 있음): 0건 / Suppressed(사유 없음): 0건
- scanned_files: 1 (`tests/unit/v2/sign/info.test.ts`)

## External Data Dependency (Step 7e)

**SKIP** — frontmatter에 `depends-on-external-data` 필드 없음 (findings 0).

## Guide Gap (Step 7c)

**SKIP** — target-repo가 `dcent-hybrid-webview-v2`가 아니고 `type: visual`도 아님. 리포트 미생성.

## 워킹트리 무결성

명령 #3(뮤테이션)이 `docs/index.html`을 임시 변조하므로 실행 직후 확인:

```
$ git status --porcelain
(출력 없음 — clean)
```

검증 전후 모두 clean. 잔여 변조·미커밋 변경 0건.

## 다음 단계

- PASS → PR 생성 단계로 진행 (epic child → reviewer 미지정, `feedback-epic-child-no-reviewers`)

## 재실행 방법

```bash
/uap-verify-objective m09-04-28-connector-dcentx-model-axis-and-docs
```


</details>

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/uap-autopilot-objective m09-04-28-connector-dcentx-model-axis-and-docs`
